### PR TITLE
fix(s3/bucket): collapse multi-line policy ternary to single line

### DIFF
--- a/modules/aws/s3/bucket/main.tf
+++ b/modules/aws/s3/bucket/main.tf
@@ -220,11 +220,7 @@ resource "aws_s3_bucket_policy" "this" {
   bucket = aws_s3_bucket.this.id
 
   policy = (
-    var.enforce_ssl && var.bucket_policy != null
-    ? data.aws_iam_policy_document.merged[0].json
-    : var.bucket_policy != null
-    ? var.bucket_policy
-    : data.aws_iam_policy_document.ssl_only[0].json
+    var.enforce_ssl && var.bucket_policy != null ? data.aws_iam_policy_document.merged[0].json : var.bucket_policy != null ? var.bucket_policy : data.aws_iam_policy_document.ssl_only[0].json
   )
 }
 


### PR DESCRIPTION
## Summary

Collapses the multi-line ternary expression in \`aws_s3_bucket_policy\` into a single line in \`modules/aws/s3/bucket/main.tf\`.

The policy assignment ternary was split across multiple lines which caused formatting/linting issues. This consolidates it to a single line to resolve those issues.

## Changes

- \`modules/aws/s3/bucket/main.tf\`: Single-line ternary for bucket policy selection logic

---
[Warp conversation](https://app.warp.dev/conversation/0ffe8c65-5507-4fe9-bf8d-520c26f8d4d6)

Co-Authored-By: Oz <oz-agent@warp.dev>