### PR TITLE
feat(automation): Oz-powered issue → spec → implementation pipeline

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -10,9 +10,10 @@ skip-check:
   - CKV2_GHA_1
   # The Oz spec/impl workflows expose an issue_number workflow_dispatch input
   # so codeowners can manually re-run a stage for a specific issue. The first
-  # step in each of those workflows validates the value against `^[0-9]+$`
-  # and fails fast otherwise, so it cannot inject content into $GITHUB_OUTPUT
-  # or influence build output. It is only used to look up an existing issue.
+  # step in each of those workflows validates the value against
+  # `^[1-9][0-9]*$` (a positive integer >= 1) and fails fast otherwise, so it
+  # cannot inject content into $GITHUB_OUTPUT or influence build output. It is
+  # only used to look up an existing issue.
   - CKV_GHA_7
 
   # ============================================================

--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -8,6 +8,11 @@ skip-check:
   - CKV_TF_1
   # These workflows utilize write access in order to write statuses and comments
   - CKV2_GHA_1
+  # The Oz spec/impl workflows expose an issue_number workflow_dispatch input
+  # so codeowners can manually re-run a stage for a specific issue. The input
+  # is restricted to integers and is only used to look up an existing issue;
+  # it cannot influence build output.
+  - CKV_GHA_7
 
   # ============================================================
   # BY DESIGN: Module purpose requires the capability

--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -9,9 +9,10 @@ skip-check:
   # These workflows utilize write access in order to write statuses and comments
   - CKV2_GHA_1
   # The Oz spec/impl workflows expose an issue_number workflow_dispatch input
-  # so codeowners can manually re-run a stage for a specific issue. The input
-  # is restricted to integers and is only used to look up an existing issue;
-  # it cannot influence build output.
+  # so codeowners can manually re-run a stage for a specific issue. The first
+  # step in each of those workflows validates the value against `^[0-9]+$`
+  # and fails fast otherwise, so it cannot inject content into $GITHUB_OUTPUT
+  # or influence build output. It is only used to look up an existing issue.
   - CKV_GHA_7
 
   # ============================================================

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,4 @@
 
 # CI/CD and repo configuration
 /.github/             @zachreborn @Jakeasaurus
+/.github/specs/       @zachreborn @Jakeasaurus

--- a/.github/specs/README.md
+++ b/.github/specs/README.md
@@ -1,0 +1,48 @@
+# Specs
+
+This directory holds **technical specifications** that sit between a GitHub
+issue and its implementation PR.
+
+Each spec is reviewed and merged by codeowners **before** the corresponding
+implementation work is done. The full pipeline is documented in the
+"Automated issue/spec/impl pipeline" section of [`AGENTS.md`](../../AGENTS.md).
+
+## Naming
+
+```
+issue-<issue-number>-<short-kebab-slug>.md
+```
+
+Examples:
+- `issue-206-oz-issue-to-impl-workflow.md`
+- `issue-310-aws-eks-node-group-iam-bug.md`
+
+The `issue-<N>-` prefix is required — the `Spec Approved` and
+`Implementation (Oz)` workflows use it to locate the originating issue and
+the matching spec file.
+
+## Layout
+
+Use [`_template.md`](./_template.md) as the starting point. Every spec
+must include the sections enumerated there:
+
+- Title + status header (with `**Issue:** #<N>`)
+- Background
+- Non-goals
+- Affected module path(s)
+- Proposed `variables.tf` / `outputs.tf` / `main.tf` shape (signatures only)
+- Breaking-change assessment
+- Checkov / tfsec suppression considerations
+- terraform-docs impact
+- Acceptance criteria
+
+## Lifecycle
+
+1. Issue gets `ready-for-spec` (after triage).
+2. `Spec Generation (Oz)` opens a PR adding a file here.
+3. Codeowners review and merge that PR.
+4. `Spec Approved` flips the issue to `spec-approved`.
+5. `Implementation (Oz)` reads the spec from `main` and opens an
+   implementation PR with `Fixes #<N>`.
+
+`README.md` and `_template.md` are excluded from spec-PR detection.

--- a/.github/specs/_template.md
+++ b/.github/specs/_template.md
@@ -1,0 +1,54 @@
+# Spec: <title>
+**Issue:** #<N>
+**Status:** Draft — pending CODEOWNERS review
+**Owners:** @zachreborn @Jakeasaurus
+**Type:** <Feature | Bug fix | CI/automation | Other>
+
+## 1. Background
+What is the current state and why do we need to change it? Link to the
+originating issue and any prior discussion.
+
+## 2. Non-goals
+Explicit list of things this spec deliberately does NOT cover.
+
+## 3. Affected module path(s)
+- `modules/<provider>/<name>/` (existing) or
+- `modules/<provider>/<name>/` (new)
+
+## 4. Proposed design
+**Signatures only — no full implementations.**
+
+### `variables.tf`
+List the variables (name, type, description, default if any).
+
+### `outputs.tf`
+List the outputs and what they expose.
+
+### `main.tf`
+List the resource block types and their high-level relationships. Note any
+`count`/`for_each` patterns, lifecycle ignores, and tagging.
+
+## 5. Breaking-change assessment
+- Breaking: yes / no
+- If yes, describe what callers must do to migrate.
+
+## 6. Checkov / tfsec considerations
+- New suppressions: none, or list each with rationale.
+- Existing suppressions affected: none, or list.
+
+## 7. terraform-docs impact
+Will the auto-generated `<!-- BEGIN_TF_DOCS -->` block change for any
+module? If yes, which.
+
+## 8. Testing
+- `terraform -chdir=<path> init -backend=false && terraform -chdir=<path> validate`
+- `terraform fmt -check -diff -recursive`
+- `checkov -d <path>` (locally; CI runs on schedule)
+- Any module-specific test plan.
+
+## 9. Open questions
+Bullet list. Each one should be resolvable before merge.
+
+## 10. Acceptance criteria
+Mirror the issue's "Confirmation" / acceptance section. The implementation
+PR must satisfy every item here.

