### PR TITLE
fix(automation): restore Oz pipeline cascade; correct gh api field

### DIFF
--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -81,11 +81,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
         run: |
-          issue=$(gh issue view "${ISSUE_NUMBER}" \
-            --repo "${{ github.repository }}" \
-            --json labels,authorAssociation)
+          # gh issue view does not expose authorAssociation; use the REST
+          # API directly so we can read .author_association (snake_case).
+          issue=$(gh api "/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}")
           labels=$(printf '%s' "${issue}" | jq -r '.labels[].name')
-          assoc=$(printf '%s' "${issue}" | jq -r '.authorAssociation')
+          assoc=$(printf '%s' "${issue}" | jq -r '.author_association')
           if printf '%s\n' "${labels}" | grep -Fxq 'skip-oz'; then
             echo "::notice::Issue #${ISSUE_NUMBER} has the skip-oz label; aborting per AGENTS.md."
             exit 1

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,6 +12,11 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  # Needed to dispatch the spec-generation workflow as the next stage when
+  # the agent applies `ready-for-spec`. Label events from GITHUB_TOKEN do
+  # not cascade to other workflows, but workflow_dispatch events from
+  # GITHUB_TOKEN do, which is how this chain is restored.
+  actions: write
 
 jobs:
   triage:
@@ -128,3 +133,30 @@ jobs:
             Do not edit any files. Do not push commits. Do not open PRs.
             Do not invoke `terraform`. Your only side effects are issue
             comments and label changes via `gh`.
+
+      - name: Chain to Spec Generation if ready-for-spec was applied
+        # Labels applied with GITHUB_TOKEN do not trigger downstream
+        # workflows (intentional GitHub safeguard against loops), so the
+        # ready-for-spec label that the triage agent just added would not
+        # by itself fire `spec-generation.yml`. Explicitly dispatch the
+        # next stage here. workflow_dispatch events from GITHUB_TOKEN are
+        # allowed to start new runs.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          labels=$(gh api "/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" \
+            --jq '.labels[].name')
+          if printf '%s\n' "${labels}" | grep -Fxq 'skip-oz'; then
+            echo "::notice::Issue #${ISSUE_NUMBER} has skip-oz; not chaining."
+            exit 0
+          fi
+          if ! printf '%s\n' "${labels}" | grep -Fxq 'ready-for-spec'; then
+            echo "::notice::Issue #${ISSUE_NUMBER} did not end up ready-for-spec; not chaining."
+            exit 0
+          fi
+          echo "::notice::Dispatching Spec Generation (Oz) for #${ISSUE_NUMBER}"
+          gh workflow run spec-generation.yml \
+            --repo "${{ github.repository }}" \
+            --field issue_number="${ISSUE_NUMBER}"

--- a/.github/workflows/spec-approved.yml
+++ b/.github/workflows/spec-approved.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+  # Needed to dispatch implementation.yml after applying spec-approved.
+  # Label events from GITHUB_TOKEN do not cascade; workflow_dispatch events
+  # do, so we trigger the next stage explicitly.
+  actions: write
 
 jobs:
   flip-labels:
@@ -102,13 +106,25 @@ jobs:
                   }
                 }
               }
+              // Explicitly dispatch implementation.yml. Labels applied via
+              // GITHUB_TOKEN do not trigger downstream workflows, but
+              // workflow_dispatch events from GITHUB_TOKEN do, so we
+              // trigger the next stage here.
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner, repo,
+                  workflow_id: "implementation.yml",
+                  ref: "main",
+                  inputs: { issue_number: String(issueNumber) },
+                });
+                core.notice(`Dispatched Implementation (Oz) for #${issueNumber}`);
+              } catch (e) {
+                core.warning(`Failed to dispatch Implementation (Oz) for #${issueNumber}: ${e.message}`);
+              }
+
               // Comment on the issue with a link to the merged spec PR.
-              // The `spec-approved` label was just applied by this workflow,
-              // which will fire the `issues:labeled` trigger for the
-              // Implementation (Oz) workflow automatically. If it does not
-              // start, codeowners can re-run it manually via workflow_dispatch.
               await github.rest.issues.createComment({
                 owner, repo, issue_number: issueNumber,
-                body: `Spec approved and merged in #${prNumber}. The Implementation (Oz) workflow will start automatically; re-run it manually via workflow_dispatch with this issue number if needed.`,
+                body: `Spec approved and merged in #${prNumber}. Implementation (Oz) has been dispatched and will run shortly; re-run it manually via workflow_dispatch with this issue number if needed.`,
               });
             }

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -81,11 +81,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
         run: |
-          issue=$(gh issue view "${ISSUE_NUMBER}" \
-            --repo "${{ github.repository }}" \
-            --json labels,authorAssociation)
+          # gh issue view does not expose authorAssociation; use the REST
+          # API directly so we can read .author_association (snake_case).
+          issue=$(gh api "/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}")
           labels=$(printf '%s' "${issue}" | jq -r '.labels[].name')
-          assoc=$(printf '%s' "${issue}" | jq -r '.authorAssociation')
+          assoc=$(printf '%s' "${issue}" | jq -r '.author_association')
           if printf '%s\n' "${labels}" | grep -Fxq 'skip-oz'; then
             echo "::notice::Issue #${ISSUE_NUMBER} has the skip-oz label; aborting per AGENTS.md."
             exit 1


### PR DESCRIPTION
fix(automation): restore Oz pipeline cascade; correct gh api field

Two bugs uncovered by the post-merge end-to-end test (#206 pipeline).

1. `gh issue view --json authorAssociation` is invalid
   The "Verify issue eligibility on manual dispatch" step in
   spec-generation.yml and implementation.yml asked `gh issue view` for
   a JSON field it does not expose. The available fields are
   `assignees, author, body, …, labels, …` — there is no
   `authorAssociation`. Switch to `gh api /repos/.../issues/N` and read
   `.author_association` (snake_case REST field).

2. GITHUB_TOKEN-driven label events do not cascade
   GitHub deliberately suppresses workflow chains triggered by labels
   applied via `GITHUB_TOKEN`. As a result:
   - `issue-triage.yml` applying `ready-for-spec` did not start
     `spec-generation.yml`.
   - `spec-approved.yml` applying `spec-approved` did not start
     `implementation.yml`.
   `workflow_dispatch` events triggered via `GITHUB_TOKEN` ARE allowed
   to start new runs, so:
   - `issue-triage.yml` now ends with a "Chain to Spec Generation"
     step that calls `gh workflow run spec-generation.yml --field
     issue_number=N` when `ready-for-spec` ended up on the issue and
     `skip-oz` is absent.
   - `spec-approved.yml` now calls
     `github.rest.actions.createWorkflowDispatch` for
     implementation.yml after applying `spec-approved`, in the same
     github-script step.

Both files gain a `actions: write` permission to allow dispatching
sibling workflows.

Manual maintainer-applied labels still trigger the labeled events as
before; the new chains are additive, deduplicated by the existing
concurrency groups.

Refs #206

Co-Authored-By: Oz <oz-agent@warp.dev>
