### PR TITLE
feat: add s3/access_log_bucket module (DEVSECOPS-37)

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -41,6 +41,10 @@ skip-check:
   # Transfer Server module supports public exposure as a caller-controlled variable
   - CKV_AWS_164
 
+  # S3 access_log_bucket requires ACLs enabled: the AWS log delivery service cannot write
+  # to buckets with ACLs disabled; BucketOwnerPreferred + log-delivery-write ACL is required
+  - CKV2_AWS_65
+
   # ============================================================
   # CONFIGURABLE BY CALLER: Checkov cannot see variable values
   # These modules expose the flagged settings as input variables.

--- a/modules/aws/s3/access_log_bucket/README.md
+++ b/modules/aws/s3/access_log_bucket/README.md
@@ -94,3 +94,55 @@ module "my_bucket" {
 | bucket_arn | ARN of the S3 access log bucket |
 | bucket_domain_name | Bucket domain name (`<bucket>.s3.amazonaws.com`) |
 | bucket_regional_domain_name | Region-specific bucket domain name (`<bucket>.s3.<region>.amazonaws.com`) |
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | (Required) Fixed name for the centralized S3 access log bucket. Used as a fixed name (not prefix) to support import capability. Must be lowercase, 3–63 characters. | `string` | n/a | yes |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | (Optional) When true, all objects (including locked objects) are deleted from the bucket when the bucket is destroyed so that the bucket can be destroyed without error. Defaults to false. | `bool` | `false` | no |
+| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | (Optional) Enable versioning on the access log bucket. When enabled, multiple versions of objects are retained. Defaults to false. | `bool` | `false` | no |
+| <a name="input_lifecycle_rules"></a> [lifecycle\_rules](#input\_lifecycle\_rules) | (Optional) Configuration of object lifecycle management. Can have several rules as a list of maps where each map is the lifecycle rule configuration. Set to null to disable lifecycle rules. | `any` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | ARN of the S3 access log bucket |
+| <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | Bucket domain name in the format: <bucket>.s3.amazonaws.com |
+| <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | Name (ID) of the S3 access log bucket |
+| <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | Bucket region-specific domain name in the format: <bucket>.s3.<region>.amazonaws.com |
+<!-- END_TF_DOCS -->

--- a/modules/aws/s3/access_log_bucket/README.md
+++ b/modules/aws/s3/access_log_bucket/README.md
@@ -1,12 +1,12 @@
 # S3 Access Log Bucket Module
 
-This module creates a centralized S3 bucket configured as the **destination** for S3 server access logs. It enforces the constraints required by the AWS S3 log delivery service:
+This module creates a centralized S3 bucket configured as the **destination** for S3 server access logs. It wraps the `s3/bucket` module and enforces the constraints required by the AWS S3 log delivery service:
 
 - **SSE-S3 (AES256)** encryption — the S3 log delivery service does not support SSE-KMS on target buckets.
 - **`BucketOwnerPreferred`** ownership controls — required for the `log-delivery-write` ACL grant.
 - **`log-delivery-write`** ACL — grants the AWS S3 log delivery group write permissions.
 - All public access blocked.
-- SSL-only bucket policy with an explicit allow for `logging.s3.amazonaws.com`.
+- SSL enforcement with an explicit allow for `logging.s3.amazonaws.com`.
 
 Source buckets should use the existing `s3/bucket` module with `enable_s3_bucket_logging = true` and `logging_target_bucket = <this bucket name>` to direct their logs here.
 
@@ -62,19 +62,17 @@ module "my_bucket" {
 |------|---------|
 | aws | >= 6.0.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | ../bucket | n/a |
+
 ## Resources
 
 | Name | Type |
 |------|------|
-| aws_s3_bucket.this | resource |
-| aws_s3_bucket_ownership_controls.this | resource |
-| aws_s3_bucket_acl.this | resource |
-| aws_s3_bucket_server_side_encryption_configuration.this | resource |
-| aws_s3_bucket_public_access_block.this | resource |
-| aws_s3_bucket_lifecycle_configuration.this | resource |
-| aws_s3_bucket_versioning.this | resource |
-| aws_s3_bucket_policy.this | resource |
-| aws_iam_policy_document.this | data source |
+| aws_iam_policy_document.log_delivery | data source |
 
 ## Inputs
 
@@ -92,8 +90,7 @@ module "my_bucket" {
 |------|-------------|
 | bucket_id | Name (ID) of the S3 access log bucket |
 | bucket_arn | ARN of the S3 access log bucket |
-| bucket_domain_name | Bucket domain name (`<bucket>.s3.amazonaws.com`) |
-| bucket_regional_domain_name | Region-specific bucket domain name (`<bucket>.s3.<region>.amazonaws.com`) |
+| bucket_region | Region of the S3 access log bucket |
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -111,21 +108,15 @@ module "my_bucket" {
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_this"></a> [this](#module\_this) | ../bucket | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
-| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
-| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -142,7 +133,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | ARN of the S3 access log bucket |
-| <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | Bucket domain name in the format: <bucket>.s3.amazonaws.com |
 | <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | Name (ID) of the S3 access log bucket |
-| <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | Bucket region-specific domain name in the format: <bucket>.s3.<region>.amazonaws.com |
+| <a name="output_bucket_region"></a> [bucket\_region](#output\_bucket\_region) | Region of the S3 access log bucket |
 <!-- END_TF_DOCS -->

--- a/modules/aws/s3/access_log_bucket/README.md
+++ b/modules/aws/s3/access_log_bucket/README.md
@@ -1,0 +1,96 @@
+# S3 Access Log Bucket Module
+
+This module creates a centralized S3 bucket configured as the **destination** for S3 server access logs. It enforces the constraints required by the AWS S3 log delivery service:
+
+- **SSE-S3 (AES256)** encryption — the S3 log delivery service does not support SSE-KMS on target buckets.
+- **`BucketOwnerPreferred`** ownership controls — required for the `log-delivery-write` ACL grant.
+- **`log-delivery-write`** ACL — grants the AWS S3 log delivery group write permissions.
+- All public access blocked.
+- SSL-only bucket policy with an explicit allow for `logging.s3.amazonaws.com`.
+
+Source buckets should use the existing `s3/bucket` module with `enable_s3_bucket_logging = true` and `logging_target_bucket = <this bucket name>` to direct their logs here.
+
+## Usage
+
+```hcl
+module "s3_access_logs" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/s3/access_log_bucket"
+
+  bucket = "my-org-s3-access-logs"
+
+  lifecycle_rules = [
+    {
+      id     = "expire-logs"
+      status = "Enabled"
+      expiration = {
+        days = 365
+      }
+    }
+  ]
+
+  tags = {
+    created_by  = "terraform"
+    environment = "prod"
+    terraform   = "true"
+  }
+}
+```
+
+To point a source bucket at this log bucket:
+
+```hcl
+module "my_bucket" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/s3/bucket"
+
+  bucket                   = "my-application-bucket"
+  enable_s3_bucket_logging = true
+  logging_target_bucket    = module.s3_access_logs.bucket_id
+  logging_target_prefix    = "my-application-bucket/"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0.0 |
+| aws | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 6.0.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| aws_s3_bucket.this | resource |
+| aws_s3_bucket_ownership_controls.this | resource |
+| aws_s3_bucket_acl.this | resource |
+| aws_s3_bucket_server_side_encryption_configuration.this | resource |
+| aws_s3_bucket_public_access_block.this | resource |
+| aws_s3_bucket_lifecycle_configuration.this | resource |
+| aws_s3_bucket_versioning.this | resource |
+| aws_s3_bucket_policy.this | resource |
+| aws_iam_policy_document.this | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| bucket | Fixed name for the centralized S3 access log bucket. | `string` | n/a | yes |
+| bucket_force_destroy | When true, all objects are deleted from the bucket on destroy. | `bool` | `false` | no |
+| enable_versioning | Enable versioning on the access log bucket. | `bool` | `false` | no |
+| lifecycle_rules | List of lifecycle rule configuration maps. Set to null to disable. | `any` | `null` | no |
+| tags | A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| bucket_id | Name (ID) of the S3 access log bucket |
+| bucket_arn | ARN of the S3 access log bucket |
+| bucket_domain_name | Bucket domain name (`<bucket>.s3.amazonaws.com`) |
+| bucket_regional_domain_name | Region-specific bucket domain name (`<bucket>.s3.<region>.amazonaws.com`) |

--- a/modules/aws/s3/access_log_bucket/main.tf
+++ b/modules/aws/s3/access_log_bucket/main.tf
@@ -13,169 +13,14 @@ terraform {
 # S3 Access Log Bucket
 ###########################
 
-resource "aws_s3_bucket" "this" {
-  bucket        = var.bucket
-  force_destroy = var.bucket_force_destroy
-  tags          = var.tags
-}
-
-resource "aws_s3_bucket_ownership_controls" "this" {
-  bucket = aws_s3_bucket.this.id
-
-  rule {
-    # BucketOwnerPreferred is required for log-delivery-write ACL to function correctly
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
-resource "aws_s3_bucket_acl" "this" {
-  # log-delivery-write grants the S3 log delivery group write permissions
-  depends_on = [aws_s3_bucket_ownership_controls.this]
-  bucket     = aws_s3_bucket.this.id
-  acl        = "log-delivery-write"
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
-  bucket = aws_s3_bucket.this.bucket
-
-  rule {
-    apply_server_side_encryption_by_default {
-      # SSE-S3 (AES256) is required — the S3 log delivery service does not support SSE-KMS on target buckets
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "this" {
-  bucket = aws_s3_bucket.this.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-###########################
-# Lifecycle Configuration
-###########################
-
-resource "aws_s3_bucket_lifecycle_configuration" "this" {
-  count  = var.lifecycle_rules == null ? 0 : 1
-  bucket = aws_s3_bucket.this.id
-
-  dynamic "rule" {
-    for_each = var.lifecycle_rules
-    content {
-      id     = rule.value.id
-      status = rule.value.status
-
-      dynamic "abort_incomplete_multipart_upload" {
-        for_each = try(flatten([rule.value.abort_incomplete_multipart_upload]), [])
-        content {
-          days_after_initiation = try(abort_incomplete_multipart_upload.value.days_after_initiation, null)
-        }
-      }
-
-      dynamic "expiration" {
-        for_each = try(flatten([rule.value.expiration]), [])
-        content {
-          date                         = try(expiration.value.date, null)
-          days                         = try(expiration.value.days, null)
-          expired_object_delete_marker = try(expiration.value.expired_object_delete_marker, null)
-        }
-      }
-
-      dynamic "filter" {
-        for_each = try(flatten([rule.value.filter]), [])
-        content {
-          object_size_greater_than = try(filter.value.object_size_greater_than, null)
-          object_size_less_than    = try(filter.value.object_size_less_than, null)
-          prefix                   = try(filter.value.prefix, null)
-          dynamic "tag" {
-            for_each = try(rule.value.filter.tag, [])
-            content {
-              key   = tag.value.key
-              value = tag.value.value
-            }
-          }
-        }
-      }
-
-      dynamic "noncurrent_version_expiration" {
-        for_each = try(flatten([rule.value.noncurrent_version_expiration]), [])
-        content {
-          newer_noncurrent_versions = try(noncurrent_version_expiration.value.newer_noncurrent_versions, null)
-          noncurrent_days           = try(noncurrent_version_expiration.value.noncurrent_days, null)
-        }
-      }
-
-      dynamic "noncurrent_version_transition" {
-        for_each = try(rule.value.noncurrent_version_transition, [])
-        content {
-          newer_noncurrent_versions = try(noncurrent_version_transition.value.newer_noncurrent_versions, null)
-          noncurrent_days           = try(noncurrent_version_transition.value.noncurrent_days, null)
-          storage_class             = try(noncurrent_version_transition.value.storage_class, null)
-        }
-      }
-
-      dynamic "transition" {
-        for_each = try(rule.value.transition, [])
-        content {
-          date          = try(transition.value.date, null)
-          days          = try(transition.value.days, null)
-          storage_class = try(transition.value.storage_class, null)
-        }
-      }
-    }
-  }
-}
-
-###########################
-# Versioning (Optional)
-###########################
-
-resource "aws_s3_bucket_versioning" "this" {
-  count  = var.enable_versioning ? 1 : 0
-  bucket = aws_s3_bucket.this.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-###########################
-# Bucket Policy
-###########################
-
-data "aws_iam_policy_document" "this" {
-  statement {
-    sid     = "DenyInsecureTransport"
-    effect  = "Deny"
-    actions = ["s3:*"]
-
-    resources = [
-      aws_s3_bucket.this.arn,
-      "${aws_s3_bucket.this.arn}/*",
-    ]
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["false"]
-    }
-  }
-
+data "aws_iam_policy_document" "log_delivery" {
   statement {
     sid     = "AllowS3LogDelivery"
     effect  = "Allow"
     actions = ["s3:PutObject"]
 
-    resources = ["${aws_s3_bucket.this.arn}/*"]
+    # Bucket ARN is deterministic for S3 — constructed from the fixed bucket name
+    resources = ["arn:aws:s3:::${var.bucket}/*"]
 
     principals {
       type        = "Service"
@@ -184,7 +29,30 @@ data "aws_iam_policy_document" "this" {
   }
 }
 
-resource "aws_s3_bucket_policy" "this" {
-  bucket = aws_s3_bucket.this.id
-  policy = data.aws_iam_policy_document.this.json
+module "this" {
+  source = "../bucket"
+
+  bucket               = var.bucket
+  bucket_force_destroy = var.bucket_force_destroy
+
+  # BucketOwnerPreferred + log-delivery-write ACL required by the S3 log delivery service
+  object_ownership = "BucketOwnerPreferred"
+  acl              = "log-delivery-write"
+
+  # SSE-S3 (AES256) required — S3 log delivery does not support SSE-KMS on target buckets
+  sse_algorithm      = "AES256"
+  enable_kms_key     = false
+  bucket_key_enabled = false
+
+  # Enforce SSL; merge with the log-delivery allow statement above
+  enforce_ssl   = true
+  bucket_policy = data.aws_iam_policy_document.log_delivery.json
+
+  # Block all public access
+  enable_public_access_block = true
+
+  lifecycle_rules   = var.lifecycle_rules
+  versioning_status = var.enable_versioning ? "Enabled" : "Disabled"
+
+  tags = var.tags
 }

--- a/modules/aws/s3/access_log_bucket/main.tf
+++ b/modules/aws/s3/access_log_bucket/main.tf
@@ -1,0 +1,190 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+###########################
+# S3 Access Log Bucket
+###########################
+
+resource "aws_s3_bucket" "this" {
+  bucket        = var.bucket
+  force_destroy = var.bucket_force_destroy
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    # BucketOwnerPreferred is required for log-delivery-write ACL to function correctly
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "this" {
+  # log-delivery-write grants the S3 log delivery group write permissions
+  depends_on = [aws_s3_bucket_ownership_controls.this]
+  bucket     = aws_s3_bucket.this.id
+  acl        = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      # SSE-S3 (AES256) is required — the S3 log delivery service does not support SSE-KMS on target buckets
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+###########################
+# Lifecycle Configuration
+###########################
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  count  = var.lifecycle_rules == null ? 0 : 1
+  bucket = aws_s3_bucket.this.id
+
+  dynamic "rule" {
+    for_each = var.lifecycle_rules
+    content {
+      id     = rule.value.id
+      status = rule.value.status
+
+      dynamic "abort_incomplete_multipart_upload" {
+        for_each = try(flatten([rule.value.abort_incomplete_multipart_upload]), [])
+        content {
+          days_after_initiation = try(abort_incomplete_multipart_upload.value.days_after_initiation, null)
+        }
+      }
+
+      dynamic "expiration" {
+        for_each = try(flatten([rule.value.expiration]), [])
+        content {
+          date                         = try(expiration.value.date, null)
+          days                         = try(expiration.value.days, null)
+          expired_object_delete_marker = try(expiration.value.expired_object_delete_marker, null)
+        }
+      }
+
+      dynamic "filter" {
+        for_each = try(flatten([rule.value.filter]), [])
+        content {
+          object_size_greater_than = try(filter.value.object_size_greater_than, null)
+          object_size_less_than    = try(filter.value.object_size_less_than, null)
+          prefix                   = try(filter.value.prefix, null)
+          dynamic "tag" {
+            for_each = try(rule.value.filter.tag, [])
+            content {
+              key   = tag.value.key
+              value = tag.value.value
+            }
+          }
+        }
+      }
+
+      dynamic "noncurrent_version_expiration" {
+        for_each = try(flatten([rule.value.noncurrent_version_expiration]), [])
+        content {
+          newer_noncurrent_versions = try(noncurrent_version_expiration.value.newer_noncurrent_versions, null)
+          noncurrent_days           = try(noncurrent_version_expiration.value.noncurrent_days, null)
+        }
+      }
+
+      dynamic "noncurrent_version_transition" {
+        for_each = try(rule.value.noncurrent_version_transition, [])
+        content {
+          newer_noncurrent_versions = try(noncurrent_version_transition.value.newer_noncurrent_versions, null)
+          noncurrent_days           = try(noncurrent_version_transition.value.noncurrent_days, null)
+          storage_class             = try(noncurrent_version_transition.value.storage_class, null)
+        }
+      }
+
+      dynamic "transition" {
+        for_each = try(rule.value.transition, [])
+        content {
+          date          = try(transition.value.date, null)
+          days          = try(transition.value.days, null)
+          storage_class = try(transition.value.storage_class, null)
+        }
+      }
+    }
+  }
+}
+
+###########################
+# Versioning (Optional)
+###########################
+
+resource "aws_s3_bucket_versioning" "this" {
+  count  = var.enable_versioning ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+###########################
+# Bucket Policy
+###########################
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.this.arn,
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+
+  statement {
+    sid     = "AllowS3LogDelivery"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.this.json
+}

--- a/modules/aws/s3/access_log_bucket/outputs.tf
+++ b/modules/aws/s3/access_log_bucket/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_id" {
+  description = "Name (ID) of the S3 access log bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 access log bucket"
+  value       = aws_s3_bucket.this.arn
+}
+
+output "bucket_domain_name" {
+  description = "Bucket domain name in the format: <bucket>.s3.amazonaws.com"
+  value       = aws_s3_bucket.this.bucket_domain_name
+}
+
+output "bucket_regional_domain_name" {
+  description = "Bucket region-specific domain name in the format: <bucket>.s3.<region>.amazonaws.com"
+  value       = aws_s3_bucket.this.bucket_regional_domain_name
+}

--- a/modules/aws/s3/access_log_bucket/outputs.tf
+++ b/modules/aws/s3/access_log_bucket/outputs.tf
@@ -1,19 +1,14 @@
 output "bucket_id" {
   description = "Name (ID) of the S3 access log bucket"
-  value       = aws_s3_bucket.this.id
+  value       = module.this.s3_bucket_id
 }
 
 output "bucket_arn" {
   description = "ARN of the S3 access log bucket"
-  value       = aws_s3_bucket.this.arn
+  value       = module.this.s3_bucket_arn
 }
 
-output "bucket_domain_name" {
-  description = "Bucket domain name in the format: <bucket>.s3.amazonaws.com"
-  value       = aws_s3_bucket.this.bucket_domain_name
-}
-
-output "bucket_regional_domain_name" {
-  description = "Bucket region-specific domain name in the format: <bucket>.s3.<region>.amazonaws.com"
-  value       = aws_s3_bucket.this.bucket_regional_domain_name
+output "bucket_region" {
+  description = "Region of the S3 access log bucket"
+  value       = module.this.s3_bucket_region
 }

--- a/modules/aws/s3/access_log_bucket/variables.tf
+++ b/modules/aws/s3/access_log_bucket/variables.tf
@@ -1,0 +1,56 @@
+###########################
+# S3 Bucket Variables
+###########################
+
+variable "bucket" {
+  type        = string
+  description = "(Required) Fixed name for the centralized S3 access log bucket. Used as a fixed name (not prefix) to support import capability. Must be lowercase, 3–63 characters."
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.\\-]{1,61}[a-z0-9]$", var.bucket))
+    error_message = "The bucket name must be lowercase, between 3 and 63 characters, and may only contain letters, numbers, hyphens, and dots."
+  }
+}
+
+variable "bucket_force_destroy" {
+  type        = bool
+  description = "(Optional) When true, all objects (including locked objects) are deleted from the bucket when the bucket is destroyed so that the bucket can be destroyed without error. Defaults to false."
+  default     = false
+  validation {
+    condition     = can(regex("true|false", var.bucket_force_destroy))
+    error_message = "The value must be true or false."
+  }
+}
+
+###########################
+# Versioning Variables
+###########################
+
+variable "enable_versioning" {
+  type        = bool
+  description = "(Optional) Enable versioning on the access log bucket. When enabled, multiple versions of objects are retained. Defaults to false."
+  default     = false
+  validation {
+    condition     = can(regex("true|false", var.enable_versioning))
+    error_message = "The value must be true or false."
+  }
+}
+
+###########################
+# Lifecycle Variables
+###########################
+
+variable "lifecycle_rules" {
+  description = "(Optional) Configuration of object lifecycle management. Can have several rules as a list of maps where each map is the lifecycle rule configuration. Set to null to disable lifecycle rules."
+  type        = any
+  default     = null
+}
+
+###########################
+# Global Variables
+###########################
+
+variable "tags" {
+  type        = map(string)
+  description = "(Optional) A mapping of tags to assign to the bucket."
+  default     = {}
+}


### PR DESCRIPTION
## Summary

Adds a new `modules/aws/s3/access_log_bucket` sub-module that creates a centralized S3 bucket suitable as the destination for S3 server access logs from any number of source buckets.

### Design decisions

- **SSE-S3 (AES256) only** — the AWS S3 log delivery service cannot write to SSE-KMS-encrypted buckets; AES256 is hardcoded with no KMS option exposed.
- **`BucketOwnerPreferred` + `log-delivery-write` ACL** — required combination for the log delivery service to own and write objects.
- **Fixed `bucket` name** — no `bucket_prefix`; a fixed name supports `terraform import`.
- **Bucket policy** — always applied: denies all traffic without SSL/TLS (`DenyInsecureTransport`) and explicitly allows `logging.s3.amazonaws.com` to `PutObject`.
- **Public access** — all 4 public access block flags hardcoded to `true`; no variable to relax them (log buckets must never be public).
- **Lifecycle rules / versioning** — both optional and count-gated, matching the pattern in `s3/bucket`.

Source buckets should use the existing `s3/bucket` module with `enable_s3_bucket_logging = true` and `logging_target_bucket = <this bucket name>`.

Closes DEVSECOPS-37

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/23ae3418-a6c2-4578-9afd-4180c41def49_
_Run: https://oz.warp.dev/runs/019e4b0b-0317-773e-8a8d-20019821e9df_

_This PR was generated with [Oz](https://warp.dev/oz)._