--- a/.github/specs/issue-206-oz-issue-to-impl-workflow.md
+++ b/.github/specs/issue-206-oz-issue-to-impl-workflow.md
@@ -1,0 +1,127 @@
+# Spec: Oz-powered issue → spec → implementation workflow
+**Issue:** #206
+**Status:** Draft — pending CODEOWNERS review
+**Owners:** @zachreborn @Jakeasaurus
+**Type:** CI/automation (no Terraform module changes)
+
+## 1. Background
+Today, issues filed via `terraform-bug.md` and `terraform-feature-request.md`
+go straight to implementation. There is no enforced minimum-information bar
+and no written spec reviewed by codeowners prior to code being written. The
+goal of this work is to insert two automated, agent-driven steps (triage and
+spec authoring) between issue creation and implementation, while keeping
+human codeowners as the gate on the spec itself.
+
+## 2. Non-goals
+- Replacing codeowner review with agent approval.
+- Automating any release/tagging behavior (handled by `release.yml`).
+- Modifying existing Terraform modules under `modules/`.
+- Bypassing existing CI (`build.yml`, `test.yml`, `scan.yml`) — implementation
+  PRs go through the same gates as today.
+
+## 3. Affected module path(s)
+None. This change is scoped to `.github/`:
+- New: `.github/workflows/issue-triage.yml`
+- New: `.github/workflows/spec-generation.yml`
+- New: `.github/workflows/spec-approved.yml`
+- New: `.github/workflows/implementation.yml`
+- New: `.github/specs/` (directory) with `README.md` and `_template.md`
+- Modified: `.github/CODEOWNERS`
+- Modified: `AGENTS.md`
+
+## 4. Proposed design
+This spec describes workflow automation rather than a Terraform module, so
+the §4 Terraform-shape sections are not applicable. The architecture is:
+
+### Pipeline state machine
+Labels on the originating issue drive state:
+
+    (new issue)
+        │  (Issue Triage)
+        ▼
+    needs-info ──► (author edits) ──► ready-for-spec
+                                          │  (Spec Generation)
+                                          ▼
+                                    spec-in-progress
+                                          │  (spec PR opened)
+                                          ▼
+                                  spec-ready-for-review
+                                          │  (codeowner merge → Spec Approved)
+                                          ▼
+                                      spec-approved
+                                          │  (Implementation)
+                                          ▼
+                              implementation-in-progress
+                                          │  (impl PR merged)
+                                          ▼
+                                        closed
+
+### Workflows
+- **`issue-triage.yml`** — Trigger: `issues: [opened, edited, labeled]` with
+  guards to avoid loops and respect `skip-oz`. Runs `warpdotdev/oz-agent-action@main`
+  with a prompt that embeds the minimum-standards checklist and instructs the
+  agent to comment + (re)label via `gh`.
+- **`spec-generation.yml`** — Trigger: `issues: [labeled]` filtered to
+  `ready-for-spec`, plus `workflow_dispatch`. Flips the issue to
+  `spec-in-progress`, runs Oz to author a spec under `.github/specs/`, open a
+  branch + PR, and apply `spec-ready-for-review`.
+- **`spec-approved.yml`** — Trigger: `pull_request: [closed]` on
+  `.github/specs/**`. Uses `actions/github-script@v7` (no agent) to parse the
+  filename and/or `**Issue:** #<N>` header, then apply `spec-approved` to the
+  originating issue and remove transitional labels.
+- **`implementation.yml`** — Trigger: `issues: [labeled]` filtered to
+  `spec-approved`, plus `workflow_dispatch`. Reads the spec from `main`,
+  runs Oz to implement strictly per spec, opens an implementation PR with
+  `Fixes #<N>` so the issue closes on merge.
+
+### Repo configuration (manual, one-time)
+- Secret: `WARP_API_KEY`
+- Variable (optional): `WARP_AGENT_PROFILE`
+- Labels: `needs-info`, `ready-for-spec`, `spec-in-progress`,
+  `spec-ready-for-review`, `spec-approved`, `implementation-in-progress`,
+  `skip-oz`
+
+## 5. Breaking-change assessment
+- Breaking: **no**.
+- Existing workflows (`build.yml`, `test.yml`, `scan.yml`, `release.yml`)
+  are not modified.
+- Existing issue templates continue to work; the new pipeline is additive.
+- Until `WARP_API_KEY` is configured, the Oz workflows fail fast in their
+  `Guard - require WARP_API_KEY` step and do not change any issue or PR state.
+
+## 6. Checkov / tfsec considerations
+- New suppressions: **none** — no Terraform changes in this PR.
+- Existing suppressions affected: **none**.
+
+## 7. terraform-docs impact
+**None.** No module-level changes; `<!-- BEGIN_TF_DOCS -->` blocks are
+unaffected.
+
+## 8. Testing
+- `terraform fmt -check -diff -recursive` — must remain clean (no `.tf` changes).
+- `super-linter` (existing `test.yml`) — must pass for the new YAML and Markdown.
+- Manual dry-run after merge:
+  1. Configure `WARP_API_KEY`.
+  2. Create the seven labels (script provided in PR description).
+  3. File a throwaway issue, verify triage comment + label.
+  4. Edit the issue to satisfy minimum standards, verify `ready-for-spec`.
+  5. Verify a spec PR is opened; merge it.
+  6. Verify `spec-approved` is applied automatically.
+  7. Verify an implementation PR opens and closes the issue on merge.
+
+## 9. Open questions
+- Pin `warpdotdev/oz-agent-action` to a SHA once a tagged release is
+  available (skill currently documents `@main`).
+- Add a `oz schedule` job to nag `needs-info` issues older than 7 days?
+  Out of scope for this PR.
+- Should the spec PR be created as a draft by default? Current decision:
+  no — codeowners can convert to draft if they want more iteration.
+
+## 10. Acceptance criteria
+Mirrors the issue's "Confirmation" section:
+- All four workflow files exist and pass `super-linter`.
+- `.github/specs/` exists with `README.md` and `_template.md`.
+- `.github/CODEOWNERS` has an explicit entry for `/.github/specs/`.
+- `AGENTS.md` has a section documenting the pipeline.
+- Dry-run end-to-end test produces: triage comment → spec PR →
+  `spec-approved` → implementation PR.

--- a/.github/specs/issue-206-oz-issue-to-impl-workflow.md
+++ b/.github/specs/issue-206-oz-issue-to-impl-workflow.md
@@ -34,45 +34,51 @@ This spec describes workflow automation rather than a Terraform module, so
 the §4 Terraform-shape sections are not applicable. The architecture is:
 
 ### Pipeline state machine
-Labels on the originating issue drive state:
+Labels on the originating issue drive state. Trusted authors
+(`author_association` in `{OWNER, MEMBER, COLLABORATOR}`) enter the
+pipeline automatically on issue open; issues from less-trusted authors do
+not auto-advance through Oz-agent stages.
 
-    (new issue)
-        │  (Issue Triage)
-        ▼
-    needs-info ──► (author edits) ──► ready-for-spec
-                                          │  (Spec Generation)
-                                          ▼
-                                    spec-in-progress
-                                          │  (spec PR opened)
-                                          ▼
-                                  spec-ready-for-review
-                                          │  (codeowner merge → Spec Approved)
-                                          ▼
-                                      spec-approved
-                                          │  (Implementation)
-                                          ▼
-                              implementation-in-progress
-                                          │  (impl PR merged)
-                                          ▼
-                                        closed
+```mermaid
+stateDiagram-v2
+    [*] --> needs_info: triage finds missing info
+    [*] --> ready_for_spec: triage passes minimum standards
+    needs_info --> ready_for_spec: author edits, re-triage passes
+    ready_for_spec --> spec_in_progress: Spec Generation runs
+    spec_in_progress --> spec_ready_for_review: spec PR opened
+    spec_in_progress --> ready_for_spec: failure (label restored)
+    spec_ready_for_review --> spec_approved: codeowner merges spec PR
+    spec_approved --> implementation_in_progress: Implementation runs
+    implementation_in_progress --> [*]: implementation PR merged
+```
 
 ### Workflows
+All Oz-agent steps pin `warpdotdev/oz-agent-action` to a specific commit
+SHA (`ce1621a` at time of authoring, with the `# main` comment indicating
+the SHA tracks `main`) per the supply-chain policy enforced by zizmor.
+
 - **`issue-triage.yml`** — Trigger: `issues: [opened, edited, labeled]` with
