### PR TITLE
feat: Add deletion protection support for CloudWatch log groups in flow_logs module

### DIFF
--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -162,13 +162,13 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.25.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.25.0 |
 
 ## Modules
 
@@ -192,6 +192,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_deletion_protection_enabled"></a> [cloudwatch\_deletion\_protection\_enabled](#input\_cloudwatch\_deletion\_protection\_enabled) | (Optional) If true, prevents the log group from being deleted. Defaults to false. Requires AWS provider >= 6.25.0. | `bool` | `false` | no |
 | <a name="input_cloudwatch_name_prefix"></a> [cloudwatch\_name\_prefix](#input\_cloudwatch\_name\_prefix) | (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. | `string` | `"flow_logs_"` | no |
 | <a name="input_cloudwatch_retention_in_days"></a> [cloudwatch\_retention\_in\_days](#input\_cloudwatch\_retention\_in\_days) | (Optional) Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `90` | no |
 | <a name="input_flow_deliver_cross_account_role"></a> [flow\_deliver\_cross\_account\_role](#input\_flow\_deliver\_cross\_account\_role) | (Optional) The ARN of the IAM role that posts logs to CloudWatch Logs in a different account. | `string` | `null` | no |

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.25.0"
     }
   }
 }
@@ -85,10 +85,11 @@ resource "aws_kms_alias" "alias" {
 ###########################
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  kms_key_id        = aws_kms_key.key.arn
-  name_prefix       = var.cloudwatch_name_prefix
-  retention_in_days = var.cloudwatch_retention_in_days
-  tags              = var.tags
+  deletion_protection_enabled = var.cloudwatch_deletion_protection_enabled
+  kms_key_id                  = aws_kms_key.key.arn
+  name_prefix                 = var.cloudwatch_name_prefix
+  retention_in_days           = var.cloudwatch_retention_in_days
+  tags                        = var.tags
 }
 
 ###########################
@@ -140,8 +141,8 @@ resource "aws_iam_role_policy_attachment" "role_attach" {
 # Flow Log
 ###########################
 resource "aws_flow_log" "this" {
-  count                         = length(local.flow_logs_source)
-  deliver_cross_account_role    = var.flow_deliver_cross_account_role
+  count                      = length(local.flow_logs_source)
+  deliver_cross_account_role = var.flow_deliver_cross_account_role
   eni_id                        = var.flow_eni_ids != null ? local.flow_logs_source[count.index] : null
   iam_role_arn                  = aws_iam_role.role.arn
   log_destination_type          = var.flow_log_destination_type

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -141,8 +141,8 @@ resource "aws_iam_role_policy_attachment" "role_attach" {
 # Flow Log
 ###########################
 resource "aws_flow_log" "this" {
-  count                      = length(local.flow_logs_source)
-  deliver_cross_account_role = var.flow_deliver_cross_account_role
+  count                         = length(local.flow_logs_source)
+  deliver_cross_account_role    = var.flow_deliver_cross_account_role
   eni_id                        = var.flow_eni_ids != null ? local.flow_logs_source[count.index] : null
   iam_role_arn                  = aws_iam_role.role.arn
   log_destination_type          = var.flow_log_destination_type

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -54,6 +54,12 @@ variable "cloudwatch_name_prefix" {
   type        = string
 }
 
+variable "cloudwatch_deletion_protection_enabled" {
+  description = "(Optional) If true, prevents the log group from being deleted. Defaults to false. Requires AWS provider >= 6.25.0."
+  default     = false
+  type        = bool
+}
+
 variable "cloudwatch_retention_in_days" {
   description = "(Optional) Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."
   default     = 90


### PR DESCRIPTION
## Description

Add support for deletion protection on CloudWatch log groups in the flow_logs module.

## Changes

- Add `deletion_protection_enabled` argument to `aws_cloudwatch_log_group` resource
- Add `cloudwatch_deletion_protection_enabled` variable with default value of `false`
- Update minimum AWS provider version requirement from `>= 6.0.0` to `>= 6.25.0` (when the feature was added on December 4, 2025)

## Context

When deletion protection is enabled on a CloudWatch log group, the log group cannot be deleted until the protection is explicitly disabled. This provides an additional safeguard for critical logging data.

## Notes

- The `deletion_protection_enabled` attribute was added to the AWS Terraform provider in v6.25.0 (released December 4, 2025)
- Documentation is available in the Terraform registry but not yet reflected in the OpenTofu documentation (recently added feature)
- This change aligns with AWS best practices for protecting critical operational and compliance logs

## Related

Addresses OpenTofu drift detection for CloudWatch log groups where deletion protection was set outside of Terraform