### PR TITLE
bugfix: Removed biome validation from superlinter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: read
   checks: write
+  statuses: write
+
 jobs:
   test_terraform:
     name: Test Terraform


### PR DESCRIPTION
# Description
<!-- Description of the changes introduced by this Pull Request (PR). Link to an issue or ticket where possible for more context.-->
This PR disables Biome validation in the super-linter workflow. Biome is a JavaScript/TypeScript linter and formatter that was recently added to super-linter v8, but is not relevant for this Terraform-focused repository.

- Disables VALIDATE_BIOME_FORMAT and VALIDATE_BIOME_LINT in the super-linter configuration

## Issue or Ticket
<!-- Link to the issue or ticket this PR addresses.-->
N/A

## Type of change
<!-- What type of change does your code introduce? -->
- [x] Bugfix
- [ ] New feature
- [ ] Version update

## Breaking Changes
<!-- Does this PR introduce any breaking changes? -->
- [ ] Yes
- [x] No

### Breaking Changes Description
<!-- If yes, describe the breaking changes introduced by this PR. -->


## TODOs
<!-- Complete these tasks prior to requesting a review.-->
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [ ] Validate all tests run successfull, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.