-  guards to avoid loops and respect `skip-oz`. Runs `warpdotdev/oz-agent-action@main`
-  with a prompt that embeds the minimum-standards checklist and instructs the
-  agent to comment + (re)label via `gh`.
+  guards to avoid loops, respect `skip-oz`, and require
+  `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`. Runs the pinned Oz
+  action with a prompt that embeds the minimum-standards checklist and
+  instructs the agent to comment + (re)label via `gh`.
 - **`spec-generation.yml`** — Trigger: `issues: [labeled]` filtered to
   `ready-for-spec`, plus `workflow_dispatch`. Flips the issue to
   `spec-in-progress`, runs Oz to author a spec under `.github/specs/`, open a
-  branch + PR, and apply `spec-ready-for-review`.
+  branch + PR, and apply `spec-ready-for-review`. Trust gate and `skip-oz`
+  are enforced for both label and dispatch triggers (dispatch checks the
+  target issue at runtime via `gh issue view`).
 - **`spec-approved.yml`** — Trigger: `pull_request: [closed]` on
   `.github/specs/**`. Uses `actions/github-script@v7` (no agent) to parse the
   filename and/or `**Issue:** #<N>` header, then apply `spec-approved` to the
-  originating issue and remove transitional labels.
+  originating issue and remove transitional labels. This workflow does NOT
+  consume `WARP_API_KEY` and will act on merged spec PRs regardless of
+  Oz-secret configuration.
 - **`implementation.yml`** — Trigger: `issues: [labeled]` filtered to
   `spec-approved`, plus `workflow_dispatch`. Reads the spec from `main`,
   runs Oz to implement strictly per spec, opens an implementation PR with
-  `Fixes #<N>` so the issue closes on merge.
+  `Fixes #<N>` so the issue closes on merge. Same trust gate as
+  spec-generation.
 
 ### Repo configuration (manual, one-time)
 - Secret: `WARP_API_KEY`
@@ -86,8 +92,12 @@ Labels on the originating issue drive state:
 - Existing workflows (`build.yml`, `test.yml`, `scan.yml`, `release.yml`)
   are not modified.
 - Existing issue templates continue to work; the new pipeline is additive.
