### PR TITLE
fix(automation): open Oz-authored PRs ready-for-review

### DIFF
--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -169,15 +169,42 @@ jobs:
               for bugs.
             - Commit messages follow conventional-commit style and include
               a Co-Authored-By line for Oz.
-            - Open a PR titled per the spec's title. The PR body MUST fill
-              in the existing `.github/pull_request_template.md` sections
-              (Description, Issue or Ticket with `Fixes #${{ steps.ctx.outputs.issue_number }}`,
+            - Open the PR as **ready-for-review** (NOT a draft) so that
+              CODEOWNERS are auto-assigned via the `pull_request:
+              ready_for_review` event. If your tooling defaults to draft,
+              flip it to ready before exiting. The workflow also runs a
+              post-step that calls `gh pr ready` as a safety net.
+            - Title: per the spec. The PR body MUST fill in the existing
+              `.github/pull_request_template.md` sections (Description,
+              Issue or Ticket with `Fixes #${{ steps.ctx.outputs.issue_number }}`,
               Type of change, Breaking Changes, TODOs).
             - Post a comment on the originating issue with the PR URL.
 
             Implementation PRs go through the same CI as any other PR
             (`build.yml`, `test.yml`, `scan.yml`). Do not attempt to
             bypass any check.
+
+      - name: Mark implementation PR ready-for-review
+        # The Oz agent action tends to open PRs as drafts when invoked from
+        # automation, which suppresses GitHub's CODEOWNERS auto-request.
+        # Locate the newly-opened implementation PR by branch prefix
+        # (feat/issue-N-* or fix/issue-N-*) and flip it to ready-for-review.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          pr_number=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,headRefName,isDraft \
+            --jq "[.[] | select(.headRefName | startswith(\"feat/issue-${ISSUE_NUMBER}-\") or startswith(\"fix/issue-${ISSUE_NUMBER}-\")) | .number] | max // empty")
+          if [ -z "${pr_number}" ]; then
+            echo "::warning::No open implementation PR matching 'feat/issue-${ISSUE_NUMBER}-*' or 'fix/issue-${ISSUE_NUMBER}-*' found; skipping pr ready."
+            exit 0
+          fi
+          echo "::notice::Marking implementation PR #${pr_number} ready-for-review."
+          gh pr ready "${pr_number}" --repo "${{ github.repository }}" || true
 
       - name: On failure - drop implementation-in-progress
         if: failure()

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -187,8 +187,12 @@ jobs:
       - name: Mark implementation PR ready-for-review
         # The Oz agent action tends to open PRs as drafts when invoked from
         # automation, which suppresses GitHub's CODEOWNERS auto-request.
-        # Locate the newly-opened implementation PR by branch prefix
-        # (feat/issue-N-* or fix/issue-N-*) and flip it to ready-for-review.
+        # Find the freshly-created draft implementation PR (branch prefix
+        # `feat/issue-N-` or `fix/issue-N-`, isDraft=true,
+        # most-recently-created) and flip it to ready-for-review.
+        # Filtering on `isDraft == true` ensures we never re-flip a stale
+        # ready PR; sorting by `createdAt` ensures we target the current
+        # run's PR even if PR numbers raced.
         if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -197,10 +201,10 @@ jobs:
           pr_number=$(gh pr list \
             --repo "${{ github.repository }}" \
             --state open \
-            --json number,headRefName,isDraft \
-            --jq "[.[] | select(.headRefName | startswith(\"feat/issue-${ISSUE_NUMBER}-\") or startswith(\"fix/issue-${ISSUE_NUMBER}-\")) | .number] | max // empty")
+            --json number,headRefName,isDraft,createdAt \
+            --jq "[.[] | select(.isDraft == true and ((.headRefName | startswith(\"feat/issue-${ISSUE_NUMBER}-\")) or (.headRefName | startswith(\"fix/issue-${ISSUE_NUMBER}-\"))))] | sort_by(.createdAt) | last | .number // empty")
           if [ -z "${pr_number}" ]; then
-            echo "::warning::No open implementation PR matching 'feat/issue-${ISSUE_NUMBER}-*' or 'fix/issue-${ISSUE_NUMBER}-*' found; skipping pr ready."
+            echo "::notice::No open *draft* implementation PR matching 'feat/issue-${ISSUE_NUMBER}-*' or 'fix/issue-${ISSUE_NUMBER}-*' found; nothing to flip."
             exit 0
           fi
           echo "::notice::Marking implementation PR #${pr_number} ready-for-review."

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -187,8 +187,11 @@ jobs:
       - name: Mark spec PR ready-for-review
         # The Oz agent action tends to open PRs as drafts when invoked from
         # automation, which suppresses GitHub's CODEOWNERS auto-request.
