### PR TITLE
improved route53/zone module scalability

### DIFF
--- a/modules/aws/route53/zone/README.md
+++ b/modules/aws/route53/zone/README.md
@@ -120,8 +120,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | n/a |
-| <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | n/a |
+| <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | A map of zones and their list of name servers. |
+| <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | A map of zones and their zone IDs. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/route53/zone/README.md
+++ b/modules/aws/route53/zone/README.md
@@ -114,7 +114,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to the zone. | `map(any)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
-| <a name="input_zones"></a> [zones](#input\_zones) | (Required) A map of hosted zone objects. Key is the name of the hosted zone. Values are the hosted zone configuration settings. | <pre>map(object({<br>    comment           = optional(string) # (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.<br>    delegation_set_id = optional(string) # (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones.<br>    name              = string           # (Required) This is the name of the hosted zone.<br>  }))</pre> | n/a | yes |
+| <a name="input_zones"></a> [zones](#input\_zones) | (Required) A map of hosted zone objects. The key is the name of the hosted zone. Values are the zone configuration settings. | <pre>map(object({<br>    comment           = optional(string) # (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.<br>    delegation_set_id = optional(string) # (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones.<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/aws/route53/zone/README.md
+++ b/modules/aws/route53/zone/README.md
@@ -121,7 +121,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | A map of zones and their list of name servers. |
-| <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | A map of zones and their zone IDs. |
+| <a name="output_zone_ids"></a> [zone\_ids](#output\_zone\_ids) | A map of zones and their zone IDs. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/route53/zone/README.md
+++ b/modules/aws/route53/zone/README.md
@@ -113,11 +113,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_comment"></a> [comment](#input\_comment) | (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'. | `string` | `"Managed by Terraform"` | no |
-| <a name="input_delegation_set_id"></a> [delegation\_set\_id](#input\_delegation\_set\_id) | (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones. | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | (Required) This is the name of the hosted zone. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to the zone. | `map(any)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | (Optional) Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with the delegation\_set\_id argument in this resource and any aws\_route53\_zone\_association resource specifying the same zone ID. Detailed below. | `string` | `null` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | (Required) A map of hosted zone objects. Key is the name of the hosted zone. Values are the hosted zone configuration settings. | <pre>map(object({<br>    comment           = optional(string) # (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.<br>    delegation_set_id = optional(string) # (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones.<br>    name              = string           # (Required) This is the name of the hosted zone.<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/aws/route53/zone/README.md
+++ b/modules/aws/route53/zone/README.md
@@ -67,8 +67,8 @@
 module "route53_zone" {
   source  = "github.com/zachreborn/terraform-modules//modules/aws/route53/zone"
   
-  comment = "ThinkStack primary domain"
-  name    = "thinkstack.co"
+  comment = "example.com"
+  name    = "example.com"
   
   tags    = {
     terraform   = "yes"

--- a/modules/aws/route53/zone/README.md
+++ b/modules/aws/route53/zone/README.md
@@ -62,19 +62,55 @@
 
 <!-- USAGE EXAMPLES -->
 ## Usage
-
+### Simple Usage
+This example configures two hosted zones with a comment and tags for each zone.
 ```
 module "route53_zone" {
   source  = "github.com/zachreborn/terraform-modules//modules/aws/route53/zone"
   
-  comment = "example.com"
-  name    = "example.com"
+  zones = {
+    "example.com" = {
+      comment = "example.com"
+    }
+    "example.net" = {
+      comment = "example.net"
+    }
+  }
   
   tags    = {
     terraform   = "yes"
     created_by  = "Zachary Hill"
     environment = "prod"
     role        = "external dns"
+  }
+}
+```
+
+### Advanced Usage
+This example shows how to use the module with a variable and a map of objects. This allows for easier readability and maintainability of the code.
+```
+module "route53_zones" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/route53/zone"
+
+  zones = var.zones
+  tags = {
+    created_by = "Zachary Hill"
+    role       = "external dns"
+  }
+}
+
+variable "zones" {
+  type = map(object({
+    comment           = optional(string)
+    delegation_set_id = optional(string)
+  }))
+  default = {
+    "example.com" = {
+      comment = "example.com"
+    }
+    "example.net" = {
+      comment = "Not in use"
+    }
   }
 }
 ```

--- a/modules/aws/route53/zone/main.tf
+++ b/modules/aws/route53/zone/main.tf
@@ -12,6 +12,6 @@ resource "aws_route53_zone" "zone" {
   for_each          = var.zones
   comment           = each.value.comment
   delegation_set_id = each.value.delegation_set_id
-  name              = each.value.name
+  name              = each.key
   tags              = var.tags
 }

--- a/modules/aws/route53/zone/main.tf
+++ b/modules/aws/route53/zone/main.tf
@@ -9,8 +9,9 @@ terraform {
 }
 
 resource "aws_route53_zone" "zone" {
-  comment           = var.comment
-  delegation_set_id = var.delegation_set_id
-  name              = var.name
+  for_each          = var.zones
+  comment           = each.value.comment
+  delegation_set_id = each.value.delegation_set_id
+  name              = each.value.name
   tags              = var.tags
 }

--- a/modules/aws/route53/zone/outputs.tf
+++ b/modules/aws/route53/zone/outputs.tf
@@ -1,7 +1,13 @@
 output "name_servers" {
-  value = aws_route53_zone.zone.name_servers
+  description = "A map of zones and their list of name servers."
+  value = {
+    for zone in aws_route53_zone.zone : zone.name => zone.name_servers
+  }
 }
 
 output "zone_id" {
-  value = aws_route53_zone.zone.zone_id
+  description = "A map of zones and their zone IDs."
+  value = {
+    for zone in aws_route53_zone.zone : zone.name => zone.zone_id
+  }
 }

--- a/modules/aws/route53/zone/outputs.tf
+++ b/modules/aws/route53/zone/outputs.tf
@@ -5,7 +5,7 @@ output "name_servers" {
   }
 }
 
-output "zone_id" {
+output "zone_ids" {
   description = "A map of zones and their zone IDs."
   value = {
     for zone in aws_route53_zone.zone : zone.name => zone.zone_id

--- a/modules/aws/route53/zone/variables.tf
+++ b/modules/aws/route53/zone/variables.tf
@@ -10,20 +10,17 @@ variable "zones" {
   type = map(object({
     comment           = optional(string) # (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.
     delegation_set_id = optional(string) # (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones.
-    name              = string           # (Required) This is the name of the hosted zone.
   }))
-  description = "(Required) A map of hosted zone objects. Key is the name of the hosted zone. Values are the hosted zone configuration settings."
+  description = "(Required) A map of hosted zone objects. The key is the name of the hosted zone. Values are the zone configuration settings."
   # Example:
   # zones = {
-  #   example.com = {
+  #   "example.com" = {
   #     comment           = "example.com"
   #     delegation_set_id = null
-  #     name              = "example.com"
   #   },
-  #   example.net = {
+  #   "example.net" = {
   #     comment           = "example.net"
   #     delegation_set_id = null
-  #     name              = "example.net"
   #   }
   # }
 }

--- a/modules/aws/route53/zone/variables.tf
+++ b/modules/aws/route53/zone/variables.tf
@@ -20,7 +20,6 @@ variable "zones" {
   #   },
   #   "example.net" = {
   #     comment = "example.net"
-  #     delegation_set_id = null
   #   },
   #   "example.org" = {
   #   }

--- a/modules/aws/route53/zone/variables.tf
+++ b/modules/aws/route53/zone/variables.tf
@@ -1,20 +1,3 @@
-variable "comment" {
-  type        = string
-  description = "(Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'."
-  default     = "Managed by Terraform"
-}
-
-variable "delegation_set_id" {
-  type        = string
-  description = "(Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones."
-  default     = null
-}
-
-variable "name" {
-  type        = string
-  description = "(Required) This is the name of the hosted zone."
-}
-
 variable "tags" {
   type        = map(any)
   description = "(Optional) A map of tags to assign to the zone."
@@ -23,8 +6,24 @@ variable "tags" {
   }
 }
 
-variable "vpc" {
-  type        = string
-  description = "(Optional) Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with the delegation_set_id argument in this resource and any aws_route53_zone_association resource specifying the same zone ID. Detailed below."
-  default     = null
+variable "zones" {
+  type = map(object({
+    comment           = optional(string) # (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.
+    delegation_set_id = optional(string) # (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones.
+    name              = string           # (Required) This is the name of the hosted zone.
+  }))
+  description = "(Required) A map of hosted zone objects. Key is the name of the hosted zone. Values are the hosted zone configuration settings."
+  # Example:
+  # zones = {
+  #   example.com = {
+  #     comment           = "example.com"
+  #     delegation_set_id = null
+  #     name              = "example.com"
+  #   },
+  #   example.net = {
+  #     comment           = "example.net"
+  #     delegation_set_id = null
+  #     name              = "example.net"
+  #   }
+  # }
 }

--- a/modules/aws/route53/zone/variables.tf
+++ b/modules/aws/route53/zone/variables.tf
@@ -15,12 +15,14 @@ variable "zones" {
   # Example:
   # zones = {
   #   "example.com" = {
-  #     comment           = "example.com"
+  #     comment = "example.com"
   #     delegation_set_id = null
   #   },
   #   "example.net" = {
-  #     comment           = "example.net"
+  #     comment = "example.net"
   #     delegation_set_id = null
+  #   },
+  #   "example.org" = {
   #   }
   # }
 }


### PR DESCRIPTION
# Overview
Updates the `route53/zone` module to utilize `for_each` for better scalability in environments where many zones are utilized or created.

This allows the input to be a map of objects.


# Migration Guide
The configuration and input structure has changed from single attributes to a map of objects. Please see the example below for how to modify your configuration to match.
**Previous Version**
```hcl
module "example_com_zone" {
  source = "github.com/zachreborn/terraform-modules//modules/aws/route53/zone"

  comment = "example.com"
  name    = "example.com"
}
```

**New Configuration**
```hcl
module "example_com_zone" {
  source = "github.com/zachreborn/terraform-modules//modules/aws/route53/zone"

  zones = {
    example.com = {
      comment           = "example.com"
      delegation_set_id = null
      name              = "example.com"
    },
    example.net = {
      comment           = "example.net"
      delegation_set_id = null
      name              = "example.net"
    }
  }
}
```