-- Until `WARP_API_KEY` is configured, the Oz workflows fail fast in their
-  `Guard - require WARP_API_KEY` step and do not change any issue or PR state.
+- Until `WARP_API_KEY` is configured, the three Oz-agent workflows
+  (`issue-triage.yml`, `spec-generation.yml`, `implementation.yml`) fail
+  fast in their `Guard - require WARP_API_KEY` step and do not change any
+  issue or PR state. `spec-approved.yml` does NOT use `WARP_API_KEY` (it is
+  a plain `actions/github-script` job) and will act on any merged spec PR
+  as soon as it lands.
 
 ## 6. Checkov / tfsec considerations
 - New suppressions: **none** — no Terraform changes in this PR.

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -1,0 +1,149 @@
+---
+name: Implementation (Oz)
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to implement"
+        required: true
+        type: string
+
+concurrency:
+  group: oz-impl-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  implement:
+    name: Implement spec with Oz
+    runs-on: ubuntu-latest
+
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.label.name == 'spec-approved' &&
+       !contains(github.event.issue.labels.*.name, 'skip-oz'))
+
+    steps:
+      - name: HashiCorp - Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Guard - require WARP_API_KEY
+        env:
+          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+        run: |
+          if [ -z "${WARP_API_KEY}" ]; then
+            echo "::error::WARP_API_KEY secret is not configured for this repository."
+            exit 1
+          fi
+
+      - name: Resolve issue number
+        id: ctx
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
+
+      - name: Locate spec file
+        id: spec
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          set -e
+          shopt -s nullglob
+          matches=( .github/specs/issue-"${ISSUE_NUMBER}"-*.md )
+          if [ ${#matches[@]} -eq 0 ]; then
+            echo "::error::No spec file found at .github/specs/issue-${ISSUE_NUMBER}-*.md"
+            exit 1
+          fi
+          if [ ${#matches[@]} -gt 1 ]; then
+            echo "::warning::Multiple spec files found; using ${matches[0]}"
+          fi
+          echo "path=${matches[0]}" >> "${GITHUB_OUTPUT}"
+
+      - name: Mark issue implementation-in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --add-label implementation-in-progress
+
+      - name: Run Oz implementation agent
+        uses: warpdotdev/oz-agent-action@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+          prompt: |
+            You are implementing an approved spec in zachreborn/terraform-modules.
+
+            ## Target issue and spec
+            Issue: #${{ steps.ctx.outputs.issue_number }}
+            Spec file (already in `main`): ${{ steps.spec.outputs.path }}
+
+            Read the spec file in full before making any changes. Treat it
+            as the source of truth for what to build.
+
+            ## Required reading
+            - `AGENTS.md` — repo conventions (four-file module layout,
+              `terraform >= 1.0.0`, `aws >= 6.0.0`, section header style,
+              `tags = merge(tomap({ Name = var.name }), var.tags)` pattern,
+              `count = var.enable_x ? 1 : 0` conditional pattern, lifecycle
+              ignores, tfsec suppression style).
+            - `modules/module_template/` — starting point for new modules.
+            - `.github/pull_request_template.md` — required PR body shape.
+
+            ## Implementation rules
+            - Stay within the scope defined by the spec. Do not modify
+              unrelated modules.
+            - Run `terraform fmt -recursive` before committing.
+            - Do not run `terraform-docs` locally — CI (`build.yml`) will
+              auto-inject the README block.
+            - Run `terraform -chdir=<module_path> init -backend=false` and
+              `terraform -chdir=<module_path> validate` for any module you
+              create or modify, and ensure both succeed.
+            - If you add a Checkov suppression, document the rationale in a
+              comment per the convention in `AGENTS.md`.
+
+            ## Commit and PR
+            - Branch name: `feat/issue-${{ steps.ctx.outputs.issue_number }}-<slug>`
+              for features, `fix/issue-${{ steps.ctx.outputs.issue_number }}-<slug>`
+              for bugs.
+            - Commit messages follow conventional-commit style and include
+              a Co-Authored-By line for Oz.
+            - Open a PR titled per the spec's title. The PR body MUST fill
+              in the existing `.github/pull_request_template.md` sections
+              (Description, Issue or Ticket with `Fixes #${{ steps.ctx.outputs.issue_number }}`,
+              Type of change, Breaking Changes, TODOs).
+            - Post a comment on the originating issue with the PR URL.
+
+            Implementation PRs go through the same CI as any other PR
+            (`build.yml`, `test.yml`, `scan.yml`). Do not attempt to
+            bypass any check.
+
+      - name: On failure - drop implementation-in-progress
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --remove-label implementation-in-progress || true
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --body "Implementation run failed. See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -55,14 +55,33 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
-          # Reject anything that is not a bare positive integer to prevent
-          # GITHUB_OUTPUT injection (e.g. newlines, '=') when the value comes
-          # from a free-form workflow_dispatch input.
-          if ! printf '%s' "${ISSUE_NUMBER}" | grep -Eq '^[0-9]+$'; then
-            echo "::error::issue_number must be a positive integer; got: ${ISSUE_NUMBER}"
+          # Reject anything that is not a bare positive integer (>= 1) to
+          # prevent GITHUB_OUTPUT injection (e.g. newlines, '=') when the
+          # value comes from a free-form workflow_dispatch input. GitHub
+          # issue numbers start at 1, so disallow 0 explicitly.
+          if ! printf '%s' "${ISSUE_NUMBER}" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::issue_number must be a positive integer (>= 1); got: ${ISSUE_NUMBER}"
             exit 1
           fi
           echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
+
+      - name: Honor skip-oz on manual dispatch
+        # The job-level `if` only enforces skip-oz for the `labeled` trigger
+        # because `github.event.issue` is unavailable for workflow_dispatch.
+        # Re-check the target issue's labels here so manual dispatch respects
+        # the documented skip-oz override.
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          labels=$(gh issue view "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --json labels --jq '.labels[].name')
+          if printf '%s\n' "${labels}" | grep -Fxq 'skip-oz'; then
+            echo "::notice::Issue #${ISSUE_NUMBER} has the skip-oz label; aborting per AGENTS.md."
+            exit 1
+          fi
 
       - name: Locate spec file
         id: spec

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -31,16 +31,19 @@ jobs:
 
     steps:
       - name: HashiCorp - Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
 
-      - name: Checkout
-        uses: actions/checkout@v6
+      # Credentials are intentionally persisted so the Oz agent can push the
+      # implementation branch back to origin. zizmor's artipacked warning is
+      # acknowledged.
+      - name: Checkout # zizmor: ignore[artipacked]
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Guard - require WARP_API_KEY
         env:
-          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+          WARP_API_KEY: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
         run: |
           if [ -z "${WARP_API_KEY}" ]; then
             echo "::error::WARP_API_KEY secret is not configured for this repository."
@@ -82,11 +85,11 @@ jobs:
             --add-label implementation-in-progress
 
       - name: Run Oz implementation agent
-        uses: warpdotdev/oz-agent-action@main
+        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          warp_api_key: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
           profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
           prompt: |
             You are implementing an approved spec in zachreborn/terraform-modules.

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: HashiCorp - Setup Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
 
       # Credentials are intentionally persisted so the Oz agent can push the
       # implementation branch back to origin. zizmor's artipacked warning is

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -50,11 +50,18 @@ jobs:
             exit 1
           fi
 
-      - name: Resolve issue number
+      - name: Resolve and validate issue number
         id: ctx
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
+          # Reject anything that is not a bare positive integer to prevent
+          # GITHUB_OUTPUT injection (e.g. newlines, '=') when the value comes
+          # from a free-form workflow_dispatch input.
+          if ! printf '%s' "${ISSUE_NUMBER}" | grep -Eq '^[0-9]+$'; then
+            echo "::error::issue_number must be a positive integer; got: ${ISSUE_NUMBER}"
+            exit 1
+          fi
           echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
 
       - name: Locate spec file

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -24,10 +24,15 @@ jobs:
     name: Implement spec with Oz
     runs-on: ubuntu-latest
 
+    # For labeled events, only trigger on the spec-approved label, skip if
+    # skip-oz is set, and require a trusted issue author. workflow_dispatch
+    # is subject to the same checks at runtime via the eligibility step below.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.label.name == 'spec-approved' &&
-       !contains(github.event.issue.labels.*.name, 'skip-oz'))
+       !contains(github.event.issue.labels.*.name, 'skip-oz') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.issue.author_association))
 
     steps:
       - name: HashiCorp - Setup Terraform
@@ -65,23 +70,33 @@ jobs:
           fi
           echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
 
-      - name: Honor skip-oz on manual dispatch
-        # The job-level `if` only enforces skip-oz for the `labeled` trigger
-        # because `github.event.issue` is unavailable for workflow_dispatch.
-        # Re-check the target issue's labels here so manual dispatch respects
-        # the documented skip-oz override.
+      - name: Verify issue eligibility on manual dispatch
+        # The job-level `if` only enforces skip-oz and author_association for
+        # the `labeled` trigger because `github.event.issue` is unavailable
+        # for workflow_dispatch. Re-check both on the target issue here so
+        # manual dispatch respects the documented skip-oz override and the
+        # same trust gate that protects the labeled path.
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
         run: |
-          labels=$(gh issue view "${ISSUE_NUMBER}" \
+          issue=$(gh issue view "${ISSUE_NUMBER}" \
             --repo "${{ github.repository }}" \
-            --json labels --jq '.labels[].name')
+            --json labels,authorAssociation)
+          labels=$(printf '%s' "${issue}" | jq -r '.labels[].name')
+          assoc=$(printf '%s' "${issue}" | jq -r '.authorAssociation')
           if printf '%s\n' "${labels}" | grep -Fxq 'skip-oz'; then
             echo "::notice::Issue #${ISSUE_NUMBER} has the skip-oz label; aborting per AGENTS.md."
             exit 1
           fi
+          case "${assoc}" in
+            OWNER|MEMBER|COLLABORATOR) ;;
+            *)
+              echo "::error::Issue #${ISSUE_NUMBER} author_association=${assoc} is not in {OWNER,MEMBER,COLLABORATOR}; refusing to run the Oz agent on untrusted issue content."
+              exit 1
+              ;;
+          esac
 
       - name: Locate spec file
         id: spec

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -18,8 +18,15 @@ jobs:
     name: Triage issue with Oz
     runs-on: ubuntu-latest
 
-    # Skip if the issue is already past triage, the human opted out, or this
-    # event is the workflow itself adding a label (avoid infinite loops).
+    # Skip when:
+    #   - The issue has already advanced past triage, or
+    #   - The human explicitly opted out via skip-oz, or
+    #   - The author is untrusted (gates secrets/agent against prompt injection
+    #     from arbitrary issue text), or
+    #   - The triggering event is a label that this workflow itself just
+    #     applied (`labeled` event whose sender is github-actions[bot]).
+    # For `labeled` events we additionally narrow to the `needs-info` label so
+    # human edits to other labels do not re-run triage.
     if: >-
       !contains(github.event.issue.labels.*.name, 'skip-oz') &&
       !contains(github.event.issue.labels.*.name, 'ready-for-spec') &&
@@ -27,7 +34,11 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'spec-ready-for-review') &&
       !contains(github.event.issue.labels.*.name, 'spec-approved') &&
       !contains(github.event.issue.labels.*.name, 'implementation-in-progress') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'needs-info')
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.issue.author_association) &&
+      (github.event.action != 'labeled' ||
+       (github.event.label.name == 'needs-info' &&
+        github.event.sender.login != 'github-actions[bot]'))
 
     steps:
       - name: Checkout

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Guard - require WARP_API_KEY
         env:
-          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+          WARP_API_KEY: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
         run: |
           if [ -z "${WARP_API_KEY}" ]; then
             echo "::error::WARP_API_KEY secret is not configured for this repository."
@@ -45,11 +45,11 @@ jobs:
           fi
 
       - name: Run Oz triage agent