-        # Locate the newly-opened spec PR by branch prefix and flip it to
-        # ready-for-review so reviewers get pinged.
+        # Find the freshly-created draft spec PR (branch prefix
+        # `spec/issue-N-`, isDraft=true, most-recently-created) and flip it
+        # to ready-for-review. Filtering on `isDraft == true` ensures we
+        # never re-flip a stale ready PR; sorting by `createdAt` ensures
+        # we target the current run's PR even if PR numbers raced.
         if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -197,10 +200,10 @@ jobs:
           pr_number=$(gh pr list \
             --repo "${{ github.repository }}" \
             --state open \
-            --json number,headRefName,isDraft \
-            --jq "[.[] | select(.headRefName | startswith(\"spec/issue-${ISSUE_NUMBER}-\")) | .number] | max // empty")
+            --json number,headRefName,isDraft,createdAt \
+            --jq "[.[] | select(.isDraft == true and (.headRefName | startswith(\"spec/issue-${ISSUE_NUMBER}-\")))] | sort_by(.createdAt) | last | .number // empty")
           if [ -z "${pr_number}" ]; then
-            echo "::warning::No open spec PR matching 'spec/issue-${ISSUE_NUMBER}-*' found; skipping pr ready."
+            echo "::notice::No open *draft* spec PR matching 'spec/issue-${ISSUE_NUMBER}-*' found; nothing to flip."
             exit 0
           fi
           echo "::notice::Marking spec PR #${pr_number} ready-for-review."

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -163,7 +163,12 @@ jobs:
               `Refs #${{ steps.ctx.outputs.issue_number }}`
               and the Co-Authored-By line for Oz.
             - Push the branch.
-            - Open a PR titled `spec: <issue title>`.
+            - Open the PR as **ready-for-review** (NOT a draft) so that
+              CODEOWNERS are auto-assigned via the `pull_request:
+              ready_for_review` event. If your tooling defaults to draft,
+              flip it to ready before exiting. The workflow also runs a
+              post-step that calls `gh pr ready` as a safety net.
+            - Title: `spec: <issue title>`.
             - PR body MUST include `Refs #${{ steps.ctx.outputs.issue_number }}`
               (not `Fixes`) so the issue stays open through implementation.
             - Apply `spec-ready-for-review` to the originating issue:
@@ -178,6 +183,28 @@ jobs:
             Do NOT modify any Terraform files. Do NOT modify existing modules.
             The only files you should create or modify live under
             `.github/specs/`.
+
+      - name: Mark spec PR ready-for-review
+        # The Oz agent action tends to open PRs as drafts when invoked from
+        # automation, which suppresses GitHub's CODEOWNERS auto-request.
+        # Locate the newly-opened spec PR by branch prefix and flip it to
+        # ready-for-review so reviewers get pinged.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          pr_number=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,headRefName,isDraft \
+            --jq "[.[] | select(.headRefName | startswith(\"spec/issue-${ISSUE_NUMBER}-\")) | .number] | max // empty")
+          if [ -z "${pr_number}" ]; then
+            echo "::warning::No open spec PR matching 'spec/issue-${ISSUE_NUMBER}-*' found; skipping pr ready."
+            exit 0
+          fi
+          echo "::notice::Marking spec PR #${pr_number} ready-for-review."
+          gh pr ready "${pr_number}" --repo "${{ github.repository }}" || true
 
       - name: On success - drop ready-for-spec
         if: success()


### PR DESCRIPTION
fix(automation): open Oz-authored PRs ready-for-review

The Oz agent action opens new PRs as drafts when invoked from
automation. Draft PRs do not trigger GitHub's CODEOWNERS auto-request,
so reviewers never get pinged unless someone manually marks the PR
ready. Observed on the test pipeline: spec PR #212 and implementation
PR #213 both opened as drafts with no reviewers requested.

Two-pronged fix in spec-generation.yml and implementation.yml:

- **Prompt instruction**: Explicitly tell the agent to open PRs as
  ready-for-review and flip from draft to ready before exiting if its
  tooling defaults to draft.
- **Defensive post-step**: After the agent step, list open PRs whose
  head branch starts with the expected prefix
  (`spec/issue-N-` for spec-generation; `feat/issue-N-` or
  `fix/issue-N-` for implementation) and call `gh pr ready` on the
  highest-numbered match. Works even if the agent ignores the prompt
  instruction.

Refs #206

Co-Authored-By: Oz <oz-agent@warp.dev>
