### PR TITLE
feat(dhcp_options_set)!: multi-VPC support, netbios, and output fix

### DIFF
--- a/modules/aws/dhcp_options_set/README.md
+++ b/modules/aws/dhcp_options_set/README.md
@@ -114,15 +114,17 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | (Optional) Define the domain name for the DHCP Options Set | `string` | `null` | no |
 | <a name="input_domain_name_servers"></a> [domain\_name\_servers](#input\_domain\_name\_servers) | (Optional) List of IP addresses for the DNS servers | `list(string)` | `[]` | no |
+| <a name="input_netbios_name_servers"></a> [netbios\_name\_servers](#input\_netbios\_name\_servers) | (Optional) List of NETBIOS name servers. | `list(string)` | `[]` | no |
+| <a name="input_netbios_node_type"></a> [netbios\_node\_type](#input\_netbios\_node\_type) | (Optional) The NetBIOS node type (1, 2, 4, or 8). AWS recommends to specify 2 since broadcast and multicast are not supported in their network. For more information about these node types, see RFC 2132. | `string` | `null` | no |
 | <a name="input_ntp_servers"></a> [ntp\_servers](#input\_ntp\_servers) | (Optional) List of IP addresses for the NTP servers | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the object. | `map` | <pre>{<br/>  "Name": "DHCP Options Set",<br/>  "created_by": "Terraform",<br/>  "description": "DHCP Option Set for the VPC",<br/>  "environment": "prod",<br/>  "terraform": "true"<br/>}</pre> | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) ID of the VPC to attach the DHCP Options Set to | `string` | n/a | yes |
+| <a name="input_vpc_ids"></a> [vpc\_ids](#input\_vpc\_ids) | (Required) Map of name => VPC ID to associate with this DHCP Options Set. Supports multiple VPCs sharing the same options set. | `map(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_dhcp_options_id"></a> [dhcp\_options\_id](#output\_dhcp\_options\_id) | n/a |
+| <a name="output_dhcp_options_id"></a> [dhcp\_options\_id](#output\_dhcp\_options\_id) | The ID of the DHCP Options Set. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/dhcp_options_set/main.tf
+++ b/modules/aws/dhcp_options_set/main.tf
@@ -22,6 +22,7 @@ resource "aws_vpc_dhcp_options" "this" {
 }
 
 resource "aws_vpc_dhcp_options_association" "this" {
+  for_each        = var.vpc_ids
   dhcp_options_id = aws_vpc_dhcp_options.this.id
-  vpc_id          = var.vpc_id
+  vpc_id          = each.value
 }

--- a/modules/aws/dhcp_options_set/main.tf
+++ b/modules/aws/dhcp_options_set/main.tf
@@ -13,10 +13,12 @@ terraform {
 ###########################
 
 resource "aws_vpc_dhcp_options" "this" {
-  domain_name         = var.domain_name
-  domain_name_servers = var.domain_name_servers
-  ntp_servers         = var.ntp_servers
-  tags                = var.tags
+  domain_name          = var.domain_name
+  domain_name_servers  = var.domain_name_servers
+  ntp_servers          = var.ntp_servers
+  netbios_name_servers = var.netbios_name_servers
+  netbios_node_type    = var.netbios_node_type
+  tags                 = var.tags
 }
 
 resource "aws_vpc_dhcp_options_association" "this" {

--- a/modules/aws/dhcp_options_set/outputs.tf
+++ b/modules/aws/dhcp_options_set/outputs.tf
@@ -1,3 +1,4 @@
 output "dhcp_options_id" {
-  value = aws_vpc_dhcp_options.this[*].id
+  description = "The ID of the DHCP Options Set."
+  value       = aws_vpc_dhcp_options.this.id
 }

--- a/modules/aws/dhcp_options_set/variables.tf
+++ b/modules/aws/dhcp_options_set/variables.tf
@@ -19,6 +19,18 @@ variable "ntp_servers" {
   default     = []
 }
 
+variable "netbios_name_servers" {
+  description = "(Optional) List of NETBIOS name servers."
+  type        = list(string)
+  default     = []
+}
+
+variable "netbios_node_type" {
+  description = "(Optional) The NetBIOS node type (1, 2, 4, or 8). AWS recommends to specify 2 since broadcast and multicast are not supported in their network. For more information about these node types, see RFC 2132."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the object."
   default = {

--- a/modules/aws/dhcp_options_set/variables.tf
+++ b/modules/aws/dhcp_options_set/variables.tf
@@ -42,7 +42,7 @@ variable "tags" {
   }
 }
 
-variable "vpc_id" {
-  description = "(Required) ID of the VPC to attach the DHCP Options Set to"
-  type        = string
+variable "vpc_ids" {
+  description = "(Required) Map of name => VPC ID to associate with this DHCP Options Set. Supports multiple VPCs sharing the same options set."
+  type        = map(string)
 }

--- a/modules/aws/ec2_dedicated_host/README.md
+++ b/modules/aws/ec2_dedicated_host/README.md
@@ -50,3 +50,48 @@ module "mac_dedicated_host" {
 | arn | The ARN of the Dedicated Host |
 | availability_zone | The Availability Zone of the Dedicated Host |
 | instance_type | The instance type supported by the Dedicated Host |
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_host.host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_host) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_auto_placement"></a> [auto\_placement](#input\_auto\_placement) | (Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: 'on' or 'off'. Default: 'on'. | `string` | `"on"` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | (Required) The Availability Zone in which to allocate the Dedicated Host. | `string` | n/a | yes |
+| <a name="input_host_recovery"></a> [host\_recovery](#input\_host\_recovery) | (Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Valid values: 'on' or 'off'. Default: 'off'. | `string` | `"off"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | (Required) Specifies the instance type to be supported by the Dedicated Hosts. e.g. mac-m4.metal, mac2-m2.metal. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name tag to assign to the Dedicated Host. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource. | `map(string)` | <pre>{<br/>  "terraform": "true"<br/>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the Dedicated Host. |
+| <a name="output_availability_zone"></a> [availability\_zone](#output\_availability\_zone) | The Availability Zone of the Dedicated Host. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the Dedicated Host. |
+| <a name="output_instance_type"></a> [instance\_type](#output\_instance\_type) | The instance type supported by the Dedicated Host. |
+<!-- END_TF_DOCS -->

--- a/modules/aws/ec2_dedicated_host/README.md
+++ b/modules/aws/ec2_dedicated_host/README.md
@@ -1,0 +1,52 @@
+# AWS EC2 Dedicated Host Module
+
+This module creates and manages an AWS EC2 Dedicated Host (`aws_ec2_host`). Dedicated Hosts are physical servers with EC2 instance capacity fully dedicated to your use.
+
+Common use cases include Mac instances (`mac-m4.metal`, `mac2-m2.metal`, etc.) which require a dedicated host for licensing compliance.
+
+## Usage
+
+```hcl
+module "mac_dedicated_host" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/ec2_dedicated_host?ref=dev_mac_dedicated_host"
+
+  name              = "mac-m4-host-01"
+  instance_type     = "mac-m4.metal"
+  availability_zone = "us-west-2a"
+  auto_placement    = "off"
+  host_recovery     = "off"
+
+  tags = {
+    terraform   = "true"
+    created_by  = "Jake Jones"
+    environment = "prod"
+  }
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0.0 |
+| aws | >= 6.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| availability_zone | The Availability Zone in which to allocate the Dedicated Host | `string` | n/a | yes |
+| instance_type | Instance type supported by the host (e.g. mac-m4.metal) | `string` | n/a | yes |
+| name | Name tag to assign to the Dedicated Host | `string` | n/a | yes |
+| auto_placement | Whether the host accepts untargeted launches. Valid: `on` or `off` | `string` | `"on"` | no |
+| host_recovery | Enable host recovery. Valid: `on` or `off` | `string` | `"off"` | no |
+| tags | Map of tags to assign to the resource | `map(string)` | `{ terraform = "true" }` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | The ID of the Dedicated Host |
+| arn | The ARN of the Dedicated Host |
+| availability_zone | The Availability Zone of the Dedicated Host |
+| instance_type | The instance type supported by the Dedicated Host |

--- a/modules/aws/ec2_dedicated_host/main.tf
+++ b/modules/aws/ec2_dedicated_host/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+###########################
+# EC2 Dedicated Host
+###########################
+
+resource "aws_ec2_host" "host" {
+  instance_type     = var.instance_type
+  availability_zone = var.availability_zone
+  host_recovery     = var.host_recovery
+  auto_placement    = var.auto_placement
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.name
+    },
+  )
+}

--- a/modules/aws/ec2_dedicated_host/outputs.tf
+++ b/modules/aws/ec2_dedicated_host/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "The ID of the Dedicated Host."
+  value       = aws_ec2_host.host.id
+}
+
+output "arn" {
+  description = "The ARN of the Dedicated Host."
+  value       = aws_ec2_host.host.arn
+}
+
+output "availability_zone" {
+  description = "The Availability Zone of the Dedicated Host."
+  value       = aws_ec2_host.host.availability_zone
+}
+
+output "instance_type" {
+  description = "The instance type supported by the Dedicated Host."
+  value       = aws_ec2_host.host.instance_type
+}

--- a/modules/aws/ec2_dedicated_host/variables.tf
+++ b/modules/aws/ec2_dedicated_host/variables.tf
@@ -1,0 +1,52 @@
+###########################
+# Required Variables
+###########################
+
+variable "availability_zone" {
+  type        = string
+  description = "(Required) The Availability Zone in which to allocate the Dedicated Host."
+}
+
+variable "instance_type" {
+  type        = string
+  description = "(Required) Specifies the instance type to be supported by the Dedicated Hosts. e.g. mac-m4.metal, mac2-m2.metal."
+}
+
+variable "name" {
+  type        = string
+  description = "(Required) The name tag to assign to the Dedicated Host."
+}
+
+###########################
+# Optional Variables
+###########################
+
+variable "auto_placement" {
+  type        = string
+  description = "(Optional) Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID. Valid values: 'on' or 'off'. Default: 'on'."
+  default     = "on"
+
+  validation {
+    condition     = can(regex("^(on|off)$", var.auto_placement))
+    error_message = "The value must be either 'on' or 'off'."
+  }
+}
+
+variable "host_recovery" {
+  type        = string
+  description = "(Optional) Indicates whether to enable or disable host recovery for the Dedicated Host. Valid values: 'on' or 'off'. Default: 'off'."
+  default     = "off"
+
+  validation {
+    condition     = can(regex("^(on|off)$", var.host_recovery))
+    error_message = "The value must be either 'on' or 'off'."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "(Optional) A mapping of tags to assign to the resource."
+  default = {
+    terraform = "true"
+  }
+}


### PR DESCRIPTION
## Summary
Enhances the `dhcp_options_set` module with multi-VPC association support, NetBIOS name server configuration, and fixes a bug in the output.

## Changes

### Breaking Change: `vpc_id` → `vpc_ids`
The `vpc_id` (string) variable has been replaced with `vpc_ids` (map of string). The association resource now uses `for_each`, allowing a single DHCP options set to be associated with multiple VPCs.

Existing callers with state will need `tofu state mv` or updated import blocks since the state address changes from `aws_vpc_dhcp_options_association.this` to `aws_vpc_dhcp_options_association.this["<key>"]`.

### New Variables
- `netbios_name_servers` (optional, default `[]`) — supports domains like `slfcu.local` requiring NetBIOS
- `netbios_node_type` (optional, default `null`)

### Output Fix
`dhcp_options_id` was incorrectly using a `[*]` splat on a non-count resource (returning a list). Fixed to return a scalar string.

## Known Callers

Searched all repos in the `slfcu-infrastructure` org:

- **`SLFCU-Infrastructure/aws_prod_opstooling`** (`vpc.tf`) — actively uses this module as `module "dhcp_options_slfcu_local"`, already referencing this branch (`dev_mac_dedicated_host`). Already fully updated with the new `vpc_ids` map (`prod_ops` → `vpc-0a7d40a965ae86815`, `prod_ops2` → `vpc-00e9a3ead1c733be5`), uses `netbios_name_servers`, and has import blocks in place with the correct `for_each` key format. No migration work needed.

- **`SLFCU-Infrastructure/aws_prod_data`** (`vpc.tf`) — the `module "dhcp_options"` block is commented out and references the `dev_dhcp_options` branch. It still uses the old `vpc_id` (singular string) variable and has never been applied to state. When uncommented, it will need the variable updated to `vpc_ids` map format and the source ref bumped to `main`. There is also an open TODO about resolving a VPCE DNS issue before this can be enabled.

No other repos in the org reference this module.

---
Co-Authored-By: Oz <oz-agent@warp.dev>