-        uses: warpdotdev/oz-agent-action@main
+        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          warp_api_key: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
           profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
           prompt: |
             You are triaging a GitHub issue in zachreborn/terraform-modules,

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,119 @@
+---
+name: Issue Triage (Oz)
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+# Cancel in-progress triage on the same issue if a new event arrives.
+concurrency:
+  group: oz-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    name: Triage issue with Oz
+    runs-on: ubuntu-latest
+
+    # Skip if the issue is already past triage, the human opted out, or this
+    # event is the workflow itself adding a label (avoid infinite loops).
+    if: >-
+      !contains(github.event.issue.labels.*.name, 'skip-oz') &&
+      !contains(github.event.issue.labels.*.name, 'ready-for-spec') &&
+      !contains(github.event.issue.labels.*.name, 'spec-in-progress') &&
+      !contains(github.event.issue.labels.*.name, 'spec-ready-for-review') &&
+      !contains(github.event.issue.labels.*.name, 'spec-approved') &&
+      !contains(github.event.issue.labels.*.name, 'implementation-in-progress') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'needs-info')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Guard - require WARP_API_KEY
+        env:
+          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+        run: |
+          if [ -z "${WARP_API_KEY}" ]; then
+            echo "::error::WARP_API_KEY secret is not configured for this repository."
+            exit 1
+          fi
+
+      - name: Run Oz triage agent
+        uses: warpdotdev/oz-agent-action@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+          prompt: |
+            You are triaging a GitHub issue in zachreborn/terraform-modules,
+            a Terraform module library. Validate the issue against the
+            minimum standards below and update its state via the `gh` CLI.
+
+            ## Issue
+            Number: #${{ github.event.issue.number }}
+            URL: ${{ github.event.issue.html_url }}
+            Title: ${{ github.event.issue.title }}
+            Labels: ${{ join(github.event.issue.labels.*.name, ', ') }}
+
+            Body:
+            ---
+            ${{ github.event.issue.body }}
+            ---
+
+            ## Classification
+            Classify as `bug` or `feature` based on the existing labels and
+            body content. If both/neither, ask in a comment and apply
+            `needs-info`.
+
+            ## Minimum standards
+            BUG must include:
+              1. Affected module path (e.g. `modules/aws/ec2_instance`).
+              2. Terraform version and relevant provider versions.
+              3. Reproduction steps.
+              4. Expected vs. actual behavior.
+              5. One of: error message, stack trace, or plan/apply output.
+              6. Acceptance criteria for "fixed."
+
+            FEATURE must include:
+              1. Target module path (existing or proposed under
+                 `modules/<provider>/<name>/`).
+              2. Motivation / problem being solved.
+              3. High-level proposed inputs and outputs.
+              4. Breaking-change assessment (yes/no + scope).
+              5. Acceptance criteria for "done."
+
+            ## Actions you must take
+            Use the `gh` CLI (already authenticated via GH_TOKEN).
+
+            If ANY required item is missing:
+              - Post a single comment listing each missing item by name and
+                briefly explaining what is needed.
+              - Run:
+                gh issue edit ${{ github.event.issue.number }} \
+                  --repo ${{ github.repository }} \
+                  --add-label needs-info
+
+            If ALL required items are present:
+              - Post a single short comment with:
+                  * Classification (bug/feature)
+                  * Affected module path(s)
+                  * Breaking-change risk (none/low/medium/high) with one
+                    sentence of rationale
+              - Run:
+                gh issue edit ${{ github.event.issue.number }} \
+                  --repo ${{ github.repository }} \
+                  --remove-label needs-info || true
+                gh issue edit ${{ github.event.issue.number }} \
+                  --repo ${{ github.repository }} \
+                  --add-label ready-for-spec
+
+            Do not edit any files. Do not push commits. Do not open PRs.
+            Do not invoke `terraform`. Your only side effects are issue
+            comments and label changes via `gh`.

--- a/.github/workflows/spec-approved.yml
+++ b/.github/workflows/spec-approved.yml
@@ -1,0 +1,106 @@
+---
+name: Spec Approved
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - ".github/specs/**"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  flip-labels:
+    name: Flip issue labels on merged spec
+    runs-on: ubuntu-latest
+    # Only act on actually-merged PRs (not just closed).
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve originating issue and flip labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // Find the spec file(s) added/modified by this PR.
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: prNumber, per_page: 100 },
+            );
+            const specFiles = files
+              .filter(f => f.filename.startsWith(".github/specs/"))
+              .filter(f => f.filename.endsWith(".md"))
+              .filter(f => !f.filename.endsWith("/README.md"))
+              .filter(f => !f.filename.endsWith("/_template.md"));
+
+            if (specFiles.length === 0) {
+              core.info("No spec files in this PR; nothing to do.");
+              return;
+            }
+
+            // Derive issue numbers. Preference order:
+            //   1. Filename pattern issue-<N>-*.md
+            //   2. **Issue:** #<N> header inside the file
+            const issueNumbers = new Set();
+            for (const file of specFiles) {
+              const match = file.filename.match(/issue-(\d+)-/);
+              if (match) {
+                issueNumbers.add(Number(match[1]));
+                continue;
+              }
+              // Fallback: read the file from the PR's merge commit.
+              const { data: blob } = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: file.filename,
+                ref: context.payload.pull_request.merge_commit_sha,
+              });
+              const content = Buffer.from(blob.content, "base64").toString("utf8");
+              const headerMatch = content.match(/\*\*Issue:\*\*\s*#(\d+)/);
+              if (headerMatch) {
+                issueNumbers.add(Number(headerMatch[1]));
+              }
+            }
+
+            if (issueNumbers.size === 0) {
+              core.warning("Could not determine an originating issue number from the spec PR.");
+              return;
+            }
+
+            for (const issueNumber of issueNumbers) {
+              // Add spec-approved.
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: issueNumber,
+                  labels: ["spec-approved"],
+                });
+              } catch (e) {
+                core.warning(`Failed to add spec-approved to #${issueNumber}: ${e.message}`);
+              }
+              // Remove transitional labels (ignore 404s).
+              for (const label of ["spec-ready-for-review", "spec-in-progress", "ready-for-spec"]) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: issueNumber, name: label,
+                  });
+                } catch (e) {
+                  if (e.status !== 404) {
+                    core.warning(`Failed to remove ${label} from #${issueNumber}: ${e.message}`);
+                  }
+                }
+              }
+              // Comment on the issue with a link to the merged spec PR.
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `Spec approved and merged in #${prNumber}. Apply \`spec-approved\` (already applied) to trigger implementation.`,
+              });
+            }

--- a/.github/workflows/spec-approved.yml
+++ b/.github/workflows/spec-approved.yml
@@ -31,12 +31,16 @@ jobs:
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
 
-            // Find the spec file(s) added/modified by this PR.
+            // Find the spec file(s) added/modified/renamed by this PR.
+            // Deletions are intentionally excluded: a PR that only removes a
+            // spec file should not flip its issue to spec-approved.
             const files = await github.paginate(
               github.rest.pulls.listFiles,
               { owner, repo, pull_number: prNumber, per_page: 100 },
             );
+            const ADDED_STATES = new Set(["added", "modified", "renamed"]);
             const specFiles = files
+              .filter(f => ADDED_STATES.has(f.status))
               .filter(f => f.filename.startsWith(".github/specs/"))
               .filter(f => f.filename.endsWith(".md"))
               .filter(f => !f.filename.endsWith("/README.md"))
@@ -99,8 +103,12 @@ jobs:
                 }
               }
               // Comment on the issue with a link to the merged spec PR.
