### PR TITLE
fix(ci): pin scan workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,10 +20,12 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Checkov Scan
-        uses: bridgecrewio/checkov-action@v12.3101.0
+        uses: bridgecrewio/checkov-action@9201a8e6eaa919e3444d7c4ca691896efde4f033 # v12.3101.0
         with:
           # This will add both a CLI output to the console and create a results.sarif file
           output_format: cli,sarif
@@ -33,7 +35,7 @@ jobs:
           soft_fail: true
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         # Results are generated only on a success or failure
         # this is required since GitHub by default won't run the next step
         # when the previous one has failed. Security checks that do not pass will 'fail'.

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Checkov Scan
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@v12.3101.0
         with:
           # This will add both a CLI output to the console and create a results.sarif file
           output_format: cli,sarif


### PR DESCRIPTION
## Summary

Fixes the failing \`GITHUB_ACTIONS_ZIZMOR\` check on PR #202 by pinning all GitHub Actions in \`.github/workflows/scan.yml\` to full commit SHAs, as required by the zizmor blanket \`unpinned-uses\` policy.

This branch is based on the Dependabot PR #202 branch and includes that checkov-action bump as well.

## Changes

- \`actions/checkout@v6\` → pinned to SHA \`de0fac2e\` (v6)
- \`bridgecrewio/checkov-action@v12.3101.0\` → pinned to SHA \`9201a8e6\` (v12.3101.0)
- \`github/codeql-action/upload-sarif@v4\` → pinned to SHA \`68bde559\` (v4)
- Added \`persist-credentials: false\` to the checkout step (resolves \`artipacked\` zizmor finding)

Supersedes #202.

---
[Warp conversation](https://app.warp.dev/conversation/22846e96-3766-4f5d-a6fa-13946756d719)