### PR TITLE
old attribute deprecated

### DIFF
--- a/modules/aws/cloudtrail/main.tf
+++ b/modules/aws/cloudtrail/main.tf
@@ -62,7 +62,7 @@ resource "aws_kms_key" "cloudtrail" {
             ]
           },
           "StringEquals" = {
-            "aws:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.name}"
+            "aws:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.name}"
           }
         }
       },
@@ -81,7 +81,7 @@ resource "aws_kms_key" "cloudtrail" {
         "Sid"    = "Allow CloudWatch Logs to encrypt logs",
         "Effect" = "Allow",
         "Principal" = {
-          "Service" = "logs.${data.aws_region.current.name}.amazonaws.com"
+          "Service" = "logs.${data.aws_region.current.region}.amazonaws.com"
         },
         "Action" = [
           "kms:Encrypt*",
@@ -93,7 +93,7 @@ resource "aws_kms_key" "cloudtrail" {
         "Resource" = "*",
         "Condition" = {
           "ArnEquals" = {
-            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"
+            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:*"
           }
         }
       },
@@ -295,7 +295,7 @@ resource "aws_s3_bucket_policy" "cloudtrail_bucket_policy" {
         "Resource" = "${aws_s3_bucket.cloudtrail_s3_bucket.arn}",
         "Condition" = {
           "StringEquals" = {
-            "AWS:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.name}"
+            "AWS:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.name}"
           }
         }
       },
@@ -311,7 +311,7 @@ resource "aws_s3_bucket_policy" "cloudtrail_bucket_policy" {
         "Resource" = "${aws_s3_bucket.cloudtrail_s3_bucket.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
         "Condition" = {
           "StringEquals" = {
-            "AWS:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.name}",
+            "AWS:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.name}",
             "s3:x-amz-acl"  = "bucket-owner-full-control"
           }
         }
@@ -328,7 +328,7 @@ resource "aws_s3_bucket_policy" "cloudtrail_bucket_policy" {
         "Resource" = "${aws_s3_bucket.cloudtrail_s3_bucket.arn}/AWSLogs/${data.aws_organizations_organization.current.id}/*",
         "Condition" = {
           "StringEquals" = {
-            "AWS:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.name}",
+            "AWS:SourceArn" = "arn:aws:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.name}",
             "s3:x-amz-acl"  = "bucket-owner-full-control"
           }
         }

--- a/modules/aws/ec2_domain_controller/main.tf
+++ b/modules/aws/ec2_domain_controller/main.tf
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "instance" {
 
 resource "aws_cloudwatch_metric_alarm" "system" {
   actions_enabled     = true
-  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.name}:ec2:recover"]
+  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.region}:ec2:recover"]
   alarm_description   = "EC2 instance StatusCheckFailed_System alarm"
   alarm_name          = format("%s-system-alarm", element(aws_instance.ec2_instance[*].id, count.index))
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/modules/aws/ec2_instance/main.tf
+++ b/modules/aws/ec2_instance/main.tf
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "instance" {
 
 resource "aws_cloudwatch_metric_alarm" "system" {
   actions_enabled     = true
-  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.name}:ec2:recover"]
+  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.region}:ec2:recover"]
   alarm_description   = "EC2 instance StatusCheckFailed_System alarm"
   alarm_name          = format("%s-system-alarm", aws_instance.ec2[count.index].id)
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -55,7 +55,7 @@ resource "aws_kms_key" "key" {
       {
         "Effect" = "Allow",
         "Principal" = {
-          "Service" = "logs.${data.aws_region.current.name}.amazonaws.com"
+          "Service" = "logs.${data.aws_region.current.region}.amazonaws.com"
         },
         "Action" = [
           "kms:Encrypt*",
@@ -67,7 +67,7 @@ resource "aws_kms_key" "key" {
         "Resource" = "*",
         "Condition" = {
           "ArnEquals" = {
-            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"
+            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:*"
           }
         }
       }

--- a/modules/aws/fsx/main.tf
+++ b/modules/aws/fsx/main.tf
@@ -42,7 +42,7 @@ resource "aws_kms_key" "fsx" {
       {
         "Effect" = "Allow",
         "Principal" = {
-          "Service" = "fsx.${data.aws_region.current.name}.amazonaws.com"
+          "Service" = "fsx.${data.aws_region.current.region}.amazonaws.com"
         },
         "Action" = [
           "kms:Encrypt*",
@@ -111,7 +111,7 @@ resource "aws_kms_key" "cloudwatch" {
       {
         "Effect" = "Allow",
         "Principal" = {
-          "Service" = "logs.${data.aws_region.current.name}.amazonaws.com"
+          "Service" = "logs.${data.aws_region.current.region}.amazonaws.com"
         },
         "Action" = [
           "kms:Encrypt*",
@@ -123,7 +123,7 @@ resource "aws_kms_key" "cloudwatch" {
         "Resource" = "*",
         "Condition" = {
           "ArnEquals" = {
-            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"
+            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:*"
           }
         }
       }

--- a/modules/aws/sqs_queue/main.tf
+++ b/modules/aws/sqs_queue/main.tf
@@ -53,7 +53,7 @@ resource "aws_kms_key" "sqs" {
             ]
           },
           "StringEquals" = {
-            "aws:SourceArn" = "arn:aws:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:queue/${var.name}"
+            "aws:SourceArn" = "arn:aws:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:queue/${var.name}"
           }
         }
       },

--- a/modules/aws/transfer_family/main.tf
+++ b/modules/aws/transfer_family/main.tf
@@ -181,7 +181,7 @@ module "transfer_family_iam_role" {
             "aws:SourceAccount" : "${data.aws_caller_identity.current.account_id}"
           },
           ArnLike = {
-            "aws:SourceArn" : "arn:aws:transfer:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:user/*"
+            "aws:SourceArn" : "arn:aws:transfer:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:user/*"
           }
         },
         Effect = "Allow",

--- a/modules/aws/vendor/cato_sdwan/main.tf
+++ b/modules/aws/vendor/cato_sdwan/main.tf
@@ -199,7 +199,7 @@ resource "aws_cloudwatch_metric_alarm" "instance" {
 
 resource "aws_cloudwatch_metric_alarm" "system" {
   actions_enabled     = true
-  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.name}:ec2:recover"]
+  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.region}:ec2:recover"]
   alarm_description   = "EC2 instance StatusCheckFailed_System alarm"
   alarm_name          = format("%s-system-alarm", element(aws_instance.ec2_instance[*].id, count.index))
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/modules/aws/vendor/velocloud/main.tf
+++ b/modules/aws/vendor/velocloud/main.tf
@@ -261,7 +261,7 @@ resource "aws_cloudwatch_metric_alarm" "instance" {
 
 resource "aws_cloudwatch_metric_alarm" "system" {
   actions_enabled     = true
-  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.name}:ec2:recover"]
+  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.region}:ec2:recover"]
   alarm_description   = "EC2 instance StatusCheckFailed_System alarm"
   alarm_name          = format("%s-system-alarm", element(aws_instance.ec2_instance[*].id, count.index))
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -21,7 +21,7 @@ data "aws_region" "current" {}
 locals {
   # Disable the IGW if either enable_internet_gateway is false or public_subnets_list is empty
   enable_igw   = var.enable_internet_gateway ? ((length(var.public_subnets_list) != 0 || var.public_subnets_list != null) ? true : false) : false
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 ###########################
@@ -81,7 +81,7 @@ resource "aws_security_group" "ssm_vpc_endpoint" {
 resource "aws_vpc_endpoint" "ec2messages" {
   count               = var.enable_ssm_vpc_endpoints ? 1 : 0
   vpc_id              = aws_vpc.vpc.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2messages"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2messages"
   security_group_ids  = [aws_security_group.ssm_vpc_endpoint.id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
@@ -92,7 +92,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
 resource "aws_vpc_endpoint" "kms" {
   count               = var.enable_ssm_vpc_endpoints ? 1 : 0
   vpc_id              = aws_vpc.vpc.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.kms"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.kms"
   security_group_ids  = [aws_security_group.ssm_vpc_endpoint.id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
@@ -103,7 +103,7 @@ resource "aws_vpc_endpoint" "kms" {
 resource "aws_vpc_endpoint" "ssm" {
   count               = var.enable_ssm_vpc_endpoints ? 1 : 0
   vpc_id              = aws_vpc.vpc.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssm"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssm"
   security_group_ids  = [aws_security_group.ssm_vpc_endpoint.id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
@@ -114,7 +114,7 @@ resource "aws_vpc_endpoint" "ssm" {
 resource "aws_vpc_endpoint" "ssm-contacts" {
   count               = var.enable_ssm_vpc_endpoints ? 1 : 0
   vpc_id              = aws_vpc.vpc.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssm-contacts"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssm-contacts"
   security_group_ids  = [aws_security_group.ssm_vpc_endpoint.id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
@@ -125,7 +125,7 @@ resource "aws_vpc_endpoint" "ssm-contacts" {
 resource "aws_vpc_endpoint" "ssm-incidents" {
   count               = var.enable_ssm_vpc_endpoints ? 1 : 0
   vpc_id              = aws_vpc.vpc.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssm-incidents"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssm-incidents"
   security_group_ids  = [aws_security_group.ssm_vpc_endpoint.id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
@@ -136,7 +136,7 @@ resource "aws_vpc_endpoint" "ssm-incidents" {
 resource "aws_vpc_endpoint" "ssmmessages" {
   count               = var.enable_ssm_vpc_endpoints ? 1 : 0
   vpc_id              = aws_vpc.vpc.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   security_group_ids  = [aws_security_group.ssm_vpc_endpoint.id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true

--- a/modules/services/siem/main.tf
+++ b/modules/services/siem/main.tf
@@ -284,7 +284,7 @@ resource "aws_cloudwatch_metric_alarm" "instance" {
 
 resource "aws_cloudwatch_metric_alarm" "system" {
   actions_enabled     = true
-  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.name}:ec2:recover"]
+  alarm_actions       = ["arn:aws:automate:${data.aws_region.current.region}:ec2:recover"]
   alarm_description   = "EC2 instance StatusCheckFailed_System alarm"
   alarm_name          = format("%s-system-alarm", aws_instance.ec2[count.index].id)
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -472,7 +472,7 @@ resource "aws_kms_key" "key" {
       {
         "Effect" = "Allow",
         "Principal" = {
-          "Service" = "logs.${data.aws_region.current.name}.amazonaws.com"
+          "Service" = "logs.${data.aws_region.current.region}.amazonaws.com"
         },
         "Action" = [
           "kms:Encrypt*",
@@ -484,7 +484,7 @@ resource "aws_kms_key" "key" {
         "Resource" = "*",
         "Condition" = {
           "ArnEquals" = {
-            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"
+            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:*"
           }
         }
       }
@@ -612,7 +612,7 @@ resource "aws_kms_key" "cloudtrail_key" {
           "Service" = "cloudtrail.amazonaws.com"
         },
         "Action"   = "kms:GenerateDataKey*",
-        "Resource" = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*",
+        "Resource" = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*",
         "Condition" = {
           "StringLike" = {
             "kms:EncryptionContext:aws:cloudtrail:arn" : "arn:aws:cloudtrail:*:${data.aws_caller_identity.current.account_id}:trail/*"
@@ -626,7 +626,7 @@ resource "aws_kms_key" "cloudtrail_key" {
           "Service" : "cloudtrail.amazonaws.com"
         },
         "Action"   = "kms:DescribeKey",
-        "Resource" = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+        "Resource" = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"
       },
       {
         "Sid"    = "Allow principals in the account to decrypt log files",
@@ -638,7 +638,7 @@ resource "aws_kms_key" "cloudtrail_key" {
           "kms:Decrypt",
           "kms:ReEncryptFrom"
         ],
-        "Resource" = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*",
+        "Resource" = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*",
         "Condition" = {
           "StringEquals" = {
             "kms:CallerAccount" : "${data.aws_caller_identity.current.account_id}"
@@ -659,7 +659,7 @@ resource "aws_kms_key" "cloudtrail_key" {
         "Condition" = {
           "StringEquals" = {
             "kms:CallerAccount" : "${data.aws_caller_identity.current.account_id}",
-            "kms:ViaService" : "ec2.${data.aws_region.current.name}.amazonaws.com"
+            "kms:ViaService" : "ec2.${data.aws_region.current.region}.amazonaws.com"
           }
         }
       },
@@ -673,7 +673,7 @@ resource "aws_kms_key" "cloudtrail_key" {
           "kms:Decrypt",
           "kms:ReEncryptFrom"
         ],
-        "Resource" = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*",
+        "Resource" = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*",
         "Condition" = {
           "StringEquals" = {
             "kms:CallerAccount" : "${data.aws_caller_identity.current.account_id}"
@@ -715,7 +715,7 @@ resource "aws_sqs_queue" "cloudtrail_queue" {
         "Service": "s3.amazonaws.com"
       },
       "Action": "SQS:SendMessage",
-      "Resource": "arn:aws:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:siem_cloudtrail_queue",
+      "Resource": "arn:aws:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:siem_cloudtrail_queue",
       "Condition": {
         "StringEquals": {
           "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"


### PR DESCRIPTION
# Description
<!-- Description of the changes introduced by this Pull Request (PR). Link to an issue or ticket where possible for more context.-->
The attribute name for data.aws_region.current has been replaced with region. 
Old: data.aws_region.current.name
New: data.aws_region.current.region
[Supporting docs.](https://registry.terraform.io/providers/-/aws/latest/docs/guides/version-6-upgrade#data-source-aws_region)

## Issue or Ticket
<!-- Link to the issue or ticket this PR addresses.-->
Fixes #134 

## Type of change
<!-- What type of change does your code introduce? -->
- [x] Bugfix
- [ ] New feature
- [ ] Version update

## Breaking Changes
<!-- Does this PR introduce any breaking changes? -->
- [x] Yes
- [ ] No

### Breaking Changes Description
<!-- If yes, describe the breaking changes introduced by this PR. -->
If using the modules and running a version of the AWS provider prior to version 6.0 you will receive errors and likely be unable to run your apply. 

## TODOs
<!-- Complete these tasks prior to requesting a review.-->
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [ ] Validate all tests run successfull, including pre-commit checks.
- [ ] Include release notes and description. This should include both a summary of the changes and any necessary context.