+              // The `spec-approved` label was just applied by this workflow,
+              // which will fire the `issues:labeled` trigger for the
+              // Implementation (Oz) workflow automatically. If it does not
+              // start, codeowners can re-run it manually via workflow_dispatch.
               await github.rest.issues.createComment({
                 owner, repo, issue_number: issueNumber,
-                body: `Spec approved and merged in #${prNumber}. Apply \`spec-approved\` (already applied) to trigger implementation.`,
+                body: `Spec approved and merged in #${prNumber}. The Implementation (Oz) workflow will start automatically; re-run it manually via workflow_dispatch with this issue number if needed.`,
               });
             }

--- a/.github/workflows/spec-approved.yml
+++ b/.github/workflows/spec-approved.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Resolve originating issue and flip labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -33,15 +33,17 @@ jobs:
        !contains(github.event.issue.labels.*.name, 'skip-oz'))
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      # Credentials are intentionally persisted so the Oz agent can push the
+      # spec branch back to origin. zizmor's artipacked warning is acknowledged.
+      - name: Checkout # zizmor: ignore[artipacked]
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Needed so the agent can create a new branch and push.
           fetch-depth: 0
 
       - name: Guard - require WARP_API_KEY
         env:
-          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+          WARP_API_KEY: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
         run: |
           if [ -z "${WARP_API_KEY}" ]; then
             echo "::error::WARP_API_KEY secret is not configured for this repository."
@@ -69,11 +71,11 @@ jobs:
             --remove-label ready-for-spec || true
 
       - name: Run Oz spec-generation agent
-        uses: warpdotdev/oz-agent-action@main
+        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          warp_api_key: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
           profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
           prompt: |
             You are generating a technical specification for an issue in

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -1,0 +1,150 @@
+---
+name: Spec Generation (Oz)
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to generate a spec for"
+        required: true
+        type: string
+
+# One spec generation at a time per issue.
+concurrency:
+  group: oz-spec-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  generate-spec:
+    name: Generate spec with Oz
+    runs-on: ubuntu-latest
+
+    # For labeled events, only trigger on the ready-for-spec label and skip
+    # if skip-oz is set. workflow_dispatch always runs.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.label.name == 'ready-for-spec' &&
+       !contains(github.event.issue.labels.*.name, 'skip-oz'))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Needed so the agent can create a new branch and push.
+          fetch-depth: 0
+
+      - name: Guard - require WARP_API_KEY
+        env:
+          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+        run: |
+          if [ -z "${WARP_API_KEY}" ]; then
+            echo "::error::WARP_API_KEY secret is not configured for this repository."
+            exit 1
+          fi
+
+      - name: Resolve issue number
+        id: ctx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
+
+      - name: Mark issue spec-in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --add-label spec-in-progress
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --remove-label ready-for-spec || true
+
+      - name: Run Oz spec-generation agent
+        uses: warpdotdev/oz-agent-action@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+          prompt: |
+            You are generating a technical specification for an issue in
+            zachreborn/terraform-modules. The repository is a Terraform
+            modules library. Conventions are documented in `AGENTS.md`.
+
+            ## Target issue
+            Issue number: #${{ steps.ctx.outputs.issue_number }}
+            Repository: ${{ github.repository }}
+
+            Fetch the issue body and comments with:
+              gh issue view ${{ steps.ctx.outputs.issue_number }} \
+                --repo ${{ github.repository }} \
+                --json title,body,labels,comments
+
+            ## Required reading (consult before writing)
+            - `AGENTS.md` (root) — repo conventions, four-file module layout,
+              tagging pattern, lifecycle ignores, tfsec suppression style.
+            - `.github/specs/_template.md` — canonical spec layout.
+            - `modules/module_template/` — starting point for new modules.
+
+            ## Output
+            Create a new branch named:
+              spec/issue-${{ steps.ctx.outputs.issue_number }}-<short-kebab-slug>
+
+            Write the spec to:
+              .github/specs/issue-${{ steps.ctx.outputs.issue_number }}-<slug>.md
+
+            The spec MUST be based on `_template.md` and MUST contain:
+              - Background
+              - Non-goals
+              - Affected module path(s)
+              - Proposed `variables.tf` / `outputs.tf` / `main.tf` shape
+                (SIGNATURES ONLY — variable names, types, descriptions,
+                resource block names. NO full implementation.)
+              - Breaking-change assessment
+              - Checkov / tfsec suppression considerations (state "none"
+                if no new suppressions are needed)
+              - terraform-docs impact (will the auto-generated README change?)
+              - Acceptance criteria
+
+            ## Commit and PR
+            - Commit message: `spec: <issue title>` with body
+              `Refs #${{ steps.ctx.outputs.issue_number }}`
+              and the Co-Authored-By line for Oz.
+            - Push the branch.
+            - Open a PR titled `spec: <issue title>`.
+            - PR body MUST include `Refs #${{ steps.ctx.outputs.issue_number }}`
+              (not `Fixes`) so the issue stays open through implementation.
+            - Apply `spec-ready-for-review` to the originating issue:
+                gh issue edit ${{ steps.ctx.outputs.issue_number }} \
+                  --repo ${{ github.repository }} \
+                  --add-label spec-ready-for-review
+                gh issue edit ${{ steps.ctx.outputs.issue_number }} \
+                  --repo ${{ github.repository }} \
+                  --remove-label spec-in-progress || true
+            - Post a comment on the issue with the spec PR URL.
+
+            Do NOT modify any Terraform files. Do NOT modify existing modules.
+            The only files you should create or modify live under
+            `.github/specs/`.
+
+      - name: On failure - drop spec-in-progress
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --remove-label spec-in-progress || true
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --body "Spec generation failed. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -25,12 +25,16 @@ jobs:
     name: Generate spec with Oz
     runs-on: ubuntu-latest
 
-    # For labeled events, only trigger on the ready-for-spec label and skip
-    # if skip-oz is set. workflow_dispatch always runs.
+    # For labeled events, only trigger on the ready-for-spec label, skip if
+    # skip-oz is set, and require a trusted issue author so untrusted issue
+    # bodies never reach the secret-backed Oz agent. workflow_dispatch is
+    # subject to the same checks at runtime via the eligibility step below.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.label.name == 'ready-for-spec' &&
-       !contains(github.event.issue.labels.*.name, 'skip-oz'))
+       !contains(github.event.issue.labels.*.name, 'skip-oz') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.issue.author_association))
 
     steps:
       # Credentials are intentionally persisted so the Oz agent can push the
@@ -66,23 +70,33 @@ jobs:
           fi
           echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
 
-      - name: Honor skip-oz on manual dispatch
-        # The job-level `if` only enforces skip-oz for the `labeled` trigger
-        # because `github.event.issue` is unavailable for workflow_dispatch.
-        # Re-check the target issue's labels here so manual dispatch respects
-        # the documented skip-oz override.
+      - name: Verify issue eligibility on manual dispatch
+        # The job-level `if` only enforces skip-oz and author_association for
+        # the `labeled` trigger because `github.event.issue` is unavailable
+        # for workflow_dispatch. Re-check both on the target issue here so
+        # manual dispatch respects the documented skip-oz override and the
+        # same trust gate that protects the labeled path.
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
         run: |
