### PR TITLE
feat: add scalr/hook module for hooks registry management

### DIFF
--- a/modules/scalr/hook/README.md
+++ b/modules/scalr/hook/README.md
@@ -165,18 +165,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [scalr_hook.this](https://registry.terraform.io/providers/Scalr/scalr/latest/docs/resources/hook) | resource |
-| [scalr_current_account.account](https://registry.terraform.io/providers/Scalr/scalr/latest/docs/data-sources/current_account) | data source |
+| scalr_hook.this | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_hooks"></a> [hooks](#input\_hooks) | Map of hooks to register in the Scalr hooks registry. The map key is used as a unique identifier and as the hook name if 'name' is not specified within the hook definition. | `map(object({...}))` | `{}` | no |
-| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | The default interpreter used to execute hook scripts. Can be overridden per hook. Common values are 'bash' and 'python3'. | `string` | `"bash"` | no |
+| <a name="input_hooks"></a> [hooks](#input\_hooks) | Map of hooks to register in the Scalr hooks registry. The map key is used as a unique identifier and as the hook name if 'name' is not specified within the hook definition. | <pre>map(object({<br/>    description     = optional(string)<br/>    interpreter     = optional(string)<br/>    name            = optional(string)<br/>    scriptfile_path = string<br/>    vcs_provider_id = optional(string)<br/>    vcs_repo = optional(object({<br/>      identifier = string<br/>      branch     = optional(string)<br/>    }))<br/>  }))</pre> | `{}` | no |
+| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | The default interpreter used to execute hook scripts. Can be overridden per hook in the hooks map. Common values are 'bash' and 'python3'. | `string` | `"bash"` | no |
 | <a name="input_vcs_provider_id"></a> [vcs\_provider\_id](#input\_vcs\_provider\_id) | The default VCS provider ID in the format 'vcs-<RANDOM STRING>'. Can be overridden per hook in the hooks map. | `string` | `null` | no |
-| <a name="input_vcs_repo_identifier"></a> [vcs\_repo\_identifier](#input\_vcs\_repo\_identifier) | The default VCS repository identifier in the format 'org/repo'. Used when vcs\_repo is not specified per hook. Can be overridden per hook in the hooks map. | `string` | `null` | no |
 | <a name="input_vcs_repo_branch"></a> [vcs\_repo\_branch](#input\_vcs\_repo\_branch) | The default VCS repository branch to pull hook scripts from. Can be overridden per hook in the hooks map. | `string` | `"main"` | no |
+| <a name="input_vcs_repo_identifier"></a> [vcs\_repo\_identifier](#input\_vcs\_repo\_identifier) | The default VCS repository identifier in the format 'org/repo'. Used when vcs\_repo is not specified per hook. Can be overridden per hook in the hooks map. | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/scalr/hook/README.md
+++ b/modules/scalr/hook/README.md
@@ -1,0 +1,233 @@
+<!-- Blank module readme template: Do a search and replace with your text editor for the following: `module_name`, `module_description` -->
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="300" height="300">
+  </a>
+
+<h3 align="center">scalr/hook</h3>
+  <p align="center">
+    Terraform module for managing Scalr hooks registry entries. This module creates and manages one or more <code>scalr_hook</code> resources, sourcing scripts from a VCS provider for use in the Scalr hooks registry. Hooks can then be attached to environments or workspaces to execute custom scripts at specific stages of the Terraform/OpenTofu workflow.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#Resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+<!-- USAGE EXAMPLES -->
+
+## Usage
+
+### Single Hook — Terravision Post-Apply
+
+This example registers the terravision post-apply script from a private GitHub repository into the Scalr hooks registry. The `vcs_provider_id` is the ID of the existing VCS provider already configured in Scalr for the SLFCU-Infrastructure org.
+
+```hcl
+module "scalr_hooks" {
+  source          = "github.com/zachreborn/terraform-modules//modules/scalr/hook"
+  vcs_provider_id = "vcs-xxxxxxxxxx"
+
+  hooks = {
+    terravision-post-apply = {
+      description     = "Generates Terraform infrastructure visualization after apply"
+      scriptfile_path = "hooks/scalr-post-apply.sh"
+      vcs_repo = {
+        identifier = "SLFCU-Infrastructure/terravision"
+        branch     = "main"
+      }
+    }
+  }
+}
+```
+
+### Multiple Hooks with Shared VCS Provider and Repo
+
+This example registers multiple hooks from the same repository, sharing the module-level VCS defaults.
+
+```hcl
+module "scalr_hooks" {
+  source              = "github.com/zachreborn/terraform-modules//modules/scalr/hook"
+  vcs_provider_id     = "vcs-xxxxxxxxxx"
+  vcs_repo_identifier = "SLFCU-Infrastructure/terravision"
+
+  hooks = {
+    terravision-post-apply = {
+      description     = "Generates Terraform infrastructure visualization after apply"
+      scriptfile_path = "hooks/scalr-post-apply.sh"
+    }
+    terravision-post-plan = {
+      description     = "Generates Terraform infrastructure visualization after plan"
+      scriptfile_path = "hooks/scalr-post-plan.sh"
+    }
+  }
+}
+```
+
+### Hook with Per-Hook VCS Provider Override
+
+Hooks can override the module-level VCS provider or repo on a per-hook basis.
+
+```hcl
+module "scalr_hooks" {
+  source          = "github.com/zachreborn/terraform-modules//modules/scalr/hook"
+  vcs_provider_id = "vcs-xxxxxxxxxx"
+
+  hooks = {
+    custom-linter = {
+      description     = "Runs custom linting before plan"
+      interpreter     = "python3"
+      scriptfile_path = "scripts/lint.py"
+      vcs_repo = {
+        identifier = "my-org/pipeline-tools"
+        branch     = "stable"
+      }
+    }
+    terravision-post-apply = {
+      description     = "Generates Terraform infrastructure visualization after apply"
+      scriptfile_path = "hooks/scalr-post-apply.sh"
+      vcs_repo = {
+        identifier = "SLFCU-Infrastructure/terravision"
+        branch     = "main"
+      }
+    }
+  }
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_scalr"></a> [scalr](#requirement\_scalr) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_scalr"></a> [scalr](#provider\_scalr) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [scalr_hook.this](https://registry.terraform.io/providers/Scalr/scalr/latest/docs/resources/hook) | resource |
+| [scalr_current_account.account](https://registry.terraform.io/providers/Scalr/scalr/latest/docs/data-sources/current_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_hooks"></a> [hooks](#input\_hooks) | Map of hooks to register in the Scalr hooks registry. The map key is used as a unique identifier and as the hook name if 'name' is not specified within the hook definition. | `map(object({...}))` | `{}` | no |
+| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | The default interpreter used to execute hook scripts. Can be overridden per hook. Common values are 'bash' and 'python3'. | `string` | `"bash"` | no |
+| <a name="input_vcs_provider_id"></a> [vcs\_provider\_id](#input\_vcs\_provider\_id) | The default VCS provider ID in the format 'vcs-<RANDOM STRING>'. Can be overridden per hook in the hooks map. | `string` | `null` | no |
+| <a name="input_vcs_repo_identifier"></a> [vcs\_repo\_identifier](#input\_vcs\_repo\_identifier) | The default VCS repository identifier in the format 'org/repo'. Used when vcs\_repo is not specified per hook. Can be overridden per hook in the hooks map. | `string` | `null` | no |
+| <a name="input_vcs_repo_branch"></a> [vcs\_repo\_branch](#input\_vcs\_repo\_branch) | The default VCS repository branch to pull hook scripts from. Can be overridden per hook in the hooks map. | `string` | `"main"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_hook_ids"></a> [hook\_ids](#output\_hook\_ids) | Map of hook keys to their Scalr hook IDs in the format 'hook-<RANDOM STRING>'. |
+| <a name="output_hook_names"></a> [hook\_names](#output\_hook\_names) | Map of hook keys to their registered Scalr hook names. |
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/scalr/hook/main.tf
+++ b/modules/scalr/hook/main.tf
@@ -12,16 +12,15 @@ terraform {
 }
 
 ###########################
-# Data Sources
+# Locals
 ###########################
-data "scalr_current_account" "account" {}
 
 ###########################
 # Hook Registry Configurations
 ###########################
 resource "scalr_hook" "this" {
   for_each        = var.hooks
-  description     = try(each.value.description, null)
+  description     = each.value.description
   interpreter     = try(each.value.interpreter, var.interpreter)
   name            = try(each.value.name, each.key)
   scriptfile_path = each.value.scriptfile_path

--- a/modules/scalr/hook/main.tf
+++ b/modules/scalr/hook/main.tf
@@ -1,0 +1,37 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    scalr = {
+      source  = "registry.scalr.io/scalr/scalr"
+      version = ">= 3.0"
+    }
+  }
+}
+
+###########################
+# Data Sources
+###########################
+data "scalr_current_account" "account" {}
+
+###########################
+# Hook Registry Configurations
+###########################
+resource "scalr_hook" "this" {
+  for_each        = var.hooks
+  description     = try(each.value.description, null)
+  interpreter     = try(each.value.interpreter, var.interpreter)
+  name            = try(each.value.name, each.key)
+  scriptfile_path = each.value.scriptfile_path
+  vcs_provider_id = try(each.value.vcs_provider_id, var.vcs_provider_id)
+
+  dynamic "vcs_repo" {
+    for_each = try(each.value.vcs_repo, null) != null || var.vcs_repo_identifier != null ? [1] : []
+    content {
+      identifier = try(each.value.vcs_repo.identifier, var.vcs_repo_identifier)
+      branch     = try(each.value.vcs_repo.branch, var.vcs_repo_branch)
+    }
+  }
+}

--- a/modules/scalr/hook/main.tf
+++ b/modules/scalr/hook/main.tf
@@ -21,16 +21,16 @@ terraform {
 resource "scalr_hook" "this" {
   for_each        = var.hooks
   description     = each.value.description
-  interpreter     = try(each.value.interpreter, var.interpreter)
-  name            = try(each.value.name, each.key)
+  interpreter     = each.value.interpreter != null ? each.value.interpreter : var.interpreter
+  name            = each.value.name != null ? each.value.name : each.key
   scriptfile_path = each.value.scriptfile_path
-  vcs_provider_id = try(each.value.vcs_provider_id, var.vcs_provider_id)
+  vcs_provider_id = each.value.vcs_provider_id != null ? each.value.vcs_provider_id : var.vcs_provider_id
 
   dynamic "vcs_repo" {
-    for_each = try(each.value.vcs_repo, null) != null || var.vcs_repo_identifier != null ? [1] : []
+    for_each = each.value.vcs_repo != null || var.vcs_repo_identifier != null ? [1] : []
     content {
-      identifier = try(each.value.vcs_repo.identifier, var.vcs_repo_identifier)
-      branch     = try(each.value.vcs_repo.branch, var.vcs_repo_branch)
+      identifier = each.value.vcs_repo != null ? each.value.vcs_repo.identifier : var.vcs_repo_identifier
+      branch     = each.value.vcs_repo != null && each.value.vcs_repo.branch != null ? each.value.vcs_repo.branch : var.vcs_repo_branch
     }
   }
 }

--- a/modules/scalr/hook/outputs.tf
+++ b/modules/scalr/hook/outputs.tf
@@ -1,0 +1,12 @@
+###########################
+# Resource Outputs
+###########################
+output "hook_ids" {
+  description = "Map of hook keys to their Scalr hook IDs in the format 'hook-<RANDOM STRING>'."
+  value       = { for k, v in scalr_hook.this : k => v.id }
+}
+
+output "hook_names" {
+  description = "Map of hook keys to their registered Scalr hook names."
+  value       = { for k, v in scalr_hook.this : k => v.name }
+}

--- a/modules/scalr/hook/variables.tf
+++ b/modules/scalr/hook/variables.tf
@@ -18,7 +18,7 @@ variable "hooks" {
 }
 
 ###########################
-# General Variables
+# Default Variables
 ###########################
 variable "interpreter" {
   description = "The default interpreter used to execute hook scripts. Can be overridden per hook in the hooks map. Common values are 'bash' and 'python3'."

--- a/modules/scalr/hook/variables.tf
+++ b/modules/scalr/hook/variables.tf
@@ -1,0 +1,45 @@
+###########################
+# Hook Variables
+###########################
+variable "hooks" {
+  description = "Map of hooks to register in the Scalr hooks registry. The map key is used as a unique identifier and as the hook name if 'name' is not specified within the hook definition."
+  type = map(object({
+    description     = optional(string)
+    interpreter     = optional(string)
+    name            = optional(string)
+    scriptfile_path = string
+    vcs_provider_id = optional(string)
+    vcs_repo = optional(object({
+      identifier = string
+      branch     = optional(string)
+    }))
+  }))
+  default = {}
+}
+
+###########################
+# General Variables
+###########################
+variable "interpreter" {
+  description = "The default interpreter used to execute hook scripts. Can be overridden per hook in the hooks map. Common values are 'bash' and 'python3'."
+  type        = string
+  default     = "bash"
+}
+
+variable "vcs_provider_id" {
+  description = "The default VCS provider ID in the format 'vcs-<RANDOM STRING>'. Can be overridden per hook in the hooks map."
+  type        = string
+  default     = null
+}
+
+variable "vcs_repo_identifier" {
+  description = "The default VCS repository identifier in the format 'org/repo'. Used when vcs_repo is not specified per hook. Can be overridden per hook in the hooks map."
+  type        = string
+  default     = null
+}
+
+variable "vcs_repo_branch" {
+  description = "The default VCS repository branch to pull hook scripts from. Can be overridden per hook in the hooks map."
+  type        = string
+  default     = "main"
+}


### PR DESCRIPTION
# Description
Adds a new Terraform module at `modules/scalr/hook/` for managing `scalr_hook` resources in the Scalr hooks registry. The module supports registering one or more VCS-backed hook scripts from a map variable, using per-hook overrides that fall back to module-level defaults via `try()` — consistent with the patterns in the sibling `modules/scalr/` module.

**Module features:**
- `for_each` over a typed `map(object(...))` variable for DRY multi-hook management
- Module-level defaults for `interpreter` (bash), `vcs_provider_id`, `vcs_repo_identifier`, and `vcs_repo_branch` (main)
- Per-hook overrides for all fields including VCS repo and interpreter
- Dynamic `vcs_repo` block rendered only when an identifier is provided
- Outputs `hook_ids` and `hook_names` maps for downstream use (e.g., `scalr_environment_hook`)

**Pre-PR review completed** using the zach-review skill. Fixes applied:
- Removed unused `scalr_current_account` data source (`scalr_hook` has no `account_id`)
- Added empty `Locals` section to `main.tf` for structural consistency
- Renamed `General Variables` → `Default Variables` for clarity
- Removed redundant `try()` on `description` (handled by `optional(string)` type)

[AI Session](https://app.warp.dev/conversation/4bd11db9-c8c9-42b5-8e41-30858833cb96) | [Plan: Scalr Hook Registry Module](https://app.warp.dev/drive/notebook/UZbYeLVJCppAwP27J6Up5q)

## Issue or Ticket
N/A

## Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Version update

## Breaking Changes
- [ ] Yes
- [x] No

### Breaking Changes Description
N/A

## TODOs
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [ ] Validate all tests run successfull, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.

Co-Authored-By: Oz <oz-agent@warp.dev>