### PR TITLE
fix: correct directory_service_simple_ad module to use vpc_settings

### DIFF
--- a/modules/aws/directory_service_simple_ad/README.md
+++ b/modules/aws/directory_service_simple_ad/README.md
@@ -109,29 +109,31 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_directory_service_directory.connector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory) | resource |
+| [aws_directory_service_directory.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alias"></a> [alias](#input\_alias) | (Optional) The alias for the directory (must be unique amongst all aliases in AWS). Required for enable\_sso. | `string` | `"default_value"` | no |
-| <a name="input_customer_dns_ips"></a> [customer\_dns\_ips](#input\_customer\_dns\_ips) | (Required) The DNS IP addresses of the domain to connect to. | `list(string)` | `[]` | no |
-| <a name="input_customer_username"></a> [customer\_username](#input\_customer\_username) | (Required) The username corresponding to the password provided. | `string` | n/a | yes |
-| <a name="input_description"></a> [description](#input\_description) | (Optional) A textual description for the directory. | `string` | `"default_value"` | no |
+| <a name="input_alias"></a> [alias](#input\_alias) | (Optional) The alias for the directory (must be unique amongst all aliases in AWS). Required for enable\_sso. | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | (Optional) A textual description for the directory. | `string` | `null` | no |
+| <a name="input_enable_sso"></a> [enable\_sso](#input\_enable\_sso) | (Optional) Whether to enable single-sign on for the directory. Requires alias. Defaults to false. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The fully qualified name for the directory, such as corp.example.com | `string` | n/a | yes |
 | <a name="input_password"></a> [password](#input\_password) | (Required) The password for the directory administrator or connector user. | `string` | n/a | yes |
-| <a name="input_size"></a> [size](#input\_size) | (Required for SimpleAD and ADConnector) The size of the directory (Small or Large are accepted values). | `string` | `"Small"` | no |
+| <a name="input_short_name"></a> [short\_name](#input\_short\_name) | (Optional) The short name of the directory, such as CORP. | `string` | `null` | no |
+| <a name="input_size"></a> [size](#input\_size) | (Required) The size of the directory. Valid values: Small, Large. | `string` | `"Small"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | (Required) The identifiers of the subnets for the directory servers (2 subnets in 2 different AZs). | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource. | `map(any)` | `{}` | no |
-| <a name="input_type"></a> [type](#input\_type) | (Optional) - The directory type (SimpleAD, ADConnector or MicrosoftAD are accepted values). Defaults to SimpleAD. | `string` | `"SimpleAD"` | no |
+| <a name="input_type"></a> [type](#input\_type) | (Optional) The directory type. For this module, SimpleAD is the supported type. | `string` | `"SimpleAD"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The identifier of the VPC that the directory is in. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_dns_ip_addresses"></a> [dns\_ip\_addresses](#output\_dns\_ip\_addresses) | A list of IP addresses of the DNS servers for the directory. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the directory. |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group created by the directory. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/directory_service_simple_ad/README.md
+++ b/modules/aws/directory_service_simple_ad/README.md
@@ -26,9 +26,9 @@
     <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
   </a>
 
-<h3 align="center">Directory Services ADConnector Module</h3>
+<h3 align="center">Directory Services Simple AD Module</h3>
   <p align="center">
-    This module sets up the ADConnector within AWS Directory Services. This can later be used to domain join instances.
+    This module sets up a Simple AD directory within AWS Directory Services. Simple AD is a Microsoft Active Directory–compatible directory powered by Samba 4. It can be used to domain join EC2 instances and AWS WorkSpaces.
     <br />
     <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
     <br />
@@ -62,25 +62,22 @@
 
 ## Usage
 
-```
-module "ad_connector" {
-    source              = "github.com/zachreborn/terraform-modules//modules/aws/directory_service_ad_connector"
+```hcl
+module "simple_ad" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/directory_service_simple_ad"
 
-    alias               = "ad.corp.com"
-    customer_dns_ips    = ["10.11.1.100", "10.11.2.100"]
-    customer_username   = "svc_aws_adconnector"
-    description         = "ad.corp.com adconnector"
-    name                = "ad.corp.com"
-    password            = var.ad_connector_password
-    size                = "Small"
-    subnet_ids          = [module.vpc.private_subnet.id]
-    type                = "ADConnector"
-    vpc_id              = module.vpc.id
-    tags                = {
-        created_by  = "Zachary Hill"
-        environment = "prod"
-        terraform   = "true"
-    }
+  name        = "corp.example.com"
+  description = "Simple AD directory for AWS WorkSpaces"
+  size        = "Small"
+  password    = var.simple_ad_password
+  subnet_ids  = [module.vpc.private_subnet_ids[0], module.vpc.private_subnet_ids[1]]
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    created_by  = "Zachary Hill"
+    environment = "prod"
+    terraform   = "true"
+  }
 }
 ```
 

--- a/modules/aws/directory_service_simple_ad/main.tf
+++ b/modules/aws/directory_service_simple_ad/main.tf
@@ -11,8 +11,10 @@ terraform {
 resource "aws_directory_service_directory" "this" {
   alias       = var.alias
   description = var.description
+  enable_sso  = var.enable_sso
   name        = var.name
   password    = var.password
+  short_name  = var.short_name
   size        = var.size
   tags        = var.tags
   type        = var.type

--- a/modules/aws/directory_service_simple_ad/main.tf
+++ b/modules/aws/directory_service_simple_ad/main.tf
@@ -8,7 +8,7 @@ terraform {
   }
 }
 
-resource "aws_directory_service_directory" "connector" {
+resource "aws_directory_service_directory" "this" {
   alias       = var.alias
   description = var.description
   name        = var.name
@@ -17,10 +17,8 @@ resource "aws_directory_service_directory" "connector" {
   tags        = var.tags
   type        = var.type
 
-  connect_settings {
-    customer_dns_ips  = var.customer_dns_ips
-    customer_username = var.customer_username
-    subnet_ids        = var.subnet_ids
-    vpc_id            = var.vpc_id
+  vpc_settings {
+    subnet_ids = var.subnet_ids
+    vpc_id     = var.vpc_id
   }
 }

--- a/modules/aws/directory_service_simple_ad/outputs.tf
+++ b/modules/aws/directory_service_simple_ad/outputs.tf
@@ -1,3 +1,14 @@
 output "id" {
-  value = aws_directory_service_directory.connector.id
+  description = "The ID of the directory."
+  value       = aws_directory_service_directory.this.id
+}
+
+output "dns_ip_addresses" {
+  description = "A list of IP addresses of the DNS servers for the directory."
+  value       = aws_directory_service_directory.this.dns_ip_addresses
+}
+
+output "security_group_id" {
+  description = "The ID of the security group created by the directory."
+  value       = aws_directory_service_directory.this.security_group_id
 }

--- a/modules/aws/directory_service_simple_ad/variables.tf
+++ b/modules/aws/directory_service_simple_ad/variables.tf
@@ -21,10 +21,27 @@ variable "password" {
   sensitive   = true
 }
 
+variable "enable_sso" {
+  type        = bool
+  description = "(Optional) Whether to enable single-sign on for the directory. Requires alias. Defaults to false."
+  default     = false
+}
+
+variable "short_name" {
+  type        = string
+  description = "(Optional) The short name of the directory, such as CORP."
+  default     = null
+}
+
 variable "size" {
   type        = string
-  description = "(Required for SimpleAD and ADConnector) The size of the directory (Small or Large are accepted values)."
+  description = "(Required) The size of the directory. Valid values: Small, Large."
   default     = "Small"
+
+  validation {
+    condition     = contains(["Small", "Large"], var.size)
+    error_message = "Size must be 'Small' or 'Large'."
+  }
 }
 
 variable "tags" {
@@ -35,8 +52,13 @@ variable "tags" {
 
 variable "type" {
   type        = string
-  description = "(Optional) - The directory type (SimpleAD, ADConnector or MicrosoftAD are accepted values). Defaults to SimpleAD."
+  description = "(Optional) The directory type. For this module, SimpleAD is the supported type."
   default     = "SimpleAD"
+
+  validation {
+    condition     = contains(["SimpleAD", "ADConnector", "MicrosoftAD"], var.type)
+    error_message = "Type must be one of: SimpleAD, ADConnector, MicrosoftAD."
+  }
 }
 
 variable "subnet_ids" {

--- a/modules/aws/directory_service_simple_ad/variables.tf
+++ b/modules/aws/directory_service_simple_ad/variables.tf
@@ -1,13 +1,13 @@
 variable "alias" {
   type        = string
   description = "(Optional) The alias for the directory (must be unique amongst all aliases in AWS). Required for enable_sso."
-  default     = "default_value"
+  default     = null
 }
 
 variable "description" {
   type        = string
   description = "(Optional) A textual description for the directory."
-  default     = "default_value"
+  default     = null
 }
 
 variable "name" {
@@ -18,6 +18,7 @@ variable "name" {
 variable "password" {
   type        = string
   description = "(Required) The password for the directory administrator or connector user."
+  sensitive   = true
 }
 
 variable "size" {
@@ -36,17 +37,6 @@ variable "type" {
   type        = string
   description = "(Optional) - The directory type (SimpleAD, ADConnector or MicrosoftAD are accepted values). Defaults to SimpleAD."
   default     = "SimpleAD"
-}
-
-variable "customer_dns_ips" {
-  type        = list(string)
-  description = "(Required) The DNS IP addresses of the domain to connect to."
-  default     = []
-}
-
-variable "customer_username" {
-  type        = string
-  description = "(Required) The username corresponding to the password provided."
 }
 
 variable "subnet_ids" {


### PR DESCRIPTION
# Description
The `directory_service_simple_ad` module was incorrectly configured to use the `connect_settings` block, which is only valid for `ADConnector` type directories. Simple AD requires the `vpc_settings` block. This PR corrects that and brings the module up to the standard of the `directory_service_microsoftad` module.

## Issue or Ticket
No related issue.

## Type of change
- [x] Bugfix

## Breaking Changes
- [x] Yes

### Breaking Changes Description
Any existing deployments using this module must run `terraform state mv` to rename the resource from `aws_directory_service_directory.connector` to `aws_directory_service_directory.this` before applying, otherwise Terraform will destroy and recreate the directory.

```
terraform state mv module.<name>.aws_directory_service_directory.connector module.<name>.aws_directory_service_directory.this
```

## Changes

**main.tf**
- Replace `connect_settings` block with `vpc_settings` (correct block for SimpleAD type)
- Add `enable_sso` and `short_name` arguments (parity with `directory_service_microsoftad`)
- Rename resource from `connector` to `this` per module conventions

**variables.tf**
- Remove `customer_dns_ips` and `customer_username` (ADConnector-only variables)
- Fix `alias` and `description` defaults from `"default_value"` string to `null`
- Add `sensitive = true` to `password` variable
- Add `enable_sso` variable (bool, default `false`)
- Add `short_name` variable (optional string)
- Add `contains()` validation blocks for `size` and `type`

**outputs.tf**
- Update resource reference from `.connector` to `.this`
- Add `dns_ip_addresses` and `security_group_id` outputs
- Add `description` to all outputs

**README.md**
- Fix module title and description (was describing ADConnector, not Simple AD)
- Update Usage example to show correct Simple AD configuration

## TODOs
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [ ] Validate all tests run successfully, including pre-commit checks.
- [x] Include release notes and description.

---
*Generated with [Warp](https://app.warp.dev/conversation/a451a4e4-2ab9-470d-b615-19eca07d9c9e)*