### PR TITLE
Add validation rule for IGW and public subnets dependency

### DIFF
--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -280,7 +280,8 @@ resource "aws_route_table" "public_route_table" {
   vpc_id           = aws_vpc.vpc.id
 }
 
-# !FIX: We should probably update this to just disable the igw if there are no public subnets present and default to disable since we are unlikely to use it in our infra.  
+# Validation is enforced via aws_internet_gateway precondition to fail fast when
+# enable_internet_gateway=true and public_subnets_list is empty.
 resource "aws_route" "public_default_route" {
   count                  = local.enable_igw ? 1 : 0
   destination_cidr_block = "0.0.0.0/0"

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -264,6 +264,13 @@ resource "aws_internet_gateway" "igw" {
   count  = local.enable_igw ? 1 : 0
   tags   = merge(var.tags, ({ "Name" = format("%s-igw", var.name) }))
   vpc_id = aws_vpc.vpc.id
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_internet_gateway || length(var.public_subnets_list) > 0
+      error_message = "enable_internet_gateway cannot be true when public_subnets_list is empty. Either set enable_internet_gateway=false or provide public subnets."
+    }
+  }
 }
 
 resource "aws_route_table" "public_route_table" {

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -268,6 +268,11 @@ variable "enable_internet_gateway" {
   description = "(Optional) A boolean flag to enable/disable the use of Internet gateways. Defaults True."
   type        = bool
   default     = true
+
+  validation {
+    condition     = !var.enable_internet_gateway || length(var.public_subnets_list) > 0
+    error_message = "enable_internet_gateway cannot be true when public_subnets_list is empty. Either set enable_internet_gateway=false or provide public subnets."
+  }
 }
 
 variable "enable_flow_logs" {

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -268,11 +268,6 @@ variable "enable_internet_gateway" {
   description = "(Optional) A boolean flag to enable/disable the use of Internet gateways. Defaults True."
   type        = bool
   default     = true
-
-  validation {
-    condition     = !var.enable_internet_gateway || length(var.public_subnets_list) > 0
-    error_message = "enable_internet_gateway cannot be true when public_subnets_list is empty. Either set enable_internet_gateway=false or provide public subnets."
-  }
 }
 
 variable "enable_flow_logs" {


### PR DESCRIPTION
## Problem
When `enable_internet_gateway` is `true` (default) and `public_subnets_list` is empty, the module could fail with an ambiguous invalid index path during planning/apply.

## First Implementation (Flawed)
Initial implementation added a `validation` block to variable `enable_internet_gateway`:
- `condition = !var.enable_internet_gateway || length(var.public_subnets_list) > 0`

Why this was flawed:
- In Terraform 1.5.x, variable validation for a given variable can only reference that variable.
- The validation referenced `var.public_subnets_list`, which caused an error during init/plan in environments on Terraform 1.5.x.

## Final Implementation (Current)
Validation has been moved to a resource precondition on `aws_internet_gateway` in `modules/aws/vpc/main.tf`:
- `lifecycle.precondition` checks that `enable_internet_gateway=true` requires non-empty `public_subnets_list`.
- This produces a clear, actionable error message instead of a downstream invalid-index style failure.
- Compatible with Terraform/OpenTofu versions used in current environments.

## Test Results (aws_dev_sandbox)
- **Negative test**: `enable_internet_gateway=true` + `public_subnets_list=[]` -> precondition failure with expected message.
- **Positive test**: same module source (`ref=dev_val_rule`) with populated public subnets -> plan succeeds.

## Impact
- Fails fast on invalid IGW/public-subnet combinations.
- Avoids silent misconfiguration and ambiguous downstream errors.
- Keeps user intent explicit and easier to debug.

Co-Authored-By: Oz <oz-agent@warp.dev>
