### PR TITLE
feat: AWS Amplify - SNS Build Notifications via EventBridge

### DIFF
--- a/modules/aws/amplify/README.md
+++ b/modules/aws/amplify/README.md
@@ -112,15 +112,15 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.46.0 |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 
@@ -129,7 +129,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_amplify_app.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_app) | resource |
 | [aws_amplify_branch.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_branch) | resource |
 | [aws_amplify_domain_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_domain_association) | resource |
@@ -143,7 +143,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_access_token"></a> [access\_token](#input\_access\_token) | Access token for the Amplify App. | `string` | `null` | no |
 | <a name="input_auto_branch_creation_config"></a> [auto\_branch\_creation\_config](#input\_auto\_branch\_creation\_config) | Auto branch creation config for the Amplify App. | <pre>object({<br/>    basic_auth_credentials        = optional(string)      # Basic auth credentials for the branch. Must be input as "username:password".<br/>    build_spec                    = optional(string)      # Build spec for the branch.<br/>    enable_auto_build             = optional(bool)        # Enable auto build for the branch.<br/>    enable_basic_auth             = optional(bool)        # Enable basic auth for the branch.<br/>    enable_performance_mode       = optional(bool)        # Enable performance mode for the branch.<br/>    enable_pull_request_preview   = optional(bool)        # Enable pull request preview for the branch.<br/>    environment_variables         = optional(map(string)) # Map of environment variables for the branch.<br/>    framework                     = optional(string)      # The framework for the branch.<br/>    pull_request_environment_name = optional(string)      # The name of the pull request environment.<br/>    stage                         = optional(string)      # Description of the stage. Valid values are PRODUCTION, BETA, DEVELOPMENT, EXPERIMENTAL, PULL_REQUEST.<br/>  })</pre> | `null` | no |
 | <a name="input_auto_branch_creation_patterns"></a> [auto\_branch\_creation\_patterns](#input\_auto\_branch\_creation\_patterns) | Patterns for auto branch creation. | `list(string)` | `null` | no |
@@ -173,7 +173,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_app_arn"></a> [app\_arn](#output\_app\_arn) | The ARN of the Amplify app. |
 | <a name="output_app_id"></a> [app\_id](#output\_app\_id) | The unique ID of the Amplify app. |
 | <a name="output_default_domain"></a> [default\_domain](#output\_default\_domain) | The default domain of the Amplify app. |

--- a/modules/aws/amplify/README.md
+++ b/modules/aws/amplify/README.md
@@ -112,15 +112,15 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.46.0 |
 
 ## Modules
 
@@ -129,15 +129,21 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_amplify_app.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_app) | resource |
 | [aws_amplify_branch.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_branch) | resource |
 | [aws_amplify_domain_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_domain_association) | resource |
+| [aws_cloudwatch_event_rule.amplify_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.amplify_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.amplify_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_subscription.email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_iam_policy_document.amplify_notifications_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_access_token"></a> [access\_token](#input\_access\_token) | Access token for the Amplify App. | `string` | `null` | no |
 | <a name="input_auto_branch_creation_config"></a> [auto\_branch\_creation\_config](#input\_auto\_branch\_creation\_config) | Auto branch creation config for the Amplify App. | <pre>object({<br/>    basic_auth_credentials        = optional(string)      # Basic auth credentials for the branch. Must be input as "username:password".<br/>    build_spec                    = optional(string)      # Build spec for the branch.<br/>    enable_auto_build             = optional(bool)        # Enable auto build for the branch.<br/>    enable_basic_auth             = optional(bool)        # Enable basic auth for the branch.<br/>    enable_performance_mode       = optional(bool)        # Enable performance mode for the branch.<br/>    enable_pull_request_preview   = optional(bool)        # Enable pull request preview for the branch.<br/>    environment_variables         = optional(map(string)) # Map of environment variables for the branch.<br/>    framework                     = optional(string)      # The framework for the branch.<br/>    pull_request_environment_name = optional(string)      # The name of the pull request environment.<br/>    stage                         = optional(string)      # Description of the stage. Valid values are PRODUCTION, BETA, DEVELOPMENT, EXPERIMENTAL, PULL_REQUEST.<br/>  })</pre> | `null` | no |
 | <a name="input_auto_branch_creation_patterns"></a> [auto\_branch\_creation\_patterns](#input\_auto\_branch\_creation\_patterns) | Patterns for auto branch creation. | `list(string)` | `null` | no |
@@ -145,6 +151,7 @@ No modules.
 | <a name="input_branches"></a> [branches](#input\_branches) | A map of branches for the Amplify App. The key becomes the branch name and the value is an object of branch attributes or settings. | <pre>map(object({<br/>    basic_auth_credentials        = optional(string)                    # Basic auth credentials for the branch. Must be input as "username:password".<br/>    certificate_type              = optional(string, "AMPLIFY_MANAGED") # The certificate type for the domain association. Valid values are AMPLIFY_MANAGED or CUSTOM.<br/>    custom_certificate_arn        = optional(string)                    # The ARN for the custom certificate.<br/>    description                   = optional(string)                    # The description of the branch.<br/>    display_name                  = optional(string)                    # The display name of the branch. This gets used as the default domain prefix.<br/>    domain_name                   = string                              # The domain name for the domain association.<br/>    enable_auto_build             = optional(bool, true)                # Enable auto build for the branch.<br/>    enable_auto_sub_domain        = optional(bool, false)               # Enable auto sub domain for the domain association.<br/>    enable_basic_auth             = optional(bool)                      # Enable basic auth for the branch.<br/>    enable_certificate            = optional(bool, true)                # Enable certificate for the domain association.<br/>    enable_notification           = optional(bool)                      # Enable notification for the branch.<br/>    enable_performance_mode       = optional(bool)                      # Enable performance mode for the branch.<br/>    enable_pull_request_preview   = optional(bool)                      # Enable pull request preview for the branch.<br/>    environment_variables         = optional(map(string))               # Map of environment variables for the branch.<br/>    framework                     = optional(string)                    # The framework for the branch.<br/>    pull_request_environment_name = optional(string)                    # The name of the pull request environment.<br/>    stage                         = optional(string)                    # The stage for the branch. Valid values are PRODUCTION, BETA, DEVELOPMENT, EXPERIMENTAL, PULL_REQUEST.<br/>    sub_domains                   = optional(set(string))               # A list of sub domains to associate with the branch.<br/>    ttl                           = optional(number)                    # The TTL for the branch.<br/>    wait_for_verification         = optional(bool, true)                # Wait for verification for the domain association.<br/>  }))</pre> | n/a | yes |
 | <a name="input_build_spec"></a> [build\_spec](#input\_build\_spec) | Build spec for the Amplify App. | `string` | `null` | no |
 | <a name="input_cache_config_type"></a> [cache\_config\_type](#input\_cache\_config\_type) | Cache config type for the Amplify App. Valid values are AMPLIFY\_MANAGED, AMPLIFY\_MANAGED\_NO\_COOKIES, | `string` | `"AMPLIFY_MANAGED"` | no |
+| <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create an SNS topic for Amplify build notifications. When false, sns\_topic\_arn must be provided. | `bool` | `true` | no |
 | <a name="input_custom_headers"></a> [custom\_headers](#input\_custom\_headers) | Custom headers string for the Amplify App. | `string` | `null` | no |
 | <a name="input_custom_rules"></a> [custom\_rules](#input\_custom\_rules) | List of custom rules for the Amplify App. | <pre>list(object({<br/>    condition = optional(string) # Condition for a URL redirect or rewrite.<br/>    source    = string           # Source pattern for URL redirect or rewrite.<br/>    status    = optional(string) # Status code for URL redirect or rewrite. Valid values are 200, 301, 302, 404, 404-200.<br/>    target    = string           # Target pattern for URL redirect or rewrite.<br/>  }))</pre> | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of the Amplify App. | `string` | `null` | no |
@@ -152,17 +159,26 @@ No modules.
 | <a name="input_enable_basic_auth"></a> [enable\_basic\_auth](#input\_enable\_basic\_auth) | Enable basic auth for the Amplify App. | `bool` | `false` | no |
 | <a name="input_enable_branch_auto_build"></a> [enable\_branch\_auto\_build](#input\_enable\_branch\_auto\_build) | Enable branch auto build for the Amplify App. | `bool` | `false` | no |
 | <a name="input_enable_branch_auto_deletion"></a> [enable\_branch\_auto\_deletion](#input\_enable\_branch\_auto\_deletion) | Enable branch auto deletion for the Amplify App. | `bool` | `false` | no |
+| <a name="input_enable_notifications"></a> [enable\_notifications](#input\_enable\_notifications) | Whether to enable SNS build notifications for Amplify via EventBridge. Creates an SNS topic (or uses sns\_topic\_arn) and a CloudWatch EventBridge rule that fires on Amplify deployment status changes. | `bool` | `false` | no |
 | <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | Environment variables in a map for the Amplify App. | `map(string)` | `null` | no |
 | <a name="input_iam_service_role_arn"></a> [iam\_service\_role\_arn](#input\_iam\_service\_role\_arn) | IAM service role ARN for the Amplify App. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Amplify App. | `string` | n/a | yes |
+| <a name="input_notification_emails"></a> [notification\_emails](#input\_notification\_emails) | List of email addresses to subscribe to Amplify build notifications. Only used when enable\_notifications is true. | `list(string)` | `null` | no |
 | <a name="input_oauth_token"></a> [oauth\_token](#input\_oauth\_token) | OAuth token for the Amplify App. | `string` | `null` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Platform for the Amplify App. Options are WEB or WEB\_COMPUTE. | `string` | `"WEB"` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | Repository for the Amplify App. This could be hosted in AWS Code Commit, Bitbucket, GitHub, GitLab, etc. | `string` | `null` | no |
+| <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | ARN of an existing SNS topic to use for Amplify build notifications. Required when enable\_notifications is true and create\_sns\_topic is false. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for the Amplify App. | `map(string)` | <pre>{<br/>  "created_by": "terraform",<br/>  "environment": "prod",<br/>  "terraform": "true"<br/>}</pre> | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_app_arn"></a> [app\_arn](#output\_app\_arn) | The ARN of the Amplify app. |
+| <a name="output_app_id"></a> [app\_id](#output\_app\_id) | The unique ID of the Amplify app. |
+| <a name="output_default_domain"></a> [default\_domain](#output\_default\_domain) | The default domain of the Amplify app. |
+| <a name="output_notification_event_rule_arn"></a> [notification\_event\_rule\_arn](#output\_notification\_event\_rule\_arn) | The ARN of the CloudWatch EventBridge rule for Amplify build notifications. Null when notifications are disabled. |
+| <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | The ARN of the SNS topic used for Amplify build notifications. Null when notifications are disabled. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/amplify/README.md
+++ b/modules/aws/amplify/README.md
@@ -124,7 +124,10 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_amplify_notifications_event"></a> [amplify\_notifications\_event](#module\_amplify\_notifications\_event) | ../cloudwatch/event | n/a |
+| <a name="module_amplify_notifications_sns"></a> [amplify\_notifications\_sns](#module\_amplify\_notifications\_sns) | ../sns | n/a |
 
 ## Resources
 
@@ -133,12 +136,8 @@ No modules.
 | [aws_amplify_app.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_app) | resource |
 | [aws_amplify_branch.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_branch) | resource |
 | [aws_amplify_domain_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_domain_association) | resource |
-| [aws_cloudwatch_event_rule.amplify_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.amplify_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
-| [aws_sns_topic_policy.amplify_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
-| [aws_sns_topic_subscription.email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
-| [aws_iam_policy_document.amplify_notifications_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/modules/aws/amplify/main.tf
+++ b/modules/aws/amplify/main.tf
@@ -135,3 +135,7 @@ resource "aws_amplify_domain_association" "this" {
     }
   }
 }
+
+###########################
+# CloudWatch EventBridge Rule
+###########################

--- a/modules/aws/amplify/main.tf
+++ b/modules/aws/amplify/main.tf
@@ -19,6 +19,9 @@ terraform {
 ###########################
 # Locals
 ###########################
+locals {
+  sns_topic_arn = var.enable_notifications ? (var.create_sns_topic ? aws_sns_topic.this[0].arn : var.sns_topic_arn) : null
+}
 
 ###########################
 # Module Configuration
@@ -137,5 +140,93 @@ resource "aws_amplify_domain_association" "this" {
 }
 
 ###########################
+# SNS Topic
+###########################
+resource "aws_sns_topic" "this" {
+  count = var.create_sns_topic && var.enable_notifications ? 1 : 0
+  name  = "${var.name}-amplify-notifications"
+  tags  = merge(tomap({ Name = "${var.name}-amplify-notifications" }), var.tags)
+}
+
+###########################
+# SNS Topic Policy
+###########################
+data "aws_iam_policy_document" "amplify_notifications_sns" {
+  count = var.create_sns_topic && var.enable_notifications ? 1 : 0
+  statement {
+    sid    = "AllowEventBridgePublish"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.this[0].arn]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudwatch_event_rule.amplify_notifications[0].arn]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "amplify_notifications" {
+  count  = var.create_sns_topic && var.enable_notifications ? 1 : 0
+  arn    = aws_sns_topic.this[0].arn
+  policy = data.aws_iam_policy_document.amplify_notifications_sns[0].json
+}
+
+###########################
+# SNS Topic Subscriptions
+###########################
+resource "aws_sns_topic_subscription" "email" {
+  for_each  = var.enable_notifications && var.notification_emails != null ? toset(var.notification_emails) : toset([])
+  topic_arn = local.sns_topic_arn
+  protocol  = "email"
+  endpoint  = each.value
+}
+
+###########################
 # CloudWatch EventBridge Rule
 ###########################
+resource "aws_cloudwatch_event_rule" "amplify_notifications" {
+  count       = var.enable_notifications ? 1 : 0
+  description = "Amplify build and deployment status notifications for ${var.name}"
+  event_pattern = jsonencode({
+    source      = ["aws.amplify"]
+    detail-type = ["Amplify Deployment Status Change"]
+    detail = {
+      appId = [aws_amplify_app.this.id]
+    }
+  })
+  name  = "${substr(var.name, 0, 50)}-amplify-notifications"
+  state = "ENABLED"
+  tags  = merge(tomap({ Name = "${var.name}-amplify-notifications" }), var.tags)
+
+  lifecycle {
+    precondition {
+      condition     = var.create_sns_topic || var.sns_topic_arn != null
+      error_message = "sns_topic_arn must be provided when enable_notifications is true and create_sns_topic is false."
+    }
+  }
+}
+
+###########################
+# CloudWatch EventBridge Target
+###########################
+resource "aws_cloudwatch_event_target" "amplify_notifications" {
+  count     = var.enable_notifications ? 1 : 0
+  arn       = local.sns_topic_arn
+  rule      = aws_cloudwatch_event_rule.amplify_notifications[0].name
+  target_id = "${var.name}-amplify-notifications"
+
+  input_transformer {
+    input_paths = {
+      appId      = "$.detail.appId"
+      branchName = "$.detail.branchName"
+      jobId      = "$.detail.jobId"
+      status     = "$.detail.jobStatus"
+    }
+    input_template = "\"Amplify build for app <appId> on branch <branchName> (job <jobId>) completed with status: <status>\""
+  }
+}

--- a/modules/aws/amplify/main.tf
+++ b/modules/aws/amplify/main.tf
@@ -21,7 +21,7 @@ data "aws_region" "current" {}
 # Locals
 ###########################
 locals {
-  notification_rule_name = "${substr(var.name, 0, 43)}-amplify-notifications"
+  notification_rule_name = "${substr(var.name, 0, 42)}-amplify-notifications"
   # Compute the EventBridge rule ARN deterministically so the SNS topic policy
   # can reference it without creating a Terraform dependency cycle.
   notification_rule_arn = "arn:aws:events:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:rule/${local.notification_rule_name}"
@@ -119,6 +119,10 @@ resource "aws_amplify_app" "this" {
       condition     = !var.enable_notifications || var.create_sns_topic || var.sns_topic_arn != null
       error_message = "sns_topic_arn must be provided when enable_notifications is true and create_sns_topic is false."
     }
+    precondition {
+      condition     = !var.enable_notifications || var.create_sns_topic || var.notification_emails == null
+      error_message = "notification_emails can only be used when create_sns_topic is true; subscriptions against a caller-supplied topic are not managed by this module."
+    }
   }
 }
 
@@ -186,10 +190,11 @@ module "amplify_notifications_sns" {
   source = "../sns"
   count  = var.enable_notifications && var.create_sns_topic ? 1 : 0
 
-  name          = "${var.name}-amplify-notifications"
-  policy        = local.notification_sns_policy
-  subscriptions = local.notification_subscriptions
-  tags          = var.tags
+  name              = "${var.name}-amplify-notifications"
+  kms_master_key_id = null
+  policy            = local.notification_sns_policy
+  subscriptions     = local.notification_subscriptions
+  tags              = var.tags
 }
 
 ###########################
@@ -203,7 +208,7 @@ module "amplify_notifications_event" {
   event_target_arn = local.sns_topic_arn
   name             = local.notification_rule_name
   tags             = var.tags
-  target_id        = "${substr(var.name, 0, 43)}-amplify-notifications"
+  target_id        = "${substr(var.name, 0, 42)}-amplify-notifications"
 
   event_pattern = jsonencode({
     source      = ["aws.amplify"]

--- a/modules/aws/amplify/main.tf
+++ b/modules/aws/amplify/main.tf
@@ -14,13 +14,45 @@ terraform {
 ###########################
 # Data Sources
 ###########################
-
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 ###########################
 # Locals
 ###########################
 locals {
-  sns_topic_arn = var.enable_notifications ? (var.create_sns_topic ? aws_sns_topic.this[0].arn : var.sns_topic_arn) : null
+  notification_rule_name = "${substr(var.name, 0, 43)}-amplify-notifications"
+  # Compute the EventBridge rule ARN deterministically so the SNS topic policy
+  # can reference it without creating a Terraform dependency cycle.
+  notification_rule_arn = "arn:aws:events:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:rule/${local.notification_rule_name}"
+  sns_topic_arn         = var.enable_notifications ? (var.create_sns_topic ? module.amplify_notifications_sns[0].topic_arn : var.sns_topic_arn) : null
+
+  notification_subscriptions = var.enable_notifications && var.notification_emails != null ? {
+    for email in var.notification_emails : email => {
+      protocol = "email"
+      endpoint = email
+    }
+  } : {}
+
+  notification_sns_policy = var.enable_notifications && var.create_sns_topic ? jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgePublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = local.notification_rule_arn
+          }
+        }
+      }
+    ]
+  }) : null
 }
 
 ###########################
@@ -71,6 +103,7 @@ resource "aws_amplify_app" "this" {
       type = var.cache_config_type
     }
   }
+
   dynamic "custom_rule" {
     for_each = var.custom_rules != null ? var.custom_rules : []
     content {
@@ -78,6 +111,13 @@ resource "aws_amplify_app" "this" {
       source    = custom_rule.value.source
       status    = custom_rule.value.status
       target    = custom_rule.value.target
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_notifications || var.create_sns_topic || var.sns_topic_arn != null
+      error_message = "sns_topic_arn must be provided when enable_notifications is true and create_sns_topic is false."
     }
   }
 }
@@ -140,58 +180,31 @@ resource "aws_amplify_domain_association" "this" {
 }
 
 ###########################
-# SNS Topic
+# SNS Notifications Topic
 ###########################
-resource "aws_sns_topic" "this" {
-  count = var.create_sns_topic && var.enable_notifications ? 1 : 0
-  name  = "${var.name}-amplify-notifications"
-  tags  = merge(tomap({ Name = "${var.name}-amplify-notifications" }), var.tags)
+module "amplify_notifications_sns" {
+  source = "../sns"
+  count  = var.enable_notifications && var.create_sns_topic ? 1 : 0
+
+  name          = "${var.name}-amplify-notifications"
+  policy        = local.notification_sns_policy
+  subscriptions = local.notification_subscriptions
+  tags          = var.tags
 }
 
 ###########################
-# SNS Topic Policy
+# CloudWatch EventBridge Notification Rule
 ###########################
-data "aws_iam_policy_document" "amplify_notifications_sns" {
-  count = var.create_sns_topic && var.enable_notifications ? 1 : 0
-  statement {
-    sid    = "AllowEventBridgePublish"
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-    actions   = ["sns:Publish"]
-    resources = [aws_sns_topic.this[0].arn]
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values   = [aws_cloudwatch_event_rule.amplify_notifications[0].arn]
-    }
-  }
-}
+module "amplify_notifications_event" {
+  source = "../cloudwatch/event"
+  count  = var.enable_notifications ? 1 : 0
 
-resource "aws_sns_topic_policy" "amplify_notifications" {
-  count  = var.create_sns_topic && var.enable_notifications ? 1 : 0
-  arn    = aws_sns_topic.this[0].arn
-  policy = data.aws_iam_policy_document.amplify_notifications_sns[0].json
-}
+  description      = "Amplify build and deployment status notifications for ${var.name}"
+  event_target_arn = local.sns_topic_arn
+  name             = local.notification_rule_name
+  tags             = var.tags
+  target_id        = "${substr(var.name, 0, 43)}-amplify-notifications"
 
-###########################
-# SNS Topic Subscriptions
-###########################
-resource "aws_sns_topic_subscription" "email" {
-  for_each  = var.enable_notifications && var.notification_emails != null ? toset(var.notification_emails) : toset([])
-  topic_arn = local.sns_topic_arn
-  protocol  = "email"
-  endpoint  = each.value
-}
-
-###########################
-# CloudWatch EventBridge Rule
-###########################
-resource "aws_cloudwatch_event_rule" "amplify_notifications" {
-  count       = var.enable_notifications ? 1 : 0
-  description = "Amplify build and deployment status notifications for ${var.name}"
   event_pattern = jsonencode({
     source      = ["aws.amplify"]
     detail-type = ["Amplify Deployment Status Change"]
@@ -199,28 +212,8 @@ resource "aws_cloudwatch_event_rule" "amplify_notifications" {
       appId = [aws_amplify_app.this.id]
     }
   })
-  name  = "${substr(var.name, 0, 50)}-amplify-notifications"
-  state = "ENABLED"
-  tags  = merge(tomap({ Name = "${var.name}-amplify-notifications" }), var.tags)
 
-  lifecycle {
-    precondition {
-      condition     = var.create_sns_topic || var.sns_topic_arn != null
-      error_message = "sns_topic_arn must be provided when enable_notifications is true and create_sns_topic is false."
-    }
-  }
-}
-
-###########################
-# CloudWatch EventBridge Target
-###########################
-resource "aws_cloudwatch_event_target" "amplify_notifications" {
-  count     = var.enable_notifications ? 1 : 0
-  arn       = local.sns_topic_arn
-  rule      = aws_cloudwatch_event_rule.amplify_notifications[0].name
-  target_id = "${var.name}-amplify-notifications"
-
-  input_transformer {
+  input_transformer = {
     input_paths = {
       appId      = "$.detail.appId"
       branchName = "$.detail.branchName"

--- a/modules/aws/amplify/outputs.tf
+++ b/modules/aws/amplify/outputs.tf
@@ -19,7 +19,7 @@ output "default_domain" {
 
 output "sns_topic_arn" {
   description = "The ARN of the SNS topic used for Amplify build notifications. Null when notifications are disabled."
-  value       = var.enable_notifications && var.create_sns_topic ? module.amplify_notifications_sns[0].topic_arn : var.sns_topic_arn
+  value       = var.enable_notifications ? (var.create_sns_topic ? module.amplify_notifications_sns[0].topic_arn : var.sns_topic_arn) : null
 }
 
 output "notification_event_rule_arn" {

--- a/modules/aws/amplify/outputs.tf
+++ b/modules/aws/amplify/outputs.tf
@@ -19,10 +19,10 @@ output "default_domain" {
 
 output "sns_topic_arn" {
   description = "The ARN of the SNS topic used for Amplify build notifications. Null when notifications are disabled."
-  value       = var.enable_notifications && var.create_sns_topic ? aws_sns_topic.this[0].arn : var.sns_topic_arn
+  value       = var.enable_notifications && var.create_sns_topic ? module.amplify_notifications_sns[0].topic_arn : var.sns_topic_arn
 }
 
 output "notification_event_rule_arn" {
   description = "The ARN of the CloudWatch EventBridge rule for Amplify build notifications. Null when notifications are disabled."
-  value       = var.enable_notifications ? aws_cloudwatch_event_rule.amplify_notifications[0].arn : null
+  value       = var.enable_notifications ? module.amplify_notifications_event[0].arn : null
 }

--- a/modules/aws/amplify/outputs.tf
+++ b/modules/aws/amplify/outputs.tf
@@ -2,3 +2,27 @@
 # Resource Outputs
 ###########################
 
+output "app_id" {
+  description = "The unique ID of the Amplify app."
+  value       = aws_amplify_app.this.id
+}
+
+output "app_arn" {
+  description = "The ARN of the Amplify app."
+  value       = aws_amplify_app.this.arn
+}
+
+output "default_domain" {
+  description = "The default domain of the Amplify app."
+  value       = aws_amplify_app.this.default_domain
+}
+
+output "sns_topic_arn" {
+  description = "The ARN of the SNS topic used for Amplify build notifications. Null when notifications are disabled."
+  value       = var.enable_notifications && var.create_sns_topic ? aws_sns_topic.this[0].arn : var.sns_topic_arn
+}
+
+output "notification_event_rule_arn" {
+  description = "The ARN of the CloudWatch EventBridge rule for Amplify build notifications. Null when notifications are disabled."
+  value       = var.enable_notifications ? aws_cloudwatch_event_rule.amplify_notifications[0].arn : null
+}

--- a/modules/aws/amplify/variables.tf
+++ b/modules/aws/amplify/variables.tf
@@ -208,6 +208,34 @@ variable "branches" {
 }
 
 ###########################
+# Notifications
+###########################
+
+variable "create_sns_topic" {
+  description = "Whether to create an SNS topic for Amplify build notifications. When false, sns_topic_arn must be provided."
+  type        = bool
+  default     = true
+}
+
+variable "enable_notifications" {
+  description = "Whether to enable SNS build notifications for Amplify via EventBridge. Creates an SNS topic (or uses sns_topic_arn) and a CloudWatch EventBridge rule that fires on Amplify deployment status changes."
+  type        = bool
+  default     = false
+}
+
+variable "notification_emails" {
+  description = "List of email addresses to subscribe to Amplify build notifications. Only used when enable_notifications is true."
+  type        = list(string)
+  default     = null
+}
+
+variable "sns_topic_arn" {
+  description = "ARN of an existing SNS topic to use for Amplify build notifications. Required when enable_notifications is true and create_sns_topic is false."
+  type        = string
+  default     = null
+}
+
+###########################
 # General Variables
 ###########################
 

--- a/modules/aws/cloudwatch/event/README.md
+++ b/modules/aws/cloudwatch/event/README.md
@@ -108,10 +108,16 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | Description of the cloudwatch event | `any` | n/a | yes |
-| <a name="input_event_target_arn"></a> [event\_target\_arn](#input\_event\_target\_arn) | arn of the target to invoke with this event | `any` | n/a | yes |
-| <a name="input_is_enabled"></a> [is\_enabled](#input\_is\_enabled) | Whether or not the event rule is enabled | `string` | `"true"` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the cloudwatch event | `any` | n/a | yes |
+| <a name="input_event_bus_name"></a> [event\_bus\_name](#input\_event\_bus\_name) | The ARN of the event bus to associate with this event. If this is not provided, the default event bus will be used. | `any` | `null` | no |
+| <a name="input_event_pattern"></a> [event\_pattern](#input\_event\_pattern) | JSON for the event pattern. Either event\_pattern or schedule\_expression must be provided. | `any` | n/a | yes |
+| <a name="input_event_target_arn"></a> [event\_target\_arn](#input\_event\_target\_arn) | ARN of the target to invoke with this event. | `any` | n/a | yes |
+| <a name="input_input_transformer"></a> [input\_transformer](#input\_input\_transformer) | Input transformer for the event target. | <pre>list(object({<br/>    input_paths    = map(string)<br/>    input_template = string<br/>  }))</pre> | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for the cloudwatch event. Must be 38 characters or less. | `any` | n/a | yes |
+| <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | The ARN of the IAM role to use for this event. | `any` | `null` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | cron expression of time or rate expression of time | `any` | n/a | yes |
+| <a name="input_state"></a> [state](#input\_state) | Whether the rule should be enabled or disabled | `string` | `"ENABLED"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource. | `map(string)` | <pre>{<br/>  "terraform": "true"<br/>}</pre> | no |
+| <a name="input_target_id"></a> [target\_id](#input\_target\_id) | The unique target assignment ID. | `any` | `null` | no |
 
 ## Outputs
 

--- a/modules/aws/cloudwatch/event/README.md
+++ b/modules/aws/cloudwatch/event/README.md
@@ -112,6 +112,7 @@ No modules.
 | <a name="input_event_pattern"></a> [event\_pattern](#input\_event\_pattern) | JSON string for the event pattern. Either event\_pattern or schedule\_expression must be provided, but not both. | `string` | `null` | no |
 | <a name="input_event_target_arn"></a> [event\_target\_arn](#input\_event\_target\_arn) | ARN of the target resource to invoke when the rule is triggered. | `string` | n/a | yes |
 | <a name="input_input_transformer"></a> [input\_transformer](#input\_input\_transformer) | Input transformer to extract values from the event and pass them to the target in a custom format. Only one input\_transformer is supported per event target. | <pre>object({<br/>    input_paths    = map(string)<br/>    input_template = string<br/>  })</pre> | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the CloudWatch event rule. Must be 64 characters or less. Mutually exclusive with name\_prefix. | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for the cloudwatch event rule. Must be 38 characters or less. Mutually exclusive with name. | `string` | `null` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | The ARN of the IAM role to associate with this rule. | `string` | `null` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The scheduling expression for the rule, e.g. cron(0 20 * * ? *) or rate(5 minutes). Either schedule\_expression or event\_pattern must be provided, but not both. | `string` | `null` | no |
@@ -123,7 +124,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_arn"></a> [arn](#output\_arn) | n/a |
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the CloudWatch event rule. |
+| <a name="output_rule_name"></a> [rule\_name](#output\_rule\_name) | The name of the CloudWatch event rule. |
+| <a name="output_target_arn"></a> [target\_arn](#output\_target\_arn) | The ARN of the CloudWatch event target. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/cloudwatch/event/README.md
+++ b/modules/aws/cloudwatch/event/README.md
@@ -82,15 +82,15 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.46.0 |
 
 ## Modules
 
@@ -99,30 +99,30 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_description"></a> [description](#input\_description) | Description of the cloudwatch event | `any` | n/a | yes |
-| <a name="input_event_bus_name"></a> [event\_bus\_name](#input\_event\_bus\_name) | The ARN of the event bus to associate with this event. If this is not provided, the default event bus will be used. | `any` | `null` | no |
-| <a name="input_event_pattern"></a> [event\_pattern](#input\_event\_pattern) | JSON for the event pattern. Either event\_pattern or schedule\_expression must be provided. | `any` | n/a | yes |
-| <a name="input_event_target_arn"></a> [event\_target\_arn](#input\_event\_target\_arn) | ARN of the target to invoke with this event. | `any` | n/a | yes |
-| <a name="input_input_transformer"></a> [input\_transformer](#input\_input\_transformer) | Input transformer for the event target. | <pre>list(object({<br/>    input_paths    = map(string)<br/>    input_template = string<br/>  }))</pre> | `null` | no |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for the cloudwatch event. Must be 38 characters or less. | `any` | n/a | yes |
-| <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | The ARN of the IAM role to use for this event. | `any` | `null` | no |
-| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | cron expression of time or rate expression of time | `any` | n/a | yes |
-| <a name="input_state"></a> [state](#input\_state) | Whether the rule should be enabled or disabled | `string` | `"ENABLED"` | no |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_description"></a> [description](#input\_description) | Description of the cloudwatch event. | `string` | `null` | no |
+| <a name="input_event_bus_name"></a> [event\_bus\_name](#input\_event\_bus\_name) | The name or ARN of the event bus to associate with this rule. If not provided, the default event bus will be used. | `string` | `null` | no |
+| <a name="input_event_pattern"></a> [event\_pattern](#input\_event\_pattern) | JSON string for the event pattern. Either event\_pattern or schedule\_expression must be provided, but not both. | `string` | `null` | no |
+| <a name="input_event_target_arn"></a> [event\_target\_arn](#input\_event\_target\_arn) | ARN of the target resource to invoke when the rule is triggered. | `string` | n/a | yes |
+| <a name="input_input_transformer"></a> [input\_transformer](#input\_input\_transformer) | Input transformer to extract values from the event and pass them to the target in a custom format. Only one input\_transformer is supported per event target. | <pre>object({<br/>    input_paths    = map(string)<br/>    input_template = string<br/>  })</pre> | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for the cloudwatch event rule. Must be 38 characters or less. Mutually exclusive with name. | `string` | `null` | no |
+| <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | The ARN of the IAM role to associate with this rule. | `string` | `null` | no |
+| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The scheduling expression for the rule, e.g. cron(0 20 * * ? *) or rate(5 minutes). Either schedule\_expression or event\_pattern must be provided, but not both. | `string` | `null` | no |
+| <a name="input_state"></a> [state](#input\_state) | The state of the rule. Valid values are ENABLED, DISABLED, or ENABLED\_WITH\_ALL\_CLOUDTRAIL\_MANAGEMENT\_EVENTS. | `string` | `"ENABLED"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource. | `map(string)` | <pre>{<br/>  "terraform": "true"<br/>}</pre> | no |
 | <a name="input_target_id"></a> [target\_id](#input\_target\_id) | The unique target assignment ID. | `any` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_arn"></a> [arn](#output\_arn) | n/a |
 <!-- END_TF_DOCS -->
 

--- a/modules/aws/cloudwatch/event/README.md
+++ b/modules/aws/cloudwatch/event/README.md
@@ -117,7 +117,7 @@ No modules.
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The scheduling expression for the rule, e.g. cron(0 20 * * ? *) or rate(5 minutes). Either schedule\_expression or event\_pattern must be provided, but not both. | `string` | `null` | no |
 | <a name="input_state"></a> [state](#input\_state) | The state of the rule. Valid values are ENABLED, DISABLED, or ENABLED\_WITH\_ALL\_CLOUDTRAIL\_MANAGEMENT\_EVENTS. | `string` | `"ENABLED"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource. | `map(string)` | <pre>{<br/>  "terraform": "true"<br/>}</pre> | no |
-| <a name="input_target_id"></a> [target\_id](#input\_target\_id) | The unique target assignment ID. | `any` | `null` | no |
+| <a name="input_target_id"></a> [target\_id](#input\_target\_id) | The unique target assignment ID. | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/aws/cloudwatch/event/README.md
+++ b/modules/aws/cloudwatch/event/README.md
@@ -82,15 +82,15 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.46.0 |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 
@@ -99,14 +99,14 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_cloudwatch_event_rule.event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | Description of the cloudwatch event. | `string` | `null` | no |
 | <a name="input_event_bus_name"></a> [event\_bus\_name](#input\_event\_bus\_name) | The name or ARN of the event bus to associate with this rule. If not provided, the default event bus will be used. | `string` | `null` | no |
 | <a name="input_event_pattern"></a> [event\_pattern](#input\_event\_pattern) | JSON string for the event pattern. Either event\_pattern or schedule\_expression must be provided, but not both. | `string` | `null` | no |
@@ -122,7 +122,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | n/a |
 <!-- END_TF_DOCS -->
 

--- a/modules/aws/cloudwatch/event/main.tf
+++ b/modules/aws/cloudwatch/event/main.tf
@@ -8,14 +8,33 @@ terraform {
   }
 }
 
+###########################
+# CloudWatch EventBridge Rule
+###########################
 resource "aws_cloudwatch_event_rule" "event_rule" {
-  name                = var.name
   description         = var.description
+  event_bus_name      = var.event_bus_name
+  event_pattern       = var.event_pattern
+  name_prefix         = var.name_prefix
+  role_arn            = var.role_arn
   schedule_expression = var.schedule_expression
-  is_enabled          = var.is_enabled
+  state               = var.state
+  tags                = var.tags
 }
 
+###########################
+# CloudWatch EventBridge Target
+###########################
 resource "aws_cloudwatch_event_target" "event_target" {
-  rule = aws_cloudwatch_event_rule.event_rule.name
-  arn  = var.event_target_arn
+  arn       = var.event_target_arn
+  rule      = aws_cloudwatch_event_rule.event_rule.name
+  target_id = var.target_id
+
+  dynamic "input_transformer" {
+    for_each = var.input_transformer != null ? toset(var.input_transformer) : []
+    content {
+      input_paths    = input_transformer.value.input_paths
+      input_template = input_transformer.value.input_template
+    }
+  }
 }

--- a/modules/aws/cloudwatch/event/main.tf
+++ b/modules/aws/cloudwatch/event/main.tf
@@ -38,9 +38,10 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
 # CloudWatch EventBridge Target
 ###########################
 resource "aws_cloudwatch_event_target" "event_target" {
-  arn       = var.event_target_arn
-  rule      = aws_cloudwatch_event_rule.event_rule.name
-  target_id = var.target_id
+  arn            = var.event_target_arn
+  event_bus_name = var.event_bus_name
+  rule           = aws_cloudwatch_event_rule.event_rule.name
+  target_id      = var.target_id
 
   dynamic "input_transformer" {
     for_each = var.input_transformer != null ? [var.input_transformer] : []

--- a/modules/aws/cloudwatch/event/main.tf
+++ b/modules/aws/cloudwatch/event/main.tf
@@ -15,16 +15,21 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
   description         = var.description
   event_bus_name      = var.event_bus_name
   event_pattern       = var.event_pattern
+  name                = var.name
   name_prefix         = var.name_prefix
   role_arn            = var.role_arn
   schedule_expression = var.schedule_expression
   state               = var.state
-  tags                = var.tags
+  tags                = merge(tomap({ Name = coalesce(var.name, var.name_prefix, "cloudwatch-event") }), var.tags)
 
   lifecycle {
     precondition {
       condition     = (var.event_pattern != null) != (var.schedule_expression != null)
       error_message = "Exactly one of event_pattern or schedule_expression must be provided."
+    }
+    precondition {
+      condition     = (var.name == null) != (var.name_prefix == null)
+      error_message = "Exactly one of name or name_prefix must be provided."
     }
   }
 }

--- a/modules/aws/cloudwatch/event/main.tf
+++ b/modules/aws/cloudwatch/event/main.tf
@@ -20,6 +20,13 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
   schedule_expression = var.schedule_expression
   state               = var.state
   tags                = var.tags
+
+  lifecycle {
+    precondition {
+      condition     = (var.event_pattern != null) != (var.schedule_expression != null)
+      error_message = "Exactly one of event_pattern or schedule_expression must be provided."
+    }
+  }
 }
 
 ###########################
@@ -31,7 +38,7 @@ resource "aws_cloudwatch_event_target" "event_target" {
   target_id = var.target_id
 
   dynamic "input_transformer" {
-    for_each = var.input_transformer != null ? toset(var.input_transformer) : []
+    for_each = var.input_transformer != null ? [var.input_transformer] : []
     content {
       input_paths    = input_transformer.value.input_paths
       input_template = input_transformer.value.input_template

--- a/modules/aws/cloudwatch/event/outputs.tf
+++ b/modules/aws/cloudwatch/event/outputs.tf
@@ -1,3 +1,18 @@
+###########################
+# Resource Outputs
+###########################
+
 output "arn" {
-  value = aws_cloudwatch_event_rule.event_rule.arn
+  description = "The ARN of the CloudWatch event rule."
+  value       = aws_cloudwatch_event_rule.event_rule.arn
+}
+
+output "rule_name" {
+  description = "The name of the CloudWatch event rule."
+  value       = aws_cloudwatch_event_rule.event_rule.name
+}
+
+output "target_arn" {
+  description = "The ARN of the CloudWatch event target."
+  value       = aws_cloudwatch_event_target.event_target.arn
 }

--- a/modules/aws/cloudwatch/event/variables.tf
+++ b/modules/aws/cloudwatch/event/variables.tf
@@ -1,20 +1,70 @@
-variable "name" {
-  description = "Name of the cloudwatch event"
-}
-
+###########################
+# CloudWatch EventBridge Rule Variables
+###########################
 variable "description" {
   description = "Description of the cloudwatch event"
+}
+
+variable "event_bus_name" {
+  description = "The ARN of the event bus to associate with this event. If this is not provided, the default event bus will be used."
+  default     = null
+}
+
+variable "event_pattern" {
+  description = "JSON for the event pattern. Either event_pattern or schedule_expression must be provided."
+}
+
+variable "name_prefix" {
+  description = "Name prefix for the cloudwatch event. Must be 38 characters or less."
+  validation {
+    condition     = length(var.name_prefix) <= 38
+    error_message = "Name prefix must be 38 characters or less."
+  }
+}
+
+variable "role_arn" {
+  description = "The ARN of the IAM role to use for this event."
+  default     = null
 }
 
 variable "schedule_expression" {
   description = "cron expression of time or rate expression of time"
 }
 
-variable "is_enabled" {
-  description = "Whether or not the event rule is enabled"
-  default     = "true"
+variable "state" {
+  description = "Whether the rule should be enabled or disabled"
+  default     = "ENABLED"
 }
 
+###########################
+# CloudWatch EventBridge Target Variables
+###########################
 variable "event_target_arn" {
-  description = "arn of the target to invoke with this event"
+  description = "ARN of the target to invoke with this event."
+}
+
+variable "input_transformer" {
+  description = "Input transformer for the event target."
+  type = list(object({
+    input_paths    = map(string)
+    input_template = string
+  }))
+  default = null
+}
+
+variable "target_id" {
+  description = "The unique target assignment ID."
+  default     = null
+}
+
+###########################
+# General Variables
+###########################
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource."
+  type        = map(string)
+  default = {
+    "terraform" = "true"
+  }
 }

--- a/modules/aws/cloudwatch/event/variables.tf
+++ b/modules/aws/cloudwatch/event/variables.tf
@@ -70,6 +70,7 @@ variable "input_transformer" {
 
 variable "target_id" {
   description = "The unique target assignment ID."
+  type        = string
   default     = null
 }
 

--- a/modules/aws/cloudwatch/event/variables.tf
+++ b/modules/aws/cloudwatch/event/variables.tf
@@ -19,12 +19,22 @@ variable "event_pattern" {
   default     = null
 }
 
+variable "name" {
+  description = "Name of the CloudWatch event rule. Must be 64 characters or less. Mutually exclusive with name_prefix."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.name == null || try(length(var.name) <= 64, false)
+    error_message = "Name must be 64 characters or less."
+  }
+}
+
 variable "name_prefix" {
   description = "Name prefix for the cloudwatch event rule. Must be 38 characters or less. Mutually exclusive with name."
   type        = string
   default     = null
   validation {
-    condition     = var.name_prefix == null || length(var.name_prefix) <= 38
+    condition     = var.name_prefix == null || try(length(var.name_prefix) <= 38, false)
     error_message = "Name prefix must be 38 characters or less."
   }
 }

--- a/modules/aws/cloudwatch/event/variables.tf
+++ b/modules/aws/cloudwatch/event/variables.tf
@@ -2,53 +2,69 @@
 # CloudWatch EventBridge Rule Variables
 ###########################
 variable "description" {
-  description = "Description of the cloudwatch event"
+  description = "Description of the cloudwatch event."
+  type        = string
+  default     = null
 }
 
 variable "event_bus_name" {
-  description = "The ARN of the event bus to associate with this event. If this is not provided, the default event bus will be used."
+  description = "The name or ARN of the event bus to associate with this rule. If not provided, the default event bus will be used."
+  type        = string
   default     = null
 }
 
 variable "event_pattern" {
-  description = "JSON for the event pattern. Either event_pattern or schedule_expression must be provided."
+  description = "JSON string for the event pattern. Either event_pattern or schedule_expression must be provided, but not both."
+  type        = string
+  default     = null
 }
 
 variable "name_prefix" {
-  description = "Name prefix for the cloudwatch event. Must be 38 characters or less."
+  description = "Name prefix for the cloudwatch event rule. Must be 38 characters or less. Mutually exclusive with name."
+  type        = string
+  default     = null
   validation {
-    condition     = length(var.name_prefix) <= 38
+    condition     = var.name_prefix == null || length(var.name_prefix) <= 38
     error_message = "Name prefix must be 38 characters or less."
   }
 }
 
 variable "role_arn" {
-  description = "The ARN of the IAM role to use for this event."
+  description = "The ARN of the IAM role to associate with this rule."
+  type        = string
   default     = null
 }
 
 variable "schedule_expression" {
-  description = "cron expression of time or rate expression of time"
+  description = "The scheduling expression for the rule, e.g. cron(0 20 * * ? *) or rate(5 minutes). Either schedule_expression or event_pattern must be provided, but not both."
+  type        = string
+  default     = null
 }
 
 variable "state" {
-  description = "Whether the rule should be enabled or disabled"
+  description = "The state of the rule. Valid values are ENABLED, DISABLED, or ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS."
+  type        = string
   default     = "ENABLED"
+  validation {
+    condition     = contains(["ENABLED", "DISABLED", "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"], var.state)
+    error_message = "State must be one of ENABLED, DISABLED, or ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS."
+  }
 }
 
 ###########################
 # CloudWatch EventBridge Target Variables
 ###########################
 variable "event_target_arn" {
-  description = "ARN of the target to invoke with this event."
+  description = "ARN of the target resource to invoke when the rule is triggered."
+  type        = string
 }
 
 variable "input_transformer" {
-  description = "Input transformer for the event target."
-  type = list(object({
+  description = "Input transformer to extract values from the event and pass them to the target in a custom format. Only one input_transformer is supported per event target."
+  type = object({
     input_paths    = map(string)
     input_template = string
-  }))
+  })
   default = null
 }
 

--- a/modules/aws/sns/README.md
+++ b/modules/aws/sns/README.md
@@ -68,4 +68,70 @@ module "notifications" {
 - **Subscriptions**: Use the `subscriptions` map to manage any number of subscriptions in a single module call. All `aws_sns_topic_subscription` attributes are exposed as optional object fields.
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_application_failure_feedback_role_arn"></a> [application\_failure\_feedback\_role\_arn](#input\_application\_failure\_feedback\_role\_arn) | IAM role ARN for delivery status failure feedback for application endpoints. | `string` | `null` | no |
+| <a name="input_application_success_feedback_role_arn"></a> [application\_success\_feedback\_role\_arn](#input\_application\_success\_feedback\_role\_arn) | IAM role ARN for delivery status success feedback for application endpoints. | `string` | `null` | no |
+| <a name="input_application_success_feedback_sample_rate"></a> [application\_success\_feedback\_sample\_rate](#input\_application\_success\_feedback\_sample\_rate) | Percentage of successful deliveries to sample for application endpoint feedback. Valid values are 0-100. | `number` | `null` | no |
+| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Enables content-based deduplication for FIFO topics. | `bool` | `false` | no |
+| <a name="input_delivery_policy"></a> [delivery\_policy](#input\_delivery\_policy) | JSON string for the SNS topic delivery policy. | `string` | `null` | no |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | Display name for the SNS topic. Used as the sender name in email notifications. | `string` | `null` | no |
+| <a name="input_fifo_topic"></a> [fifo\_topic](#input\_fifo\_topic) | Whether to create a FIFO (first-in, first-out) topic. When true, the topic name will have '.fifo' appended automatically. | `bool` | `false` | no |
+| <a name="input_firehose_failure_feedback_role_arn"></a> [firehose\_failure\_feedback\_role\_arn](#input\_firehose\_failure\_feedback\_role\_arn) | IAM role ARN for delivery status failure feedback for Firehose endpoints. | `string` | `null` | no |
+| <a name="input_firehose_success_feedback_role_arn"></a> [firehose\_success\_feedback\_role\_arn](#input\_firehose\_success\_feedback\_role\_arn) | IAM role ARN for delivery status success feedback for Firehose endpoints. | `string` | `null` | no |
+| <a name="input_firehose_success_feedback_sample_rate"></a> [firehose\_success\_feedback\_sample\_rate](#input\_firehose\_success\_feedback\_sample\_rate) | Percentage of successful deliveries to sample for Firehose endpoint feedback. Valid values are 0-100. | `number` | `null` | no |
+| <a name="input_http_failure_feedback_role_arn"></a> [http\_failure\_feedback\_role\_arn](#input\_http\_failure\_feedback\_role\_arn) | IAM role ARN for delivery status failure feedback for HTTP/HTTPS endpoints. | `string` | `null` | no |
+| <a name="input_http_success_feedback_role_arn"></a> [http\_success\_feedback\_role\_arn](#input\_http\_success\_feedback\_role\_arn) | IAM role ARN for delivery status success feedback for HTTP/HTTPS endpoints. | `string` | `null` | no |
+| <a name="input_http_success_feedback_sample_rate"></a> [http\_success\_feedback\_sample\_rate](#input\_http\_success\_feedback\_sample\_rate) | Percentage of successful deliveries to sample for HTTP/HTTPS endpoint feedback. Valid values are 0-100. | `number` | `null` | no |
+| <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | ID of the AWS KMS key to use for server-side encryption of the SNS topic. Use 'alias/aws/sns' for the AWS-managed key. Defaults to the AWS-managed SNS key for encryption at rest. | `string` | `"alias/aws/sns"` | no |
+| <a name="input_lambda_failure_feedback_role_arn"></a> [lambda\_failure\_feedback\_role\_arn](#input\_lambda\_failure\_feedback\_role\_arn) | IAM role ARN for delivery status failure feedback for Lambda endpoints. | `string` | `null` | no |
+| <a name="input_lambda_success_feedback_role_arn"></a> [lambda\_success\_feedback\_role\_arn](#input\_lambda\_success\_feedback\_role\_arn) | IAM role ARN for delivery status success feedback for Lambda endpoints. | `string` | `null` | no |
+| <a name="input_lambda_success_feedback_sample_rate"></a> [lambda\_success\_feedback\_sample\_rate](#input\_lambda\_success\_feedback\_sample\_rate) | Percentage of successful deliveries to sample for Lambda endpoint feedback. Valid values are 0-100. | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the SNS topic. Mutually exclusive with name\_prefix. When fifo\_topic is true, '.fifo' is appended automatically. | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for the SNS topic. Mutually exclusive with name. A unique suffix is appended by AWS. | `string` | `null` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | JSON string for the SNS topic access policy. When null, no topic policy is created and AWS defaults apply. | `string` | `null` | no |
+| <a name="input_signature_version"></a> [signature\_version](#input\_signature\_version) | Signature version used for SNS notifications. Valid values are 1 (SHA1) or 2 (SHA256). Defaults to 1. | `number` | `null` | no |
+| <a name="input_sqs_failure_feedback_role_arn"></a> [sqs\_failure\_feedback\_role\_arn](#input\_sqs\_failure\_feedback\_role\_arn) | IAM role ARN for delivery status failure feedback for SQS endpoints. | `string` | `null` | no |
+| <a name="input_sqs_success_feedback_role_arn"></a> [sqs\_success\_feedback\_role\_arn](#input\_sqs\_success\_feedback\_role\_arn) | IAM role ARN for delivery status success feedback for SQS endpoints. | `string` | `null` | no |
+| <a name="input_sqs_success_feedback_sample_rate"></a> [sqs\_success\_feedback\_sample\_rate](#input\_sqs\_success\_feedback\_sample\_rate) | Percentage of successful deliveries to sample for SQS endpoint feedback. Valid values are 0-100. | `number` | `null` | no |
+| <a name="input_subscriptions"></a> [subscriptions](#input\_subscriptions) | Map of SNS topic subscriptions to create. The key is a logical name for the subscription. | <pre>map(object({<br/>    confirmation_timeout_in_minutes = optional(number, 1)<br/>    delivery_policy                 = optional(string)<br/>    endpoint                        = string<br/>    endpoint_auto_confirms          = optional(bool, false)<br/>    filter_policy                   = optional(string)<br/>    filter_policy_scope             = optional(string)<br/>    protocol                        = string<br/>    raw_message_delivery            = optional(bool, false)<br/>    redrive_policy                  = optional(string)<br/>    replay_policy                   = optional(string)<br/>    subscription_role_arn           = optional(string)<br/>  }))</pre> | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources. | `map(string)` | <pre>{<br/>  "created_by": "terraform",<br/>  "environment": "prod",<br/>  "terraform": "true"<br/>}</pre> | no |
+| <a name="input_tracing_config"></a> [tracing\_config](#input\_tracing\_config) | Tracing mode for the SNS topic. Valid values are PassThrough or Active. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_subscription_arns"></a> [subscription\_arns](#output\_subscription\_arns) | Map of subscription logical names to their ARNs. |
+| <a name="output_topic_arn"></a> [topic\_arn](#output\_topic\_arn) | The ARN of the SNS topic. |
+| <a name="output_topic_id"></a> [topic\_id](#output\_topic\_id) | The ID of the SNS topic (same as the ARN). |
+| <a name="output_topic_name"></a> [topic\_name](#output\_topic\_name) | The name of the SNS topic. |
+| <a name="output_topic_owner"></a> [topic\_owner](#output\_topic\_owner) | The AWS account ID of the SNS topic owner. |
 <!-- END_TF_DOCS -->

--- a/modules/aws/sns/README.md
+++ b/modules/aws/sns/README.md
@@ -1,0 +1,71 @@
+# SNS Topic Module
+
+## Description
+
+Creates and manages an AWS SNS (Simple Notification Service) topic, optional topic access policy, and topic subscriptions. This module exposes all provider-supported attributes for `aws_sns_topic` and `aws_sns_topic_subscription`.
+
+## Prerequisites
+
+- If using a customer-managed KMS key (`kms_master_key_id`), the KMS key must be provisioned beforehand via the `modules/aws/kms` module and the key policy must permit SNS to use it.
+
+## Usage
+
+```hcl
+module "notifications" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/sns"
+
+  name              = "my-app-notifications"
+  kms_master_key_id = "alias/aws/sns"
+
+  subscriptions = {
+    ops_email = {
+      protocol = "email"
+      endpoint = "ops@example.com"
+    }
+  }
+
+  tags = {
+    Team        = "platform"
+    Environment = "prod"
+  }
+}
+```
+
+### With a custom topic policy
+
+```hcl
+data "aws_iam_policy_document" "eventbridge_publish" {
+  statement {
+    sid    = "AllowEventBridgePublish"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    actions   = ["sns:Publish"]
+    resources = ["*"]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:events:us-east-1:123456789012:rule/my-rule"]
+    }
+  }
+}
+
+module "notifications" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/sns"
+
+  name   = "my-app-notifications"
+  policy = data.aws_iam_policy_document.eventbridge_publish.json
+}
+```
+
+## Notes / Design Decisions
+
+- **Encryption at rest**: `kms_master_key_id` defaults to `alias/aws/sns` (the AWS-managed SNS KMS key) to satisfy CIS AWS Foundations Benchmark 3.9 and Well-Architected security pillar guidance. Set to `null` to disable encryption, or provide a customer-managed key ARN/alias.
+- **Topic policy**: When `policy` is `null` (the default), no `aws_sns_topic_policy` resource is created and AWS's default policy applies (account root has full access). Callers that need EventBridge, SQS, or cross-account access should render a policy with `data "aws_iam_policy_document"` and pass it in.
+- **FIFO topics**: Setting `fifo_topic = true` automatically appends `.fifo` to the topic name as required by AWS.
+- **Subscriptions**: Use the `subscriptions` map to manage any number of subscriptions in a single module call. All `aws_sns_topic_subscription` attributes are exposed as optional object fields.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/modules/aws/sns/main.tf
+++ b/modules/aws/sns/main.tf
@@ -45,8 +45,8 @@ resource "aws_sns_topic" "this" {
   lambda_failure_feedback_role_arn         = var.lambda_failure_feedback_role_arn
   lambda_success_feedback_role_arn         = var.lambda_success_feedback_role_arn
   lambda_success_feedback_sample_rate      = var.lambda_success_feedback_sample_rate
-  name                                     = var.fifo_topic ? "${var.name}.fifo" : var.name
-  name_prefix                              = var.name_prefix
+  name                                     = var.name != null ? (var.fifo_topic ? "${var.name}.fifo" : var.name) : null
+  name_prefix                              = var.name_prefix != null ? (var.fifo_topic ? "${var.name_prefix}.fifo" : var.name_prefix) : null
   signature_version                        = var.signature_version
   sqs_failure_feedback_role_arn            = var.sqs_failure_feedback_role_arn
   sqs_success_feedback_role_arn            = var.sqs_success_feedback_role_arn

--- a/modules/aws/sns/main.tf
+++ b/modules/aws/sns/main.tf
@@ -1,0 +1,85 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+###########################
+# Data Sources
+###########################
+
+
+###########################
+# Locals
+###########################
+
+###########################
+# Module Configuration
+###########################
+
+###########################
+# SNS Topic
+###########################
+resource "aws_sns_topic" "this" {
+  application_failure_feedback_role_arn    = var.application_failure_feedback_role_arn
+  application_success_feedback_role_arn    = var.application_success_feedback_role_arn
+  application_success_feedback_sample_rate = var.application_success_feedback_sample_rate
+  content_based_deduplication              = var.content_based_deduplication
+  delivery_policy                          = var.delivery_policy
+  display_name                             = var.display_name
+  fifo_topic                               = var.fifo_topic
+  firehose_failure_feedback_role_arn       = var.firehose_failure_feedback_role_arn
+  firehose_success_feedback_role_arn       = var.firehose_success_feedback_role_arn
+  firehose_success_feedback_sample_rate    = var.firehose_success_feedback_sample_rate
+  http_failure_feedback_role_arn           = var.http_failure_feedback_role_arn
+  http_success_feedback_role_arn           = var.http_success_feedback_role_arn
+  http_success_feedback_sample_rate        = var.http_success_feedback_sample_rate
+  kms_master_key_id                        = var.kms_master_key_id
+  lambda_failure_feedback_role_arn         = var.lambda_failure_feedback_role_arn
+  lambda_success_feedback_role_arn         = var.lambda_success_feedback_role_arn
+  lambda_success_feedback_sample_rate      = var.lambda_success_feedback_sample_rate
+  name                                     = var.fifo_topic ? "${var.name}.fifo" : var.name
+  name_prefix                              = var.name_prefix
+  signature_version                        = var.signature_version
+  sqs_failure_feedback_role_arn            = var.sqs_failure_feedback_role_arn
+  sqs_success_feedback_role_arn            = var.sqs_success_feedback_role_arn
+  sqs_success_feedback_sample_rate         = var.sqs_success_feedback_sample_rate
+  tags                                     = merge(tomap({ Name = var.name != null ? var.name : var.name_prefix }), var.tags)
+  tracing_config                           = var.tracing_config
+}
+
+###########################
+# SNS Topic Policy
+###########################
+resource "aws_sns_topic_policy" "this" {
+  count  = var.policy != null ? 1 : 0
+  arn    = aws_sns_topic.this.arn
+  policy = var.policy
+}
+
+###########################
+# SNS Topic Subscriptions
+###########################
+resource "aws_sns_topic_subscription" "this" {
+  for_each = var.subscriptions
+
+  confirmation_timeout_in_minutes = each.value.confirmation_timeout_in_minutes
+  delivery_policy                 = each.value.delivery_policy
+  endpoint                        = each.value.endpoint
+  endpoint_auto_confirms          = each.value.endpoint_auto_confirms
+  filter_policy                   = each.value.filter_policy
+  filter_policy_scope             = each.value.filter_policy_scope
+  protocol                        = each.value.protocol
+  raw_message_delivery            = each.value.raw_message_delivery
+  redrive_policy                  = each.value.redrive_policy
+  replay_policy                   = each.value.replay_policy
+  subscription_role_arn           = each.value.subscription_role_arn
+  topic_arn                       = aws_sns_topic.this.arn
+}

--- a/modules/aws/sns/outputs.tf
+++ b/modules/aws/sns/outputs.tf
@@ -1,0 +1,28 @@
+###########################
+# Resource Outputs
+###########################
+
+output "topic_arn" {
+  description = "The ARN of the SNS topic."
+  value       = aws_sns_topic.this.arn
+}
+
+output "topic_id" {
+  description = "The ID of the SNS topic (same as the ARN)."
+  value       = aws_sns_topic.this.id
+}
+
+output "topic_name" {
+  description = "The name of the SNS topic."
+  value       = aws_sns_topic.this.name
+}
+
+output "topic_owner" {
+  description = "The AWS account ID of the SNS topic owner."
+  value       = aws_sns_topic.this.owner
+}
+
+output "subscription_arns" {
+  description = "Map of subscription logical names to their ARNs."
+  value       = { for k, v in aws_sns_topic_subscription.this : k => v.arn }
+}

--- a/modules/aws/sns/variables.tf
+++ b/modules/aws/sns/variables.tf
@@ -1,0 +1,212 @@
+###########################
+# Resource Variables
+###########################
+
+###########################
+# SNS Topic
+###########################
+
+variable "application_failure_feedback_role_arn" {
+  description = "IAM role ARN for delivery status failure feedback for application endpoints."
+  type        = string
+  default     = null
+}
+
+variable "application_success_feedback_role_arn" {
+  description = "IAM role ARN for delivery status success feedback for application endpoints."
+  type        = string
+  default     = null
+}
+
+variable "application_success_feedback_sample_rate" {
+  description = "Percentage of successful deliveries to sample for application endpoint feedback. Valid values are 0-100."
+  type        = number
+  default     = null
+}
+
+variable "content_based_deduplication" {
+  description = "Enables content-based deduplication for FIFO topics."
+  type        = bool
+  default     = false
+}
+
+variable "delivery_policy" {
+  description = "JSON string for the SNS topic delivery policy."
+  type        = string
+  default     = null
+}
+
+variable "display_name" {
+  description = "Display name for the SNS topic. Used as the sender name in email notifications."
+  type        = string
+  default     = null
+}
+
+variable "fifo_topic" {
+  description = "Whether to create a FIFO (first-in, first-out) topic. When true, the topic name will have '.fifo' appended automatically."
+  type        = bool
+  default     = false
+}
+
+variable "firehose_failure_feedback_role_arn" {
+  description = "IAM role ARN for delivery status failure feedback for Firehose endpoints."
+  type        = string
+  default     = null
+}
+
+variable "firehose_success_feedback_role_arn" {
+  description = "IAM role ARN for delivery status success feedback for Firehose endpoints."
+  type        = string
+  default     = null
+}
+
+variable "firehose_success_feedback_sample_rate" {
+  description = "Percentage of successful deliveries to sample for Firehose endpoint feedback. Valid values are 0-100."
+  type        = number
+  default     = null
+}
+
+variable "http_failure_feedback_role_arn" {
+  description = "IAM role ARN for delivery status failure feedback for HTTP/HTTPS endpoints."
+  type        = string
+  default     = null
+}
+
+variable "http_success_feedback_role_arn" {
+  description = "IAM role ARN for delivery status success feedback for HTTP/HTTPS endpoints."
+  type        = string
+  default     = null
+}
+
+variable "http_success_feedback_sample_rate" {
+  description = "Percentage of successful deliveries to sample for HTTP/HTTPS endpoint feedback. Valid values are 0-100."
+  type        = number
+  default     = null
+}
+
+variable "kms_master_key_id" {
+  description = "ID of the AWS KMS key to use for server-side encryption of the SNS topic. Use 'alias/aws/sns' for the AWS-managed key. Defaults to the AWS-managed SNS key for encryption at rest."
+  type        = string
+  default     = "alias/aws/sns"
+}
+
+variable "lambda_failure_feedback_role_arn" {
+  description = "IAM role ARN for delivery status failure feedback for Lambda endpoints."
+  type        = string
+  default     = null
+}
+
+variable "lambda_success_feedback_role_arn" {
+  description = "IAM role ARN for delivery status success feedback for Lambda endpoints."
+  type        = string
+  default     = null
+}
+
+variable "lambda_success_feedback_sample_rate" {
+  description = "Percentage of successful deliveries to sample for Lambda endpoint feedback. Valid values are 0-100."
+  type        = number
+  default     = null
+}
+
+variable "name" {
+  description = "Name of the SNS topic. Mutually exclusive with name_prefix. When fifo_topic is true, '.fifo' is appended automatically."
+  type        = string
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "Name prefix for the SNS topic. Mutually exclusive with name. A unique suffix is appended by AWS."
+  type        = string
+  default     = null
+}
+
+variable "policy" {
+  description = "JSON string for the SNS topic access policy. When null, no topic policy is created and AWS defaults apply."
+  type        = string
+  default     = null
+}
+
+variable "signature_version" {
+  description = "Signature version used for SNS notifications. Valid values are 1 (SHA1) or 2 (SHA256). Defaults to 1."
+  type        = number
+  default     = null
+  validation {
+    condition     = var.signature_version == null || var.signature_version == 1 || var.signature_version == 2
+    error_message = "signature_version must be 1 or 2."
+  }
+}
+
+variable "sqs_failure_feedback_role_arn" {
+  description = "IAM role ARN for delivery status failure feedback for SQS endpoints."
+  type        = string
+  default     = null
+}
+
+variable "sqs_success_feedback_role_arn" {
+  description = "IAM role ARN for delivery status success feedback for SQS endpoints."
+  type        = string
+  default     = null
+}
+
+variable "sqs_success_feedback_sample_rate" {
+  description = "Percentage of successful deliveries to sample for SQS endpoint feedback. Valid values are 0-100."
+  type        = number
+  default     = null
+}
+
+variable "tracing_config" {
+  description = "Tracing mode for the SNS topic. Valid values are PassThrough or Active."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.tracing_config == null || var.tracing_config == "PassThrough" || var.tracing_config == "Active"
+    error_message = "tracing_config must be PassThrough or Active."
+  }
+}
+
+###########################
+# SNS Topic Subscriptions
+###########################
+
+variable "subscriptions" {
+  description = "Map of SNS topic subscriptions to create. The key is a logical name for the subscription."
+  type = map(object({
+    confirmation_timeout_in_minutes = optional(number, 1)
+    delivery_policy                 = optional(string)
+    endpoint                        = string
+    endpoint_auto_confirms          = optional(bool, false)
+    filter_policy                   = optional(string)
+    filter_policy_scope             = optional(string)
+    protocol                        = string
+    raw_message_delivery            = optional(bool, false)
+    redrive_policy                  = optional(string)
+    replay_policy                   = optional(string)
+    subscription_role_arn           = optional(string)
+  }))
+  default = {}
+  # Example:
+  # subscriptions = {
+  #   ops_email = {
+  #     protocol = "email"
+  #     endpoint = "ops@example.com"
+  #   }
+  #   alerts_lambda = {
+  #     protocol = "lambda"
+  #     endpoint = "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+  #   }
+  # }
+}
+
+###########################
+# General Variables
+###########################
+
+variable "tags" {
+  description = "A mapping of tags to assign to all resources."
+  type        = map(string)
+  default = {
+    created_by  = "terraform"
+    terraform   = "true"
+    environment = "prod"
+  }
+}


### PR DESCRIPTION
Implements SNS build and deployment notifications for the AWS Amplify module using EventBridge. Fixes #123

## Issue or Ticket

Fixes #123

## Type of change

- [ ] Bugfix
- [x] New feature
- [ ] Version update

## Breaking Changes

- [x] Yes
- [ ] No

**Breaking change detail**: The \`cloudwatch/event\` module's \`is_enabled\` variable has been removed and replaced with \`state\` (valid values: \`ENABLED\`, \`DISABLED\`, \`ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS\`). Callers using \`is_enabled\` must migrate to \`state\`. The old variable was untyped and not used elsewhere in this repository.

## Summary of changes

### amplify module

- Adds opt-in notification support (disabled by default) via \`enable_notifications = true\`
- Creates an SNS topic scoped to the Amplify app (or accepts an existing \`sns_topic_arn\`) via the new \`modules/aws/sns\` child module
- Creates a CloudWatch EventBridge rule via the \`modules/aws/cloudwatch/event\` child module filtered to the app's ID listening for \`Amplify Deployment Status Change\` events
- Targets the SNS topic with an input transformer that formats a human-readable message: app ID, branch, job ID, and status
- Attaches an SNS topic policy allowing EventBridge to publish (scoped by source ARN for least-privilege); uses \`kms_master_key_id = null\` on the managed notification topic so EventBridge can publish without a customer-managed key
- Optionally creates email subscriptions via \`notification_emails\` (only when \`create_sns_topic = true\`)
- New outputs: \`app_id\`, \`app_arn\`, \`default_domain\`, \`sns_topic_arn\`, \`notification_event_rule_arn\`

### cloudwatch/event module

- Made \`event_pattern\` and \`schedule_expression\` optional (null default) with a lifecycle \`precondition\` enforcing that exactly one is provided
- Added \`name\` variable (mutually exclusive with \`name_prefix\`) and wired \`event_bus_name\` through to the target resource
- Changed \`input_transformer\` from \`list(object)\` to a single \`object\` (EventBridge only supports one per target)
- Added \`type\` declarations and improved descriptions to all variables
- Replaced \`is_enabled\` with \`state\` validation (ENABLED / DISABLED / ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS) — **breaking change**
- Added \`rule_name\` and \`target_arn\` outputs

### sns module (new)

- New reusable module for \`aws_sns_topic\`, optional \`aws_sns_topic_policy\` (via \`policy\` variable), and \`aws_sns_topic_subscription\` (via \`subscriptions\` map)
- Encryption at rest enabled by default (\`alias/aws/sns\`); FIFO topic support with automatic \`.fifo\` suffix for both \`name\` and \`name_prefix\`

## TODOs

- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [x] Validate all tests run successfully, including pre-commit checks.
- [x] Include release notes and description.