### PR TITLE
feat: added ecr vpc endpoints

### DIFF
--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -262,7 +262,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 | [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.workspaces](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
-| [aws_security_group.ssm_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_subnet.db_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.dmz_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.mgmt_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
@@ -270,7 +270,10 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 | [aws_subnet.public_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.workspaces_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_vpc_endpoint.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.ec2messages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ecr_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ecr_dkr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
@@ -295,12 +298,13 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 | <a name="input_dmz_subnets_list"></a> [dmz\_subnets\_list](#input\_dmz\_subnets\_list) | A list of DMZ subnets inside the VPC. | `list(string)` | <pre>[<br/>  "10.11.101.0/24",<br/>  "10.11.102.0/24",<br/>  "10.11.103.0/24"<br/>]</pre> | no |
 | <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | (Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false. | `bool` | `true` | no |
 | <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | (Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true. | `bool` | `true` | no |
+| <a name="input_enable_ecr_vpc_endpoints"></a> [enable\_ecr\_vpc\_endpoints](#input\_enable\_ecr\_vpc\_endpoints) | (Optional) A boolean flag to enable/disable ECR (Elastic Container Registry) VPC endpoints. This enables ECR API, ECR DKR, Cloudwatch Logs, and S3 endpoints. | `bool` | `false` | no |
 | <a name="input_enable_firewall"></a> [enable\_firewall](#input\_enable\_firewall) | (Optional) A boolean flag to enable/disable the use of a firewall instance within the VPC. Defaults False. | `bool` | `false` | no |
 | <a name="input_enable_flow_logs"></a> [enable\_flow\_logs](#input\_enable\_flow\_logs) | (Optional) A boolean flag to enable/disable the use of flow logs with the resources. Defaults True. | `bool` | `true` | no |
 | <a name="input_enable_internet_gateway"></a> [enable\_internet\_gateway](#input\_enable\_internet\_gateway) | (Optional) A boolean flag to enable/disable the use of Internet gateways. Defaults True. | `bool` | `true` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | (Optional) A boolean flag to enable/disable the use of NAT gateways in the private subnets. Defaults True. | `bool` | `true` | no |
-| <a name="input_enable_s3_endpoint"></a> [enable\_s3\_endpoint](#input\_enable\_s3\_endpoint) | (Optional) A boolean flag to enable/disable the use of a S3 endpoint with the VPC. Defaults False | `bool` | `false` | no |
-| <a name="input_enable_ssm_vpc_endpoints"></a> [enable\_ssm\_vpc\_endpoints](#input\_enable\_ssm\_vpc\_endpoints) | (Optional) A boolean flag to enable/disable SSM (Systems Manager) VPC endpoints. Defaults true. | `bool` | `false` | no |
+| <a name="input_enable_s3_endpoint"></a> [enable\_s3\_endpoint](#input\_enable\_s3\_endpoint) | (Optional) A boolean flag to enable/disable the use of a S3 endpoint with the VPC. | `bool` | `false` | no |
+| <a name="input_enable_ssm_vpc_endpoints"></a> [enable\_ssm\_vpc\_endpoints](#input\_enable\_ssm\_vpc\_endpoints) | (Optional) A boolean flag to enable/disable SSM (Systems Manager) VPC endpoints. | `bool` | `false` | no |
 | <a name="input_flow_deliver_cross_account_role"></a> [flow\_deliver\_cross\_account\_role](#input\_flow\_deliver\_cross\_account\_role) | (Optional) The ARN of the IAM role that posts logs to CloudWatch Logs in a different account. | `string` | `null` | no |
 | <a name="input_flow_log_destination_type"></a> [flow\_log\_destination\_type](#input\_flow\_log\_destination\_type) | (Optional) The type of the logging destination. Valid values: cloud-watch-logs, s3. Default: cloud-watch-logs. | `string` | `"cloud-watch-logs"` | no |
 | <a name="input_flow_log_format"></a> [flow\_log\_format](#input\_flow\_log\_format) | (Optional) The fields to include in the flow log record, in the order in which they should appear. For more information, see Flow Log Records. Default: fields are in the order that they are described in the Flow Log Records section. | `string` | `null` | no |

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -191,13 +191,13 @@ resource "aws_vpc_endpoint" "s3" {
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
   count           = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? length(var.private_subnets_list) : 0
-  vpc_endpoint_id = aws_vpc_endpoint.s3[count.index]
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0]
   route_table_id  = element(aws_route_table.private_route_table[*].id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
   count           = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? length(var.public_subnets_list) : 0
-  vpc_endpoint_id = aws_vpc_endpoint.s3[count.index]
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0]
   route_table_id  = aws_route_table.public_route_table[0].id
 }
 

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -190,14 +190,14 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  for_each        = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? toset(aws_subnet.private_subnets[*].id) : {}
+  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_subnet.private_subnets[*].id) : []
   route_table_id  = each.value
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
   # route_table_id  = element(aws_route_table.private_route_table[*].id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  for_each        = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? toset(aws_subnet.public_subnets[*].id) : {}
+  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_subnet.public_subnets[*].id) : []
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
   route_table_id  = each.value
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -190,15 +190,16 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  count           = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? length(var.private_subnets_list) : 0
-  vpc_endpoint_id = aws_vpc_endpoint.s3[0]
-  route_table_id  = element(aws_route_table.private_route_table[*].id, count.index)
+  for_each        = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? toset(aws_subnet.private_subnets[*].id) : {}
+  route_table_id  = each.value
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  # route_table_id  = element(aws_route_table.private_route_table[*].id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  count           = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? length(var.public_subnets_list) : 0
-  vpc_endpoint_id = aws_vpc_endpoint.s3[0]
-  route_table_id  = aws_route_table.public_route_table[0].id
+  for_each        = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? toset(aws_subnet.public_subnets[*].id) : {}
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = each.value
 }
 
 ###########################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -36,6 +36,7 @@ resource "aws_vpc" "vpc" {
   tags                 = merge(tomap({ Name = var.name }), var.tags)
 }
 
+
 ###########################
 # VPC Endpoints
 ###########################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -190,14 +190,14 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_route_table.private_route_table[*].id) : []
-  route_table_id  = each.value
+  count           = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? length(aws_route_table.private_route_table[*].id) : 0
+  route_table_id  = element(aws_route_table.private_route_table[*].id, count.index)
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_route_table.public_route_table[*].id) : []
-  route_table_id  = each.value
+  count           = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? length(aws_route_table.public_route_table[*].id) : 0
+  route_table_id  = element(aws_route_table.public_route_table[*].id, count.index)
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }
 

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -190,13 +190,13 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  count           = var.enable_s3_endpoint ? length(var.private_subnets_list) : 0
+  count           = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? length(var.private_subnets_list) : 0
   vpc_endpoint_id = aws_vpc_endpoint.s3[count.index]
   route_table_id  = element(aws_route_table.private_route_table[*].id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  count           = var.enable_s3_endpoint ? length(var.public_subnets_list) : 0
+  count           = var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints ? length(var.public_subnets_list) : 0
   vpc_endpoint_id = aws_vpc_endpoint.s3[count.index]
   route_table_id  = aws_route_table.public_route_table[0].id
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -167,7 +167,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   tags                = merge(tomap({ Name = var.name }), var.tags)
 }
 
-resource "aws_vpc_endpoint" "s3" {
+resource "aws_vpc_endpoint" "ecr_s3" {
   count               = var.enable_ecr_vpc_endpoints ? 1 : 0
   private_dns_enabled = true
   service_name        = "com.amazonaws.${data.aws_region.current.region}.s3"

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -190,16 +190,15 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_subnet.private_subnets[*].id) : []
+  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_route_table.private_route_table[*].id) : []
   route_table_id  = each.value
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
-  # route_table_id  = element(aws_route_table.private_route_table[*].id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_subnet.public_subnets[*].id) : []
-  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  for_each        = (var.enable_s3_endpoint || var.enable_ecr_vpc_endpoints) ? toset(aws_route_table.public_route_table[*].id) : []
   route_table_id  = each.value
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }
 
 ###########################

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -34,13 +34,19 @@ variable "instance_tenancy" {
 ###########################
 
 variable "enable_s3_endpoint" {
-  description = "(Optional) A boolean flag to enable/disable the use of a S3 endpoint with the VPC. Defaults False"
+  description = "(Optional) A boolean flag to enable/disable the use of a S3 endpoint with the VPC."
   type        = bool
   default     = false
 }
 
 variable "enable_ssm_vpc_endpoints" {
-  description = "(Optional) A boolean flag to enable/disable SSM (Systems Manager) VPC endpoints. Defaults true."
+  description = "(Optional) A boolean flag to enable/disable SSM (Systems Manager) VPC endpoints."
+  type        = bool
+  default     = false
+}
+
+variable "enable_ecr_vpc_endpoints" {
+  description = "(Optional) A boolean flag to enable/disable ECR (Elastic Container Registry) VPC endpoints. This enables ECR API, ECR DKR, Cloudwatch Logs, and S3 endpoints."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
# Description
<!-- Description of the changes introduced by this Pull Request (PR). Link to an issue or ticket where possible for more context.-->
This PR adds ECR (Elastic Container Registry) VPC endpoints to enable ECS with Fargate on private subnets using private repositories. The implementation refactors the existing SSM VPC endpoint security group to be reusable across all interface-type VPC endpoints.

- Introduces a new enable_ecr_vpc_endpoints variable to control ECR-related VPC endpoints
- Refactors the SSM-specific security group to a generic VPC endpoint security group
- Adds ECR API, ECR DKR, CloudWatch Logs endpoints and enhances S3 endpoint configuration

## Issue or Ticket
<!-- Link to the issue or ticket this PR addresses.-->
Fixes #145

## Type of change
<!-- What type of change does your code introduce? -->
- [ ] Bugfix
- [x] New feature
- [ ] Version update

## Breaking Changes
<!-- Does this PR introduce any breaking changes? -->
- [x] Yes
- [ ] No

### Breaking Changes Description
<!-- If yes, describe the breaking changes introduced by this PR. -->
This will recreate the security group associated with VPC endpoints. Previously this was the `aws_security_group.ssm_vpc_endpoint` resource, it has been renamed to `aws_security_group.vpc_endpoint` as the same security group is applicable to all VPC endpoints with the interface type.

## TODOs
<!-- Complete these tasks prior to requesting a review.-->
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [x] Validate all tests run successfull, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.
