### PR TITLE
Transit Gateway Route Module - Refactor to for_each

### DIFF
--- a/modules/aws/transit_gateway/route/README.md
+++ b/modules/aws/transit_gateway/route/README.md
@@ -104,19 +104,18 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 <!-- terraform-docs output will be input automatically below-->
 <!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 4.0.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 
 ## Providers
 
-| Name                                             | Version  |
-| ------------------------------------------------ | -------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | >= 4.0.0 |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
 
 ## Modules
 
@@ -124,23 +123,24 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                        | Type     |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Name | Type |
+|------|------|
 | [aws_ec2_transit_gateway_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 
 ## Inputs
 
-| Name                                                                                                                        | Description                                                                                                                | Type     | Default | Required |
-| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | :------: |
-| <a name="input_blackhole"></a> [blackhole](#input_blackhole)                                                                | (Optional) Indicates whether to drop traffic that matches this route (default to false).                                   | `bool`   | `false` |    no    |
-| <a name="input_destination_cidr_block"></a> [destination_cidr_block](#input_destination_cidr_block)                         | (Required) IPv4 or IPv6 RFC1924 CIDR used for destination matches. Routing decisions are based on the most specific match. | `string` | n/a     |   yes    |
-| <a name="input_transit_gateway_attachment_id"></a> [transit_gateway_attachment_id](#input_transit_gateway_attachment_id)    | (Optional) Identifier of EC2 Transit Gateway Attachment (required if blackhole is set to false).                           | `string` | `null`  |    no    |
-| <a name="input_transit_gateway_route_table_id"></a> [transit_gateway_route_table_id](#input_transit_gateway_route_table_id) | (Required) Identifier of EC2 Transit Gateway Route Table.                                                                  | `string` | n/a     |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_blackhole"></a> [blackhole](#input\_blackhole) | (Optional) Indicates whether to drop traffic that matches this route (default to false). | `bool` | `false` | no |
+| <a name="input_destination_cidr_blocks"></a> [destination\_cidr\_blocks](#input\_destination\_cidr\_blocks) | (Required) List of IPv4 or IPv6 RFC1924 CIDR blocks used for destination matches. Routing decisions are based on the most specific match. | `set(string)` | n/a | yes |
+| <a name="input_transit_gateway_attachment_id"></a> [transit\_gateway\_attachment\_id](#input\_transit\_gateway\_attachment\_id) | (Optional) Identifier of EC2 Transit Gateway Attachment (required if blackhole is set to false). | `string` | `null` | no |
+| <a name="input_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#input\_transit\_gateway\_route\_table\_id) | (Required) Identifier of EC2 Transit Gateway Route Table. | `string` | n/a | yes |
 
 ## Outputs
 
-No outputs.
-
+| Name | Description |
+|------|-------------|
+| <a name="output_routes"></a> [routes](#output\_routes) | Map of routes and their next hops |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/transit_gateway/route/README.md
+++ b/modules/aws/transit_gateway/route/README.md
@@ -67,7 +67,7 @@ module "destination_name_transit_gateway_route" {
     source = "github.com/zachreborn/terraform-modules//modules/aws/transit_gateway/route"
 
     # Destination Name Comment
-    destination_cidr_block         = "192.168.0.0/16"
+    destination_cidr_blocks        = "192.168.0.0/16"
     transit_gateway_attachment_id  = module.transit_gateway_attachment.id
     transit_gateway_route_table_id = module.transit_gateway.propagation_default_route_table_id
 }
@@ -80,18 +80,19 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 <!-- terraform-docs output will be input automatically below-->
 <!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 4.0.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+| Name                                             | Version  |
+| ------------------------------------------------ | -------- |
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 4.0.0 |
 
 ## Modules
 
@@ -99,22 +100,23 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
+| Name                                                                                                                                        | Type     |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | [aws_ec2_transit_gateway_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_blackhole"></a> [blackhole](#input\_blackhole) | (Optional) Indicates whether to drop traffic that matches this route (default to false). | `bool` | `false` | no |
-| <a name="input_destination_cidr_block"></a> [destination\_cidr\_block](#input\_destination\_cidr\_block) | (Required) IPv4 or IPv6 RFC1924 CIDR used for destination matches. Routing decisions are based on the most specific match. | `string` | n/a | yes |
-| <a name="input_transit_gateway_attachment_id"></a> [transit\_gateway\_attachment\_id](#input\_transit\_gateway\_attachment\_id) | (Optional) Identifier of EC2 Transit Gateway Attachment (required if blackhole is set to false). | `string` | `null` | no |
-| <a name="input_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#input\_transit\_gateway\_route\_table\_id) | (Required) Identifier of EC2 Transit Gateway Route Table. | `string` | n/a | yes |
+| Name                                                                                                                        | Description                                                                                                                | Type     | Default | Required |
+| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | :------: |
+| <a name="input_blackhole"></a> [blackhole](#input_blackhole)                                                                | (Optional) Indicates whether to drop traffic that matches this route (default to false).                                   | `bool`   | `false` |    no    |
+| <a name="input_destination_cidr_block"></a> [destination_cidr_block](#input_destination_cidr_block)                         | (Required) IPv4 or IPv6 RFC1924 CIDR used for destination matches. Routing decisions are based on the most specific match. | `string` | n/a     |   yes    |
+| <a name="input_transit_gateway_attachment_id"></a> [transit_gateway_attachment_id](#input_transit_gateway_attachment_id)    | (Optional) Identifier of EC2 Transit Gateway Attachment (required if blackhole is set to false).                           | `string` | `null`  |    no    |
+| <a name="input_transit_gateway_route_table_id"></a> [transit_gateway_route_table_id](#input_transit_gateway_route_table_id) | (Required) Identifier of EC2 Transit Gateway Route Table.                                                                  | `string` | n/a     |   yes    |
 
 ## Outputs
 
 No outputs.
+
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/transit_gateway/route/README.md
+++ b/modules/aws/transit_gateway/route/README.md
@@ -28,7 +28,7 @@
 
 <h3 align="center">Transit Gateway Route Module</h3>
   <p align="center">
-    This module configures a route within a transit gateway route table.
+    This module configures one or more routes in a route table of a transit gateway. The module requires one or more CIDR blocks and destination transit gateway attachment id to route those CIDR blocks to. The module can also be used to create blackhole routes by setting the blackhole variable to true.
     <br />
     <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
     <br />
@@ -62,13 +62,37 @@
 
 ## Usage
 
+### Simple Example
+
+This example creates two routes, one for each CIDR block, in the default route table of a transit gateway. The routes next hop are set to the transit gateway attachment id specified in the transit_gateway_attachment_id variable.
+
 ```
-module "destination_name_transit_gateway_route" {
+module "tgw_routes" {
     source = "github.com/zachreborn/terraform-modules//modules/aws/transit_gateway/route"
 
     # Destination Name Comment
-    destination_cidr_blocks        = "192.168.0.0/16"
+    destination_cidr_blocks = [
+      "10.255.0.0/24",
+      "192.168.0.0/16"
+    ]
     transit_gateway_attachment_id  = module.transit_gateway_attachment.id
+    transit_gateway_route_table_id = module.transit_gateway.propagation_default_route_table_id
+}
+```
+
+### Blackhole Example
+
+This example creates two blackhole routes, one for each CIDR block, in the default route table of a transit gateway. Blackhole routes can be used to drop traffic that matches the specified CIDR block. The blackhole variable is set to true to create blackhole routes.
+
+```
+module "tgw_blackhole_routes" {
+    source = "github.com/zachreborn/terraform-modules//modules/aws/transit_gateway/route"
+
+    blackhole = true
+    destination_cidr_blocks = [
+      "10.255.0.0/24",
+      "192.168.0.0/16"
+    ]
     transit_gateway_route_table_id = module.transit_gateway.propagation_default_route_table_id
 }
 ```

--- a/modules/aws/transit_gateway/route/main.tf
+++ b/modules/aws/transit_gateway/route/main.tf
@@ -9,8 +9,9 @@ terraform {
 }
 
 resource "aws_ec2_transit_gateway_route" "this" {
+  for_each                       = toset(var.destination_cidr_blocks)
   blackhole                      = var.blackhole
-  destination_cidr_block         = var.destination_cidr_block
+  destination_cidr_block         = each.key
   transit_gateway_attachment_id  = var.transit_gateway_attachment_id
   transit_gateway_route_table_id = var.transit_gateway_route_table_id
 }

--- a/modules/aws/transit_gateway/route/outputs.tf
+++ b/modules/aws/transit_gateway/route/outputs.tf
@@ -1,4 +1,4 @@
 output "routes" {
   description = "Map of routes and their next hops"
-  value       = { for route in aws_ec2_transit_gateway_route.route : route.destination_cidr_block => route.transit_gateway_attachment_id }
+  value       = { for route in aws_ec2_transit_gateway_route.this : route.destination_cidr_block => route.transit_gateway_attachment_id }
 }

--- a/modules/aws/transit_gateway/route/outputs.tf
+++ b/modules/aws/transit_gateway/route/outputs.tf
@@ -1,0 +1,4 @@
+output "routes" {
+  description = "Map of routes and their next hops"
+  value       = { for route in aws_ec2_transit_gateway_route.route : route.destination_cidr_block => route.transit_gateway_attachment_id }
+}

--- a/modules/aws/transit_gateway/route/variables.tf
+++ b/modules/aws/transit_gateway/route/variables.tf
@@ -4,9 +4,9 @@ variable "blackhole" {
   type        = bool
 }
 
-variable "destination_cidr_block" {
-  description = "(Required) IPv4 or IPv6 RFC1924 CIDR used for destination matches. Routing decisions are based on the most specific match."
-  type        = string
+variable "destination_cidr_blocks" {
+  description = "(Required) List of IPv4 or IPv6 RFC1924 CIDR blocks used for destination matches. Routing decisions are based on the most specific match."
+  type        = set(string)
 }
 
 variable "transit_gateway_attachment_id" {


### PR DESCRIPTION
# Description
<!-- Description of the changes introduced by this Pull Request (PR). Link to an issue or ticket where possible for more context.-->
Refactored the `transit_gateway/route` module to use `for_each` for better management of multiple routes.

## Issue or Ticket
<!-- Link to the issue or ticket this PR addresses.-->
N/A

## Type of change
<!-- What type of change does your code introduce? -->
- [ ] Bugfix
- [x] New feature
- [ ] Version update

## Breaking Changes
<!-- Does this PR introduce any breaking changes? -->
- [x] Yes
- [ ] No

### Breaking Changes Description
<!-- If yes, describe the breaking changes introduced by this PR. -->
The following changes need to be made to upgrade your modules.
- Change `destination_cidr_block` -> `destination_cidr_blocks`
- Modified `destination_cidr_blocks` to be a list of CIDR blocks where each module has a single destination attachment ID.

Example:
```
module "tgw_routes" {
    source = "github.com/zachreborn/terraform-modules//modules/aws/transit_gateway/route"

    # Destination Name Comment
    destination_cidr_blocks = [
      "10.255.0.0/24",
      "192.168.0.0/16"
    ]
    transit_gateway_attachment_id  = module.transit_gateway_attachment.id
    transit_gateway_route_table_id = module.transit_gateway.propagation_default_route_table_id
}
```

## TODOs
<!-- Complete these tasks prior to requesting a review.-->
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [ ] Validate all tests run successfull, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.