-          labels=$(gh issue view "${ISSUE_NUMBER}" \
+          issue=$(gh issue view "${ISSUE_NUMBER}" \
             --repo "${{ github.repository }}" \
-            --json labels --jq '.labels[].name')
+            --json labels,authorAssociation)
+          labels=$(printf '%s' "${issue}" | jq -r '.labels[].name')
+          assoc=$(printf '%s' "${issue}" | jq -r '.authorAssociation')
           if printf '%s\n' "${labels}" | grep -Fxq 'skip-oz'; then
             echo "::notice::Issue #${ISSUE_NUMBER} has the skip-oz label; aborting per AGENTS.md."
             exit 1
           fi
+          case "${assoc}" in
+            OWNER|MEMBER|COLLABORATOR) ;;
+            *)
+              echo "::error::Issue #${ISSUE_NUMBER} author_association=${assoc} is not in {OWNER,MEMBER,COLLABORATOR}; refusing to run the Oz agent on untrusted issue content."
+              exit 1
+              ;;
+          esac
 
       - name: Mark issue spec-in-progress
         env:

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -50,12 +50,19 @@ jobs:
             exit 1
           fi
 
-      - name: Resolve issue number
+      - name: Resolve and validate issue number
         id: ctx
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
+          # Reject anything that is not a bare positive integer to prevent
+          # GITHUB_OUTPUT injection (e.g. newlines, '=') when the value comes
+          # from a free-form workflow_dispatch input.
+          if ! printf '%s' "${ISSUE_NUMBER}" | grep -Eq '^[0-9]+$'; then
+            echo "::error::issue_number must be a positive integer; got: ${ISSUE_NUMBER}"
+            exit 1
+          fi
           echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
 
       - name: Mark issue spec-in-progress
@@ -63,12 +70,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
         run: |
+          # Keep ready-for-spec attached for now; the success step below
+          # removes it only after the agent has opened a spec PR. This way
+          # a failure mid-run does not leave the issue stuck with no
+          # actionable label.
           gh issue edit "${ISSUE_NUMBER}" \
             --repo "${{ github.repository }}" \
             --add-label spec-in-progress
-          gh issue edit "${ISSUE_NUMBER}" \
-            --repo "${{ github.repository }}" \
-            --remove-label ready-for-spec || true
 
       - name: Run Oz spec-generation agent
         uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
@@ -138,7 +146,17 @@ jobs:
             The only files you should create or modify live under
             `.github/specs/`.
 
-      - name: On failure - drop spec-in-progress
+      - name: On success - drop ready-for-spec
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --remove-label ready-for-spec || true
+
+      - name: On failure - restore ready-for-spec, drop spec-in-progress
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -147,6 +165,11 @@ jobs:
           gh issue edit "${ISSUE_NUMBER}" \
             --repo "${{ github.repository }}" \
             --remove-label spec-in-progress || true
+          # Re-attach ready-for-spec so a maintainer (or another labeled
+          # event) can retry the stage. It is idempotent.
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --add-label ready-for-spec || true
           gh issue comment "${ISSUE_NUMBER}" \
             --repo "${{ github.repository }}" \
             --body "Spec generation failed. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -56,14 +56,33 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
-          # Reject anything that is not a bare positive integer to prevent
-          # GITHUB_OUTPUT injection (e.g. newlines, '=') when the value comes
-          # from a free-form workflow_dispatch input.
-          if ! printf '%s' "${ISSUE_NUMBER}" | grep -Eq '^[0-9]+$'; then
-            echo "::error::issue_number must be a positive integer; got: ${ISSUE_NUMBER}"
+          # Reject anything that is not a bare positive integer (>= 1) to
+          # prevent GITHUB_OUTPUT injection (e.g. newlines, '=') when the
+          # value comes from a free-form workflow_dispatch input. GitHub
+          # issue numbers start at 1, so disallow 0 explicitly.
+          if ! printf '%s' "${ISSUE_NUMBER}" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::issue_number must be a positive integer (>= 1); got: ${ISSUE_NUMBER}"
             exit 1
           fi
           echo "issue_number=${ISSUE_NUMBER}" >> "${GITHUB_OUTPUT}"
