### PR TITLE
feat: route tables are able to be disabled

### DIFF
--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -124,6 +124,30 @@ module "vpc" {
 }
 ```
 
+### Disabling Unneeded Subnets
+This example disabled unused subnets and associated resources. In the example we leave only the public and private subnets enabled.
+```hcl
+module "vpc" {
+    source = "github.com/zachreborn/terraform-modules//modules/aws/vpc"
+
+    name                    = "client_prod_vpc"
+    vpc_cidr                = "10.11.0.0/16"
+    azs                     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    db_subnets_list         = []
+    dmz_subnets_list        = []
+    mgmt_subnets_list       = []
+    private_subnets_list    = ["10.11.0.0/24", "10.11.1.0/24", "10.11.2.0/24"]
+    public_subnets_list     = ["10.11.200.0/24", "10.11.201.0/24", "10.11.202.0/24"]
+    workspaces_subnets_list = []
+    tags = {
+        terraform   = "true"
+        created_by  = "Zachary Hill"
+        environment = "prod"
+        project     = "core_infrastructure"
+    }
+}
+```
+
 _For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -228,7 +228,7 @@ resource "aws_nat_gateway" "natgw" {
 ###########################
 
 resource "aws_route_table" "private_route_table" {
-  count            = length(var.azs)
+  count            = length(var.private_subnets_list)
   propagating_vgws = var.private_propagating_vgws
   tags             = merge(var.tags, ({ "Name" = format("%s-rt-private-%s", var.name, element(var.azs, count.index)) }))
   vpc_id           = aws_vpc.vpc.id
@@ -249,7 +249,7 @@ resource "aws_route" "private_default_route_fw" {
 }
 
 resource "aws_route_table" "db_route_table" {
-  count            = length(var.azs)
+  count            = length(var.db_subnets_list)
   propagating_vgws = var.db_propagating_vgws
   tags             = merge(var.tags, ({ "Name" = format("%s-rt-db-%s", var.name, element(var.azs, count.index)) }))
   vpc_id           = aws_vpc.vpc.id
@@ -270,7 +270,7 @@ resource "aws_route" "db_default_route_fw" {
 }
 
 resource "aws_route_table" "dmz_route_table" {
-  count            = length(var.azs)
+  count            = length(var.dmz_subnets_list)
   propagating_vgws = var.dmz_propagating_vgws
   tags             = merge(var.tags, ({ "Name" = format("%s-rt-dmz-%s", var.name, element(var.azs, count.index)) }))
   vpc_id           = aws_vpc.vpc.id
@@ -291,7 +291,7 @@ resource "aws_route" "dmz_default_route_fw" {
 }
 
 resource "aws_route_table" "mgmt_route_table" {
-  count            = length(var.azs)
+  count            = length(var.mgmt_subnets_list)
   propagating_vgws = var.mgmt_propagating_vgws
   tags             = merge(var.tags, ({ "Name" = format("%s-rt-mgmt-%s", var.name, element(var.azs, count.index)) }))
   vpc_id           = aws_vpc.vpc.id
@@ -312,7 +312,7 @@ resource "aws_route" "mgmt_default_route_fw" {
 }
 
 resource "aws_route_table" "workspaces_route_table" {
-  count            = length(var.azs)
+  count            = length(var.workspaces_subnets_list)
   propagating_vgws = var.workspaces_propagating_vgws
   tags             = merge(var.tags, ({ "Name" = format("%s-rt-workspaces-%s", var.name, element(var.azs, count.index)) }))
   vpc_id           = aws_vpc.vpc.id


### PR DESCRIPTION
BREAKING CHANGE
- route tables are now disabled if the list of subnets is empty for each subnet type

# Description
<!-- Description of the changes introduced by this Pull Request (PR). Link to an issue or ticket where possible for more context.-->
The ability to disable subnets now extends to disabling the route tables associated with them.

## Issue or Ticket
<!-- Link to the issue or ticket this PR addresses.-->
Fixes #71

## Type of change
<!-- What type of change does your code introduce? -->
- [ ] Bugfix
- [x] New feature
- [ ] Version update

## Breaking Changes
<!-- Does this PR introduce any breaking changes? -->
- [ ] Yes
- [x] No

### Breaking Changes Description
<!-- If yes, describe the breaking changes introduced by this PR. -->


## TODOs
<!-- Complete these tasks prior to requesting a review.-->
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [x] Validate all tests run successfull, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.