+
+      - name: Honor skip-oz on manual dispatch
+        # The job-level `if` only enforces skip-oz for the `labeled` trigger
+        # because `github.event.issue` is unavailable for workflow_dispatch.
+        # Re-check the target issue's labels here so manual dispatch respects
+        # the documented skip-oz override.
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          labels=$(gh issue view "${ISSUE_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --json labels --jq '.labels[].name')
+          if printf '%s\n' "${labels}" | grep -Fxq 'skip-oz'; then
+            echo "::notice::Issue #${ISSUE_NUMBER} has the skip-oz label; aborting per AGENTS.md."
+            exit 1
+          fi
 
       - name: Mark issue spec-in-progress
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,37 @@ tags = merge(tomap({ Name = var.name }), var.tags)
 | `test.yml` | PR or push → main | Checks `terraform fmt` compliance + super-linter |
 | `scan.yml` | Scheduled (12 hrs) or manual | Checkov security scan, uploads SARIF to GitHub |
 | `release.yml` | Push of `v*.*.*` tag | Creates a GitHub release with auto-generated release notes |
+| `issue-triage.yml` | Issue opened/edited/labeled | Oz agent validates issue against minimum standards, comments + labels |
+| `spec-generation.yml` | Issue labeled `ready-for-spec` (or manual) | Oz agent opens a spec PR under `.github/specs/` |
+| `spec-approved.yml` | Spec PR merged | Flips originating issue to `spec-approved` |
+| `implementation.yml` | Issue labeled `spec-approved` (or manual) | Oz agent opens an implementation PR per the merged spec |
+
+## Automated issue/spec/impl pipeline
+
+This repo runs an Oz-powered pipeline that turns issues into reviewed specs and approved specs into implementation PRs. The full design lives in `.github/specs/issue-206-oz-issue-to-impl-workflow.md`.
+
+**Stages and the label that drives each transition**:
+
+1. Issue opened → triage agent runs.
+   - Missing required info → label `needs-info` + comment listing what's missing.
+   - Complete → label `ready-for-spec` + classification comment.
+2. `ready-for-spec` → spec-generation agent runs; opens a PR under `.github/specs/issue-<N>-<slug>.md`; issue moves to `spec-in-progress` then `spec-ready-for-review`.
+3. Spec PR merged → `spec-approved.yml` flips the issue to `spec-approved`.
+4. `spec-approved` → implementation agent runs; opens an implementation PR with `Fixes #<N>`; issue moves to `implementation-in-progress` and closes on PR merge.
+
+**Minimum standards** enforced by triage:
+
+- **Bug**: affected module path, Terraform/provider versions, repro steps, expected vs actual, one of {error, stack trace, plan/apply output}, acceptance criteria.
+- **Feature**: target module path, motivation, proposed inputs/outputs (high level), breaking-change assessment, acceptance criteria.
+
+**Overrides**:
+
+- Apply the `skip-oz` label to any issue to disable all Oz workflows for it.
+- Use `workflow_dispatch` on `spec-generation.yml` or `implementation.yml` to re-run a stage manually with an `issue_number` input.
+
+**Required repo config** (one-time): set `WARP_API_KEY` (secret), optional `WARP_AGENT_PROFILE` (variable), and create the labels listed above plus `needs-info` and `skip-oz`. Workflows fail fast with a clear error if `WARP_API_KEY` is missing, so they are safe to merge before configuration is done.
+
+**Specs directory**: see `.github/specs/README.md` for naming and `.github/specs/_template.md` for the canonical layout.
 
 ## Security Posture Philosophy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,14 +114,29 @@ tags = merge(tomap({ Name = var.name }), var.tags)
 
 This repo runs an Oz-powered pipeline that turns issues into reviewed specs and approved specs into implementation PRs. The full design lives in `.github/specs/issue-206-oz-issue-to-impl-workflow.md`.
 
+```mermaid
+stateDiagram-v2
+    [*] --> needs_info: triage finds missing info
+    [*] --> ready_for_spec: triage passes minimum standards
+    needs_info --> ready_for_spec: author edits, re-triage passes
+    ready_for_spec --> spec_in_progress: Spec Generation runs
+    spec_in_progress --> spec_ready_for_review: spec PR opened
+    spec_in_progress --> ready_for_spec: failure (label restored)
+    spec_ready_for_review --> spec_approved: codeowner merges spec PR
+    spec_approved --> implementation_in_progress: Implementation runs
+    implementation_in_progress --> [*]: implementation PR merged
+```
+
 **Stages and the label that drives each transition**:
 
-1. Issue opened → triage agent runs.
+1. Issue opened → triage agent runs (only for trusted authors; see below).
    - Missing required info → label `needs-info` + comment listing what's missing.
    - Complete → label `ready-for-spec` + classification comment.
 2. `ready-for-spec` → spec-generation agent runs; opens a PR under `.github/specs/issue-<N>-<slug>.md`; issue moves to `spec-in-progress` then `spec-ready-for-review`.
 3. Spec PR merged → `spec-approved.yml` flips the issue to `spec-approved`.
 4. `spec-approved` → implementation agent runs; opens an implementation PR with `Fixes #<N>`; issue moves to `implementation-in-progress` and closes on PR merge.
+
+**Trust gate**: the three Oz-agent workflows (`issue-triage.yml`, `spec-generation.yml`, `implementation.yml`) only run when the originating issue's `author_association` is one of `OWNER`, `MEMBER`, or `COLLABORATOR`. Issues from `CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE` will not be auto-triaged and will not advance through the pipeline until a maintainer takes manual action. This is intentional: it keeps untrusted issue bodies out of the secret-backed agent prompts.
 
 **Minimum standards** enforced by triage:
 
@@ -130,10 +145,10 @@ This repo runs an Oz-powered pipeline that turns issues into reviewed specs and 
 
 **Overrides**:
 
-- Apply the `skip-oz` label to any issue to disable all Oz workflows for it.
-- Use `workflow_dispatch` on `spec-generation.yml` or `implementation.yml` to re-run a stage manually with an `issue_number` input.
+- Apply the `skip-oz` label to any issue to disable all Oz workflows for it (label-triggered runs *and* `workflow_dispatch`).
+- Use `workflow_dispatch` on `spec-generation.yml` or `implementation.yml` to re-run a stage manually with an `issue_number` input. Manual dispatch still re-checks `skip-oz` and the trust gate at runtime.
 
-**Required repo config** (one-time): set `WARP_API_KEY` (secret), optional `WARP_AGENT_PROFILE` (variable), and create the labels listed above plus `needs-info` and `skip-oz`. Workflows fail fast with a clear error if `WARP_API_KEY` is missing, so they are safe to merge before configuration is done.
+**Required repo config** (one-time): set `WARP_API_KEY` (secret), optional `WARP_AGENT_PROFILE` (variable), and create the labels listed above plus `needs-info` and `skip-oz`. The three Oz-agent workflows fail fast with a clear error if `WARP_API_KEY` is missing, so the PR is safe to merge before configuration is done. Note: `spec-approved.yml` does *not* use `WARP_API_KEY` (it is a plain `actions/github-script` job) and will act on merged spec PRs as soon as it lands, regardless of secret configuration.
 
 **Specs directory**: see `.github/specs/README.md` for naming and `.github/specs/_template.md` for the canonical layout.
 


### PR DESCRIPTION
# Description
Introduce an Oz-powered pipeline that turns issues into reviewed specs and
approved specs into implementation PRs.

Four new GitHub Actions workflows under `.github/workflows/`:

- `issue-triage.yml` — validates issues against minimum standards and
  applies `needs-info` or `ready-for-spec`.
- `spec-generation.yml` — on `ready-for-spec`, opens a PR adding a spec
  under `.github/specs/issue-<N>-<slug>.md`.
- `spec-approved.yml` — on merged spec PR, applies `spec-approved` to
  the originating issue (pure `actions/github-script`; no agent call).
- `implementation.yml` — on `spec-approved`, reads the spec from `main`
  and opens an implementation PR with `Fixes #<N>`.

Plus:

- `.github/specs/README.md` and `.github/specs/_template.md` defining the
  canonical spec layout and naming.
- `.github/specs/issue-206-oz-issue-to-impl-workflow.md` — the spec for
  this very PR, kept in-repo for traceability.
- Explicit `/.github/specs/` entry in `CODEOWNERS`.
- New "Automated issue/spec/impl pipeline" section in `AGENTS.md`.

## Issue or Ticket
Refs #206

## Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Version update

## Breaking Changes
- [ ] Yes
- [x] No

### Breaking Changes Description
No existing workflow, module, or template is modified. Until `WARP_API_KEY`
is configured, the four new workflows fail fast in their guard step and do
not change any issue or PR state — so this PR is safe to merge before
secrets/labels are set up.

## TODOs
- [x] Validate your code matches the style of the project.
- [x] Update the docs (`AGENTS.md`, new `.github/specs/README.md`).
- [x] Validate all tests run successfully, including pre-commit checks
      (no `.tf` changes; YAML parses cleanly).
- [x] Include release notes and description.

## Post-merge configuration (one-time)
After merge, these are still required to actually run the pipeline:

1. **Secret**: set `WARP_API_KEY` in repository secrets.
2. **Variable** (optional): set `WARP_AGENT_PROFILE`.
3. **Labels**: create the following with:
   ```sh
   gh label create needs-info                  --description "Issue is missing required information" --color "fbca04"
   gh label create ready-for-spec              --description "Issue passed triage; ready for spec authoring" --color "0e8a16"
   gh label create spec-in-progress            --description "Spec generation is running" --color "0052cc"
   gh label create spec-ready-for-review       --description "Spec PR open and awaiting codeowner review" --color "5319e7"
   gh label create spec-approved               --description "Spec merged; ready for implementation" --color "0e8a16"
   gh label create implementation-in-progress  --description "Implementation agent is running" --color "0052cc"
   gh label create skip-oz                     --description "Disable all Oz workflows for this issue" --color "cccccc"
   ```

## Related
- Spec: `.github/specs/issue-206-oz-issue-to-impl-workflow.md`
- Conversation: https://app.warp.dev/conversation/6ee52e79-e52f-41b6-9d75-d9093175f5c7

Co-Authored-By: Oz <oz-agent@warp.dev>
