### PR TITLE
feat: add AWS Config organization module (DEVSECOPS-32)

### DIFF
--- a/modules/aws/config/organization/README.md
+++ b/modules/aws/config/organization/README.md
@@ -1,0 +1,290 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">AWS Config Organization</h3>
+  <p align="center">
+    This module enables AWS Config at the organization level by registering a delegated administrator, creating a configuration recorder, delivery channel (with optional S3 bucket), and optional organization conformance packs. Scope is read/reporting only — no enforcement rules are deployed.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#Resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+<!-- USAGE EXAMPLES -->
+
+## Usage
+
+### Organization Config with New S3 Bucket
+
+This example delegates AWS Config administration to a security account and creates a new delivery bucket.
+
+```hcl
+provider "aws" {
+  alias  = "organization_management_account"
+  region = "us-east-1"
+  # assume_role { role_arn = "arn:aws:iam::MANAGEMENT_ACCOUNT_ID:role/OrganizationRole" }
+}
+
+provider "aws" {
+  alias  = "organization_config_account"
+  region = "us-east-1"
+  # assume_role { role_arn = "arn:aws:iam::SECURITY_ACCOUNT_ID:role/ConfigAdminRole" }
+}
+```
+
+```hcl
+module "config_organization" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/config/organization"
+
+  providers = {
+    aws.organization_management_account = aws.organization_management_account
+    aws.organization_config_account     = aws.organization_config_account
+  }
+
+  admin_account_id  = "123456789012"
+  recorder_role_arn = "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
+
+  create_s3_bucket  = true
+  s3_bucket_prefix  = "config-"
+  s3_key_prefix     = "org-config"
+  delivery_frequency = "TwentyFour_Hours"
+
+  tags = {
+    created_by  = "terraform"
+    environment = "prod"
+    terraform   = "true"
+  }
+}
+```
+
+### Organization Config with Existing S3 Bucket
+
+```hcl
+module "config_organization" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/config/organization"
+
+  providers = {
+    aws.organization_management_account = aws.organization_management_account
+    aws.organization_config_account     = aws.organization_config_account
+  }
+
+  admin_account_id  = "123456789012"
+  recorder_role_arn = "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
+
+  create_s3_bucket = false
+  s3_bucket_name   = "my-existing-config-bucket"
+  s3_key_prefix    = "config"
+
+  tags = {
+    created_by  = "terraform"
+    environment = "prod"
+    terraform   = "true"
+  }
+}
+```
+
+### Organization Config with Conformance Packs
+
+```hcl
+module "config_organization" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/config/organization"
+
+  providers = {
+    aws.organization_management_account = aws.organization_management_account
+    aws.organization_config_account     = aws.organization_config_account
+  }
+
+  admin_account_id  = "123456789012"
+  recorder_role_arn = "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
+
+  create_s3_bucket         = true
+  s3_bucket_prefix         = "config-"
+  enable_conformance_packs = true
+
+  conformance_packs = [
+    {
+      name            = "operational-best-practices-for-cis-aws"
+      template_s3_uri = "s3://my-templates-bucket/cis-conformance-pack.yaml"
+    },
+    {
+      name          = "custom-security-controls"
+      template_body = <<-YAML
+        Parameters: {}
+        Resources: {}
+      YAML
+    }
+  ]
+
+  tags = {
+    created_by  = "terraform"
+    environment = "prod"
+    terraform   = "true"
+  }
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.organization_management_account"></a> [aws.organization\_management\_account](#provider\_aws.organization\_management\_account) | >= 6.0.0 |
+| <a name="provider_aws.organization_config_account"></a> [aws.organization\_config\_account](#provider\_aws.organization\_config\_account) | >= 6.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_organizations_delegated_administrator.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
+| [aws_config_configuration_recorder.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder) | resource |
+| [aws_config_configuration_recorder_status.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder_status) | resource |
+| [aws_config_delivery_channel.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel) | resource |
+| [aws_config_organization_conformance_pack.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_organization_conformance_pack) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_caller_identity.config_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.config_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_account_id"></a> [admin\_account\_id](#input\_admin\_account\_id) | (Required) The AWS account ID to register as the delegated administrator for AWS Config in the organization. | `string` | n/a | yes |
+| <a name="input_recorder_role_arn"></a> [recorder\_role\_arn](#input\_recorder\_role\_arn) | (Required) ARN of the IAM role that AWS Config uses to record and deliver configuration changes. | `string` | n/a | yes |
+| <a name="input_recorder_name"></a> [recorder\_name](#input\_recorder\_name) | (Optional) The name of the AWS Config configuration recorder. Defaults to 'default'. | `string` | `"default"` | no |
+| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | (Optional) Whether to include global resource types (e.g., IAM). Defaults to true. | `bool` | `true` | no |
+| <a name="input_delivery_channel_name"></a> [delivery\_channel\_name](#input\_delivery\_channel\_name) | (Optional) The name of the AWS Config delivery channel. Defaults to 'default'. | `string` | `"default"` | no |
+| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | (Optional) Snapshot delivery frequency. Valid values: One\_Hour, Three\_Hours, Six\_Hours, Twelve\_Hours, TwentyFour\_Hours. Defaults to TwentyFour\_Hours. | `string` | `"TwentyFour_Hours"` | no |
+| <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | (Optional) ARN of an SNS topic for Config notifications. Defaults to null. | `string` | `null` | no |
+| <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | (Optional) If true, creates a new S3 bucket for Config delivery. Defaults to true. | `bool` | `true` | no |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Optional) Name of an existing S3 bucket when create\_s3\_bucket is false. | `string` | `null` | no |
+| <a name="input_s3_bucket_prefix"></a> [s3\_bucket\_prefix](#input\_s3\_bucket\_prefix) | (Optional) Name prefix for a newly created S3 bucket. Defaults to 'config-'. | `string` | `"config-"` | no |
+| <a name="input_s3_key_prefix"></a> [s3\_key\_prefix](#input\_s3\_key\_prefix) | (Optional) S3 key prefix for Config delivery within the bucket. Defaults to null. | `string` | `null` | no |
+| <a name="input_enable_conformance_packs"></a> [enable\_conformance\_packs](#input\_enable\_conformance\_packs) | (Optional) If true, deploys organization conformance packs. Defaults to false. | `bool` | `false` | no |
+| <a name="input_conformance_packs"></a> [conformance\_packs](#input\_conformance\_packs) | (Optional) List of organization conformance packs. Each requires name and template\_s3\_uri or template\_body. | `list(object({...}))` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to all taggable resources. | `map(string)` | `{...}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_delegated_admin_id"></a> [delegated\_admin\_id](#output\_delegated\_admin\_id) | The unique identifier of the delegated administrator registration. |
+| <a name="output_recorder_name"></a> [recorder\_name](#output\_recorder\_name) | The name of the AWS Config configuration recorder. |
+| <a name="output_delivery_channel_name"></a> [delivery\_channel\_name](#output\_delivery\_channel\_name) | The name of the AWS Config delivery channel. |
+| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The ID (name) of the S3 bucket used for AWS Config delivery. |
+| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the S3 bucket used for AWS Config delivery. |
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasaurus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/aws/config/organization/README.md
+++ b/modules/aws/config/organization/README.md
@@ -188,8 +188,9 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.organization_management_account"></a> [aws.organization\_management\_account](#provider\_aws.organization\_management\_account) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 | <a name="provider_aws.organization_config_account"></a> [aws.organization\_config\_account](#provider\_aws.organization\_config\_account) | >= 6.0.0 |
+| <a name="provider_aws.organization_management_account"></a> [aws.organization\_management\_account](#provider\_aws.organization\_management\_account) | >= 6.0.0 |
 
 ## Modules
 
@@ -199,11 +200,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_organizations_delegated_administrator.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
 | [aws_config_configuration_recorder.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder) | resource |
 | [aws_config_configuration_recorder_status.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder_status) | resource |
 | [aws_config_delivery_channel.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel) | resource |
 | [aws_config_organization_conformance_pack.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_organization_conformance_pack) | resource |
+| [aws_organizations_delegated_administrator.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -218,29 +219,29 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_account_id"></a> [admin\_account\_id](#input\_admin\_account\_id) | (Required) The AWS account ID to register as the delegated administrator for AWS Config in the organization. | `string` | n/a | yes |
-| <a name="input_recorder_role_arn"></a> [recorder\_role\_arn](#input\_recorder\_role\_arn) | (Required) ARN of the IAM role that AWS Config uses to record and deliver configuration changes. | `string` | n/a | yes |
-| <a name="input_recorder_name"></a> [recorder\_name](#input\_recorder\_name) | (Optional) The name of the AWS Config configuration recorder. Defaults to 'default'. | `string` | `"default"` | no |
-| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | (Optional) Whether to include global resource types (e.g., IAM). Defaults to true. | `bool` | `true` | no |
+| <a name="input_conformance_packs"></a> [conformance\_packs](#input\_conformance\_packs) | (Optional) List of organization conformance packs to deploy. Each object requires a name, and either a template\_s3\_uri (S3 URI to a conformance pack template) or template\_body (inline YAML template). Only used when enable\_conformance\_packs is true. | <pre>list(object({<br/>    name            = string<br/>    template_s3_uri = optional(string)<br/>    template_body   = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | (Optional) If true, creates a new S3 bucket for AWS Config delivery. If false, the s3\_bucket\_name variable must reference an existing bucket. Defaults to true. | `bool` | `true` | no |
 | <a name="input_delivery_channel_name"></a> [delivery\_channel\_name](#input\_delivery\_channel\_name) | (Optional) The name of the AWS Config delivery channel. Defaults to 'default'. | `string` | `"default"` | no |
-| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | (Optional) Snapshot delivery frequency. Valid values: One\_Hour, Three\_Hours, Six\_Hours, Twelve\_Hours, TwentyFour\_Hours. Defaults to TwentyFour\_Hours. | `string` | `"TwentyFour_Hours"` | no |
-| <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | (Optional) ARN of an SNS topic for Config notifications. Defaults to null. | `string` | `null` | no |
-| <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | (Optional) If true, creates a new S3 bucket for Config delivery. Defaults to true. | `bool` | `true` | no |
-| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Optional) Name of an existing S3 bucket when create\_s3\_bucket is false. | `string` | `null` | no |
-| <a name="input_s3_bucket_prefix"></a> [s3\_bucket\_prefix](#input\_s3\_bucket\_prefix) | (Optional) Name prefix for a newly created S3 bucket. Defaults to 'config-'. | `string` | `"config-"` | no |
-| <a name="input_s3_key_prefix"></a> [s3\_key\_prefix](#input\_s3\_key\_prefix) | (Optional) S3 key prefix for Config delivery within the bucket. Defaults to null. | `string` | `null` | no |
-| <a name="input_enable_conformance_packs"></a> [enable\_conformance\_packs](#input\_enable\_conformance\_packs) | (Optional) If true, deploys organization conformance packs. Defaults to false. | `bool` | `false` | no |
-| <a name="input_conformance_packs"></a> [conformance\_packs](#input\_conformance\_packs) | (Optional) List of organization conformance packs. Each requires name and template\_s3\_uri or template\_body. | `list(object({...}))` | `[]` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to all taggable resources. | `map(string)` | `{...}` | no |
+| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | (Optional) The frequency with which AWS Config delivers configuration snapshots to the S3 bucket. Valid values: One\_Hour, Three\_Hours, Six\_Hours, Twelve\_Hours, TwentyFour\_Hours. Defaults to TwentyFour\_Hours. | `string` | `"TwentyFour_Hours"` | no |
+| <a name="input_enable_conformance_packs"></a> [enable\_conformance\_packs](#input\_enable\_conformance\_packs) | (Optional) If true, deploys the organization conformance packs defined in the conformance\_packs variable. Defaults to false. | `bool` | `false` | no |
+| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | (Optional) Specifies whether AWS Config includes all supported types of global resources (e.g., IAM) with the resources it records. Defaults to true. | `bool` | `true` | no |
+| <a name="input_recorder_name"></a> [recorder\_name](#input\_recorder\_name) | (Optional) The name of the AWS Config configuration recorder. Only one recorder per region is allowed. Defaults to 'default'. | `string` | `"default"` | no |
+| <a name="input_recorder_role_arn"></a> [recorder\_role\_arn](#input\_recorder\_role\_arn) | (Required) ARN of the IAM role that AWS Config uses to record and deliver configuration changes. Must have the AWSConfigRole managed policy or equivalent permissions. | `string` | n/a | yes |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Optional) The name of an existing S3 bucket to use for AWS Config delivery when create\_s3\_bucket is false. Must be set when create\_s3\_bucket is false. | `string` | `null` | no |
+| <a name="input_s3_bucket_prefix"></a> [s3\_bucket\_prefix](#input\_s3\_bucket\_prefix) | (Optional) Name prefix for the S3 bucket created when create\_s3\_bucket is true. AWS will append a unique suffix to ensure global uniqueness. Defaults to 'config-'. | `string` | `"config-"` | no |
+| <a name="input_s3_key_prefix"></a> [s3\_key\_prefix](#input\_s3\_key\_prefix) | (Optional) The S3 key prefix (folder path) within the delivery bucket where AWS Config stores configuration snapshots and history files. Set to null to store at bucket root. | `string` | `null` | no |
+| <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | (Optional) The ARN of the SNS topic to which AWS Config sends notifications about configuration changes and compliance. Set to null to disable SNS notifications. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to all taggable resources created by this module. | `map(string)` | <pre>{<br/>  "created_by": "<YOUR NAME>",<br/>  "environment": "prod",<br/>  "terraform": "true"<br/>}</pre> | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_delegated_admin_id"></a> [delegated\_admin\_id](#output\_delegated\_admin\_id) | The unique identifier of the delegated administrator registration. |
-| <a name="output_recorder_name"></a> [recorder\_name](#output\_recorder\_name) | The name of the AWS Config configuration recorder. |
+| <a name="output_delegated_admin_id"></a> [delegated\_admin\_id](#output\_delegated\_admin\_id) | The unique identifier of the delegated administrator registration (account\_id:service\_principal). |
 | <a name="output_delivery_channel_name"></a> [delivery\_channel\_name](#output\_delivery\_channel\_name) | The name of the AWS Config delivery channel. |
-| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The ID (name) of the S3 bucket used for AWS Config delivery. |
-| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the S3 bucket used for AWS Config delivery. |
+| <a name="output_recorder_name"></a> [recorder\_name](#output\_recorder\_name) | The name of the AWS Config configuration recorder. |
+| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the S3 bucket used for AWS Config delivery. Returns null when create\_s3\_bucket is false. |
+| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The ID (name) of the S3 bucket used for AWS Config delivery. Returns null when create\_s3\_bucket is false. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/config/organization/README.md
+++ b/modules/aws/config/organization/README.md
@@ -59,6 +59,16 @@
 
 <!-- USAGE EXAMPLES -->
 
+## Prerequisites
+
+The following must exist before deploying this module:
+
+- **AWS Organizations** — the organization must already be set up and the management account must have permissions to register delegated administrators.
+- **Delegated administrator account** — the account specified by `admin_account_id` must already be a member of the organization.
+- **IAM role for Config recorder** — an IAM role with the `AWSConfigRole` managed policy (or equivalent) must be pre-created in the Config account and passed as `recorder_role_arn`. The AWS-managed service-linked role `AWSServiceRoleForConfig` is the standard choice.
+- **Dual provider aliases** — the caller must configure two `aws` provider aliases: `aws.organization_management_account` (management account credentials) and `aws.organization_config_account` (the delegated Config account credentials) and pass them via the `providers` block.
+- **S3 logging bucket** (optional) — if `enable_s3_bucket_logging = true`, a target logging bucket must exist before applying.
+
 ## Usage
 
 ### Organization Config with New S3 Bucket
@@ -88,18 +98,18 @@ module "config_organization" {
     aws.organization_config_account     = aws.organization_config_account
   }
 
-  admin_account_id  = "123456789012"
+  name             = "org-config"
+  admin_account_id = "123456789012"
   recorder_role_arn = "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
 
-  create_s3_bucket  = true
-  s3_bucket_prefix  = "config-"
-  s3_key_prefix     = "org-config"
+  create_s3_bucket   = true
+  s3_bucket_prefix   = "config-"
+  s3_key_prefix      = "org-config"
   delivery_frequency = "TwentyFour_Hours"
 
   tags = {
-    created_by  = "terraform"
-    environment = "prod"
     terraform   = "true"
+    environment = "prod"
   }
 }
 ```
@@ -115,6 +125,7 @@ module "config_organization" {
     aws.organization_config_account     = aws.organization_config_account
   }
 
+  name              = "org-config"
   admin_account_id  = "123456789012"
   recorder_role_arn = "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
 
@@ -123,14 +134,13 @@ module "config_organization" {
   s3_key_prefix    = "config"
 
   tags = {
-    created_by  = "terraform"
-    environment = "prod"
     terraform   = "true"
+    environment = "prod"
   }
 }
 ```
 
-### Organization Config with Conformance Packs
+### Organization Config with Conformance Packs and Input Parameters
 
 ```hcl
 module "config_organization" {
@@ -141,6 +151,7 @@ module "config_organization" {
     aws.organization_config_account     = aws.organization_config_account
   }
 
+  name              = "org-config"
   admin_account_id  = "123456789012"
   recorder_role_arn = "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
 
@@ -152,23 +163,52 @@ module "config_organization" {
     {
       name            = "operational-best-practices-for-cis-aws"
       template_s3_uri = "s3://my-templates-bucket/cis-conformance-pack.yaml"
-    },
-    {
-      name          = "custom-security-controls"
-      template_body = <<-YAML
-        Parameters: {}
-        Resources: {}
-      YAML
+      excluded_accounts = ["111111111111"]  # exclude a sandbox account
+      input_parameters = [
+        { parameter_name = "AccessKeysRotatedParamMaxAccessKeyAge", parameter_value = "90" }
+      ]
     }
   ]
 
   tags = {
-    created_by  = "terraform"
-    environment = "prod"
     terraform   = "true"
+    environment = "prod"
   }
 }
 ```
+
+### Exclusion-Based Recording
+
+```hcl
+module "config_organization" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/config/organization"
+
+  providers = {
+    aws.organization_management_account = aws.organization_management_account
+    aws.organization_config_account     = aws.organization_config_account
+  }
+
+  name              = "org-config"
+  admin_account_id  = "123456789012"
+  recorder_role_arn = "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
+
+  all_supported        = true
+  recording_strategy   = "EXCLUSION_BY_RESOURCE_TYPES"
+  exclusion_resource_types = [
+    "AWS::CloudFormation::Stack",
+  ]
+
+  create_s3_bucket = true
+}
+```
+
+## Notes / Design Decisions
+
+- **Dual-provider pattern** — registering a delegated administrator must be done from the management account, while the recorder, delivery channel, and bucket all live in the delegated (Config) account. Two provider aliases are required and cannot be collapsed.
+- **Read/reporting scope only** — this module deploys the recorder and conformance packs but does not create Config Rules or remediation actions. Enforcement is left to callers to avoid overly prescriptive defaults at the org level.
+- **S3 bucket policy is inline, not in the child module** — the Config delivery policy (`GetBucketAcl`, `ListBucket`, `PutObject` for `config.amazonaws.com`) depends on the bucket ARN. Passing the policy into the `s3/bucket` child module would create a Terraform cycle (policy document → bucket ARN → module input → module), so the policy and `aws_s3_bucket_policy` resource remain inline in this module. The `DenyInsecureTransport` statement is merged into the same policy document so it is not managed separately.
+- **KMS encryption** — the delivery bucket uses SSE-KMS with the AWS-managed key by default. To use a customer-managed key for Config _deliveries_, pass `s3_kms_key_arn` (the delivery channel attribute). The bucket itself always uses `sse_algorithm = "aws:kms"`; `enable_kms_key = false` in the child module means the AWS-managed S3 key is used for bucket-level encryption.
+- **Recording mode** — `recording_frequency` defaults to `CONTINUOUS`. For high-velocity resource types, consider switching to `DAILY` to reduce costs.
 
 _For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
 
@@ -180,63 +220,73 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
-| <a name="provider_aws.organization_config_account"></a> [aws.organization\_config\_account](#provider\_aws.organization\_config\_account) | >= 6.0.0 |
-| <a name="provider_aws.organization_management_account"></a> [aws.organization\_management\_account](#provider\_aws.organization\_management\_account) | >= 6.0.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.46.0 |
+| <a name="provider_aws.organization_config_account"></a> [aws.organization\_config\_account](#provider\_aws.organization\_config\_account) | 6.46.0 |
+| <a name="provider_aws.organization_management_account"></a> [aws.organization\_management\_account](#provider\_aws.organization\_management\_account) | 6.46.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | ../../s3/bucket | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_config_configuration_recorder.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder) | resource |
 | [aws_config_configuration_recorder_status.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder_status) | resource |
 | [aws_config_delivery_channel.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel) | resource |
 | [aws_config_organization_conformance_pack.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_organization_conformance_pack) | resource |
 | [aws_organizations_delegated_administrator.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
-| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_caller_identity.config_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.config_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_admin_account_id"></a> [admin\_account\_id](#input\_admin\_account\_id) | (Required) The AWS account ID to register as the delegated administrator for AWS Config in the organization. | `string` | n/a | yes |
-| <a name="input_conformance_packs"></a> [conformance\_packs](#input\_conformance\_packs) | (Optional) List of organization conformance packs to deploy. Each object requires a name, and either a template\_s3\_uri (S3 URI to a conformance pack template) or template\_body (inline YAML template). Only used when enable\_conformance\_packs is true. | <pre>list(object({<br/>    name            = string<br/>    template_s3_uri = optional(string)<br/>    template_body   = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_all_supported"></a> [all\_supported](#input\_all\_supported) | (Optional) Specifies whether AWS Config records configuration changes for every supported type of regional resource. Defaults to true. Set to false when using resource\_types for inclusion-based recording. | `bool` | `true` | no |
+| <a name="input_conformance_pack_delivery_s3_bucket"></a> [conformance\_pack\_delivery\_s3\_bucket](#input\_conformance\_pack\_delivery\_s3\_bucket) | (Optional) The name of the S3 bucket where AWS Config stores conformance pack templates and results. Set to null to use the main delivery bucket. | `string` | `null` | no |
+| <a name="input_conformance_pack_delivery_s3_key_prefix"></a> [conformance\_pack\_delivery\_s3\_key\_prefix](#input\_conformance\_pack\_delivery\_s3\_key\_prefix) | (Optional) The prefix for the S3 key where conformance pack templates and results are stored. Defaults to null. | `string` | `null` | no |
+| <a name="input_conformance_packs"></a> [conformance\_packs](#input\_conformance\_packs) | (Optional) List of organization conformance packs to deploy. Each object requires a name and either template\_s3\_uri or template\_body. Optionally supply excluded\_accounts (list of account IDs to exclude) and input\_parameters (list of name/value pairs to pass to the template). Only used when enable\_conformance\_packs is true. | <pre>list(object({<br/>    name              = string<br/>    template_s3_uri   = optional(string)<br/>    template_body     = optional(string)<br/>    excluded_accounts = optional(list(string), [])<br/>    input_parameters = optional(list(object({<br/>      parameter_name  = string<br/>      parameter_value = string<br/>    })), [])<br/>  }))</pre> | `[]` | no |
 | <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | (Optional) If true, creates a new S3 bucket for AWS Config delivery. If false, the s3\_bucket\_name variable must reference an existing bucket. Defaults to true. | `bool` | `true` | no |
 | <a name="input_delivery_channel_name"></a> [delivery\_channel\_name](#input\_delivery\_channel\_name) | (Optional) The name of the AWS Config delivery channel. Defaults to 'default'. | `string` | `"default"` | no |
 | <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | (Optional) The frequency with which AWS Config delivers configuration snapshots to the S3 bucket. Valid values: One\_Hour, Three\_Hours, Six\_Hours, Twelve\_Hours, TwentyFour\_Hours. Defaults to TwentyFour\_Hours. | `string` | `"TwentyFour_Hours"` | no |
 | <a name="input_enable_conformance_packs"></a> [enable\_conformance\_packs](#input\_enable\_conformance\_packs) | (Optional) If true, deploys the organization conformance packs defined in the conformance\_packs variable. Defaults to false. | `bool` | `false` | no |
-| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | (Optional) Specifies whether AWS Config includes all supported types of global resources (e.g., IAM) with the resources it records. Defaults to true. | `bool` | `true` | no |
+| <a name="input_enable_s3_bucket_logging"></a> [enable\_s3\_bucket\_logging](#input\_enable\_s3\_bucket\_logging) | (Optional) If true, enables S3 server access logging for the Config delivery bucket. Requires s3\_logging\_target\_bucket to be set. Defaults to false. | `bool` | `false` | no |
+| <a name="input_exclusion_resource_types"></a> [exclusion\_resource\_types](#input\_exclusion\_resource\_types) | (Optional) A list of resource types to exclude from recording when using EXCLUSION\_BY\_RESOURCE\_TYPES recording strategy. Leave empty when all\_supported is true and no exclusions are needed. | `list(string)` | `[]` | no |
+| <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | (Optional) Specifies whether AWS Config includes all supported types of global resources (e.g., IAM) with the resources it records. Only valid when all\_supported is true. Defaults to true. | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | (Required) A name used as the Name tag on all taggable resources created by this module. | `string` | n/a | yes |
 | <a name="input_recorder_name"></a> [recorder\_name](#input\_recorder\_name) | (Optional) The name of the AWS Config configuration recorder. Only one recorder per region is allowed. Defaults to 'default'. | `string` | `"default"` | no |
 | <a name="input_recorder_role_arn"></a> [recorder\_role\_arn](#input\_recorder\_role\_arn) | (Required) ARN of the IAM role that AWS Config uses to record and deliver configuration changes. Must have the AWSConfigRole managed policy or equivalent permissions. | `string` | n/a | yes |
+| <a name="input_recording_frequency"></a> [recording\_frequency](#input\_recording\_frequency) | (Optional) The recording frequency for the recorder. Valid values: CONTINUOUS, DAILY. Defaults to CONTINUOUS. | `string` | `"CONTINUOUS"` | no |
+| <a name="input_recording_strategy"></a> [recording\_strategy](#input\_recording\_strategy) | (Optional) The recording strategy for the recorder. Valid values: ALL\_SUPPORTED\_RESOURCE\_TYPES, EXCLUSION\_BY\_RESOURCE\_TYPES, INCLUSION\_BY\_RESOURCE\_TYPES. Defaults to null (provider uses ALL\_SUPPORTED\_RESOURCE\_TYPES). | `string` | `null` | no |
+| <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types) | (Optional) A list of resource types to include for recording when using INCLUSION\_BY\_RESOURCE\_TYPES recording strategy. Leave empty when all\_supported is true. | `list(string)` | `[]` | no |
+| <a name="input_s3_bucket_force_destroy"></a> [s3\_bucket\_force\_destroy](#input\_s3\_bucket\_force\_destroy) | (Optional) If true, all objects are deleted from the bucket when the bucket is destroyed, allowing the bucket to be destroyed without error. Defaults to false. | `bool` | `false` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Optional) The name of an existing S3 bucket to use for AWS Config delivery when create\_s3\_bucket is false. Must be set when create\_s3\_bucket is false. | `string` | `null` | no |
+| <a name="input_s3_bucket_object_lock_enabled"></a> [s3\_bucket\_object\_lock\_enabled](#input\_s3\_bucket\_object\_lock\_enabled) | (Optional) Indicates whether this bucket has Object Lock enabled. Valid values are true or false. Defaults to false. | `bool` | `false` | no |
 | <a name="input_s3_bucket_prefix"></a> [s3\_bucket\_prefix](#input\_s3\_bucket\_prefix) | (Optional) Name prefix for the S3 bucket created when create\_s3\_bucket is true. AWS will append a unique suffix to ensure global uniqueness. Defaults to 'config-'. | `string` | `"config-"` | no |
 | <a name="input_s3_key_prefix"></a> [s3\_key\_prefix](#input\_s3\_key\_prefix) | (Optional) The S3 key prefix (folder path) within the delivery bucket where AWS Config stores configuration snapshots and history files. Set to null to store at bucket root. | `string` | `null` | no |
+| <a name="input_s3_kms_key_arn"></a> [s3\_kms\_key\_arn](#input\_s3\_kms\_key\_arn) | (Optional) The ARN of the AWS KMS key used to encrypt objects delivered by AWS Config to the S3 delivery bucket. Set to null to use the bucket's default encryption. Defaults to null. | `string` | `null` | no |
+| <a name="input_s3_logging_target_bucket"></a> [s3\_logging\_target\_bucket](#input\_s3\_logging\_target\_bucket) | (Optional) The name of the S3 bucket to receive server access logs from the Config delivery bucket. Required when enable\_s3\_bucket\_logging is true. | `string` | `null` | no |
+| <a name="input_s3_logging_target_prefix"></a> [s3\_logging\_target\_prefix](#input\_s3\_logging\_target\_prefix) | (Optional) A prefix for all log object keys when S3 server access logging is enabled. Defaults to null. | `string` | `null` | no |
 | <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | (Optional) The ARN of the SNS topic to which AWS Config sends notifications about configuration changes and compliance. Set to null to disable SNS notifications. | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to all taggable resources created by this module. | `map(string)` | <pre>{<br/>  "created_by": "<YOUR NAME>",<br/>  "environment": "prod",<br/>  "terraform": "true"<br/>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of additional tags to assign to all taggable resources. Merged with a Name tag derived from var.name. | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_delegated_admin_id"></a> [delegated\_admin\_id](#output\_delegated\_admin\_id) | The unique identifier of the delegated administrator registration (account\_id:service\_principal). |
 | <a name="output_delivery_channel_name"></a> [delivery\_channel\_name](#output\_delivery\_channel\_name) | The name of the AWS Config delivery channel. |
 | <a name="output_recorder_name"></a> [recorder\_name](#output\_recorder\_name) | The name of the AWS Config configuration recorder. |

--- a/modules/aws/config/organization/main.tf
+++ b/modules/aws/config/organization/main.tf
@@ -1,0 +1,240 @@
+##############################
+# Provider Configuration
+##############################
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 6.0.0"
+      configuration_aliases = [aws.organization_management_account, aws.organization_config_account]
+    }
+  }
+}
+
+##############################
+# Data Sources
+##############################
+data "aws_caller_identity" "config_account" {
+  provider = aws.organization_config_account
+}
+
+##############################
+# Locals
+##############################
+locals {
+  bucket_name      = var.create_s3_bucket ? aws_s3_bucket.this[0].id : var.s3_bucket_name
+  bucket_arn       = var.create_s3_bucket ? aws_s3_bucket.this[0].arn : "arn:aws:s3:::${var.s3_bucket_name}"
+  s3_delivery_path = var.s3_key_prefix != null ? "${var.s3_key_prefix}/AWSLogs/*/Config/*" : "AWSLogs/*/Config/*"
+}
+
+##############################
+# Organizations Delegated Admin
+##############################
+resource "aws_organizations_delegated_administrator" "this" {
+  provider          = aws.organization_management_account
+  account_id        = var.admin_account_id
+  service_principal = "config.amazonaws.com"
+}
+
+##############################
+# Config S3 Bucket
+##############################
+data "aws_iam_policy_document" "config_bucket" {
+  count = var.create_s3_bucket ? 1 : 0
+
+  statement {
+    sid    = "AWSConfigBucketPermissionsCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.this[0].arn]
+  }
+
+  statement {
+    sid    = "AWSConfigBucketExistenceCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.this[0].arn]
+  }
+
+  statement {
+    sid    = "AWSConfigBucketDelivery"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.this[0].arn}/${local.s3_delivery_path}"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.this[0].arn,
+      "${aws_s3_bucket.this[0].arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  count    = var.create_s3_bucket ? 1 : 0
+  provider = aws.organization_config_account
+
+  bucket_prefix = var.s3_bucket_prefix # e.g., "config-" yields globally unique name
+  force_destroy = false
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "this" {
+  count    = var.create_s3_bucket ? 1 : 0
+  provider = aws.organization_config_account
+
+  bucket = aws_s3_bucket.this[0].id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  count    = var.create_s3_bucket ? 1 : 0
+  provider = aws.organization_config_account
+
+  bucket = aws_s3_bucket.this[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  count    = var.create_s3_bucket ? 1 : 0
+  provider = aws.organization_config_account
+
+  bucket = aws_s3_bucket.this[0].id
+
+  rule {
+    bucket_key_enabled = true
+
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms" # SSE-KMS with AWS managed key
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  count    = var.create_s3_bucket ? 1 : 0
+  provider = aws.organization_config_account
+
+  bucket = aws_s3_bucket.this[0].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  count    = var.create_s3_bucket ? 1 : 0
+  provider = aws.organization_config_account
+
+  bucket = aws_s3_bucket.this[0].id
+  policy = data.aws_iam_policy_document.config_bucket[0].json
+
+  depends_on = [aws_s3_bucket_public_access_block.this]
+}
+
+##############################
+# Config Recorder
+##############################
+resource "aws_config_configuration_recorder" "this" {
+  provider = aws.organization_config_account
+
+  name     = var.recorder_name
+  role_arn = var.recorder_role_arn
+
+  recording_group {
+    all_supported                 = true
+    include_global_resource_types = var.include_global_resource_types
+  }
+}
+
+##############################
+# Config Delivery Channel
+##############################
+resource "aws_config_delivery_channel" "this" {
+  provider = aws.organization_config_account
+
+  name           = var.delivery_channel_name
+  s3_bucket_name = local.bucket_name
+  s3_key_prefix  = var.s3_key_prefix
+  sns_topic_arn  = var.sns_topic_arn
+
+  snapshot_delivery_properties {
+    delivery_frequency = var.delivery_frequency # How often Config snapshots are delivered
+  }
+
+  depends_on = [aws_config_configuration_recorder.this]
+}
+
+##############################
+# Config Recorder Status
+##############################
+resource "aws_config_configuration_recorder_status" "this" {
+  provider = aws.organization_config_account
+
+  name       = aws_config_configuration_recorder.this.name
+  is_enabled = true
+
+  depends_on = [aws_config_delivery_channel.this]
+}
+
+##############################
+# Organization Conformance Packs
+##############################
+resource "aws_config_organization_conformance_pack" "this" {
+  for_each = var.enable_conformance_packs ? { for pack in var.conformance_packs : pack.name => pack } : {}
+  provider = aws.organization_config_account
+
+  name            = each.value.name
+  template_s3_uri = try(each.value.template_s3_uri, null)
+  template_body   = try(each.value.template_body, null)
+
+  depends_on = [aws_config_configuration_recorder_status.this]
+}

--- a/modules/aws/config/organization/main.tf
+++ b/modules/aws/config/organization/main.tf
@@ -193,7 +193,7 @@ resource "aws_config_delivery_channel" "this" {
 
   name           = var.delivery_channel_name
   s3_bucket_name = local.bucket_name
-  s3_key_prefix  = var.s3_key_prefix # gitleaks:allow
+  s3_key_prefix  = var.s3_key_prefix
   s3_kms_key_arn = var.s3_kms_key_arn
   sns_topic_arn  = var.sns_topic_arn
 

--- a/modules/aws/config/organization/main.tf
+++ b/modules/aws/config/organization/main.tf
@@ -193,7 +193,7 @@ resource "aws_config_delivery_channel" "this" {
 
   name           = var.delivery_channel_name
   s3_bucket_name = local.bucket_name
-  s3_key_prefix  = var.s3_key_prefix  # gitleaks:allow
+  s3_key_prefix  = var.s3_key_prefix # gitleaks:allow
   s3_kms_key_arn = var.s3_kms_key_arn
   sns_topic_arn  = var.sns_topic_arn
 

--- a/modules/aws/config/organization/main.tf
+++ b/modules/aws/config/organization/main.tf
@@ -13,18 +13,11 @@ terraform {
 }
 
 ##############################
-# Data Sources
-##############################
-data "aws_caller_identity" "config_account" {
-  provider = aws.organization_config_account
-}
-
-##############################
 # Locals
 ##############################
 locals {
-  bucket_name      = var.create_s3_bucket ? aws_s3_bucket.this[0].id : var.s3_bucket_name
-  bucket_arn       = var.create_s3_bucket ? aws_s3_bucket.this[0].arn : "arn:aws:s3:::${var.s3_bucket_name}"
+  bucket_name      = var.create_s3_bucket ? module.config_bucket[0].s3_bucket_id : var.s3_bucket_name
+  bucket_arn       = var.create_s3_bucket ? module.config_bucket[0].s3_bucket_arn : "arn:aws:s3:::${var.s3_bucket_name}"
   s3_delivery_path = var.s3_key_prefix != null ? "${var.s3_key_prefix}/AWSLogs/*/Config/*" : "AWSLogs/*/Config/*"
 }
 
@@ -40,6 +33,12 @@ resource "aws_organizations_delegated_administrator" "this" {
 ##############################
 # Config S3 Bucket
 ##############################
+
+# The Config-specific access policy (GetBucketAcl, ListBucket, PutObject for
+# config.amazonaws.com, plus DenyInsecureTransport) is managed here rather than
+# passed into the child s3/bucket module because the policy document must
+# reference the bucket ARN — which is only known after the module creates the
+# bucket — and passing it as a module input would create a Terraform cycle.
 data "aws_iam_policy_document" "config_bucket" {
   count = var.create_s3_bucket ? 1 : 0
 
@@ -53,7 +52,7 @@ data "aws_iam_policy_document" "config_bucket" {
     }
 
     actions   = ["s3:GetBucketAcl"]
-    resources = [aws_s3_bucket.this[0].arn]
+    resources = [module.config_bucket[0].s3_bucket_arn]
   }
 
   statement {
@@ -66,7 +65,7 @@ data "aws_iam_policy_document" "config_bucket" {
     }
 
     actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.this[0].arn]
+    resources = [module.config_bucket[0].s3_bucket_arn]
   }
 
   statement {
@@ -79,7 +78,7 @@ data "aws_iam_policy_document" "config_bucket" {
     }
 
     actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.this[0].arn}/${local.s3_delivery_path}"]
+    resources = ["${module.config_bucket[0].s3_bucket_arn}/${local.s3_delivery_path}"]
 
     condition {
       test     = "StringEquals"
@@ -100,8 +99,8 @@ data "aws_iam_policy_document" "config_bucket" {
     actions = ["s3:*"]
 
     resources = [
-      aws_s3_bucket.this[0].arn,
-      "${aws_s3_bucket.this[0].arn}/*",
+      module.config_bucket[0].s3_bucket_arn,
+      "${module.config_bucket[0].s3_bucket_arn}/*",
     ]
 
     condition {
@@ -112,72 +111,42 @@ data "aws_iam_policy_document" "config_bucket" {
   }
 }
 
-resource "aws_s3_bucket" "this" {
-  count    = var.create_s3_bucket ? 1 : 0
-  provider = aws.organization_config_account
+module "config_bucket" {
+  count  = var.create_s3_bucket ? 1 : 0
+  source = "../../s3/bucket"
 
-  bucket_prefix = var.s3_bucket_prefix # e.g., "config-" yields globally unique name
-  force_destroy = false
-  tags          = var.tags
-}
-
-resource "aws_s3_bucket_ownership_controls" "this" {
-  count    = var.create_s3_bucket ? 1 : 0
-  provider = aws.organization_config_account
-
-  bucket = aws_s3_bucket.this[0].id
-
-  rule {
-    object_ownership = "BucketOwnerEnforced"
+  providers = {
+    aws = aws.organization_config_account
   }
-}
 
-resource "aws_s3_bucket_public_access_block" "this" {
-  count    = var.create_s3_bucket ? 1 : 0
-  provider = aws.organization_config_account
+  bucket_prefix              = var.s3_bucket_prefix
+  bucket_force_destroy       = var.s3_bucket_force_destroy
+  bucket_object_lock_enabled = var.s3_bucket_object_lock_enabled
 
-  bucket = aws_s3_bucket.this[0].id
+  # SSL enforcement is handled by the inline aws_s3_bucket_policy below,
+  # which also includes Config-specific permissions. Disable it in the child
+  # module to avoid a separate, conflicting bucket policy resource.
+  enforce_ssl = false
 
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
+  versioning_status = "Enabled"
+  sse_algorithm     = "aws:kms"
+  enable_kms_key    = false # AWS-managed key by default; use var.s3_kms_key_arn on the delivery channel for CMK
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
-  count    = var.create_s3_bucket ? 1 : 0
-  provider = aws.organization_config_account
+  enable_s3_bucket_logging = var.enable_s3_bucket_logging
+  logging_target_bucket    = var.s3_logging_target_bucket
+  logging_target_prefix    = var.s3_logging_target_prefix
 
-  bucket = aws_s3_bucket.this[0].id
-
-  rule {
-    bucket_key_enabled = true
-
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms" # SSE-KMS with AWS managed key
-    }
-  }
-}
-
-resource "aws_s3_bucket_versioning" "this" {
-  count    = var.create_s3_bucket ? 1 : 0
-  provider = aws.organization_config_account
-
-  bucket = aws_s3_bucket.this[0].id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
+  tags = merge(tomap({ Name = var.name }), var.tags)
 }
 
 resource "aws_s3_bucket_policy" "this" {
   count    = var.create_s3_bucket ? 1 : 0
   provider = aws.organization_config_account
 
-  bucket = aws_s3_bucket.this[0].id
+  bucket = module.config_bucket[0].s3_bucket_id
   policy = data.aws_iam_policy_document.config_bucket[0].json
 
-  depends_on = [aws_s3_bucket_public_access_block.this]
+  depends_on = [module.config_bucket]
 }
 
 ##############################
@@ -190,8 +159,30 @@ resource "aws_config_configuration_recorder" "this" {
   role_arn = var.recorder_role_arn
 
   recording_group {
-    all_supported                 = true
+    all_supported                 = var.all_supported
     include_global_resource_types = var.include_global_resource_types
+    resource_types                = length(var.resource_types) > 0 ? var.resource_types : null
+
+    dynamic "exclusion_by_resource_types" {
+      for_each = length(var.exclusion_resource_types) > 0 ? [1] : []
+      content {
+        resource_types = var.exclusion_resource_types
+      }
+    }
+
+    dynamic "recording_strategy" {
+      for_each = var.recording_strategy != null ? [var.recording_strategy] : []
+      content {
+        use_only = recording_strategy.value
+      }
+    }
+  }
+
+  dynamic "recording_mode" {
+    for_each = var.recording_frequency != null ? [var.recording_frequency] : []
+    content {
+      recording_frequency = recording_mode.value
+    }
   }
 }
 
@@ -204,10 +195,11 @@ resource "aws_config_delivery_channel" "this" {
   name           = var.delivery_channel_name
   s3_bucket_name = local.bucket_name
   s3_key_prefix  = var.s3_key_prefix
+  s3_kms_key_arn = var.s3_kms_key_arn
   sns_topic_arn  = var.sns_topic_arn
 
   snapshot_delivery_properties {
-    delivery_frequency = var.delivery_frequency # How often Config snapshots are delivered
+    delivery_frequency = var.delivery_frequency
   }
 
   depends_on = [aws_config_configuration_recorder.this]
@@ -232,9 +224,20 @@ resource "aws_config_organization_conformance_pack" "this" {
   for_each = var.enable_conformance_packs ? { for pack in var.conformance_packs : pack.name => pack } : {}
   provider = aws.organization_config_account
 
-  name            = each.value.name
-  template_s3_uri = try(each.value.template_s3_uri, null)
-  template_body   = try(each.value.template_body, null)
+  name                   = each.value.name
+  template_s3_uri        = try(each.value.template_s3_uri, null)
+  template_body          = try(each.value.template_body, null)
+  delivery_s3_bucket     = var.conformance_pack_delivery_s3_bucket
+  delivery_s3_key_prefix = var.conformance_pack_delivery_s3_key_prefix
+  excluded_accounts      = try(each.value.excluded_accounts, null)
+
+  dynamic "input_parameter" {
+    for_each = try(each.value.input_parameters, [])
+    content {
+      parameter_name  = input_parameter.value.parameter_name
+      parameter_value = input_parameter.value.parameter_value
+    }
+  }
 
   depends_on = [aws_config_configuration_recorder_status.this]
 }

--- a/modules/aws/config/organization/main.tf
+++ b/modules/aws/config/organization/main.tf
@@ -17,7 +17,6 @@ terraform {
 ##############################
 locals {
   bucket_name      = var.create_s3_bucket ? module.config_bucket[0].s3_bucket_id : var.s3_bucket_name
-  bucket_arn       = var.create_s3_bucket ? module.config_bucket[0].s3_bucket_arn : "arn:aws:s3:::${var.s3_bucket_name}"
   s3_delivery_path = var.s3_key_prefix != null ? "${var.s3_key_prefix}/AWSLogs/*/Config/*" : "AWSLogs/*/Config/*"
 }
 
@@ -194,7 +193,7 @@ resource "aws_config_delivery_channel" "this" {
 
   name           = var.delivery_channel_name
   s3_bucket_name = local.bucket_name
-  s3_key_prefix  = var.s3_key_prefix
+  s3_key_prefix  = var.s3_key_prefix  # gitleaks:allow
   s3_kms_key_arn = var.s3_kms_key_arn
   sns_topic_arn  = var.sns_topic_arn
 

--- a/modules/aws/config/organization/outputs.tf
+++ b/modules/aws/config/organization/outputs.tf
@@ -1,0 +1,24 @@
+output "delegated_admin_id" {
+  description = "The unique identifier of the delegated administrator registration (account_id:service_principal)."
+  value       = aws_organizations_delegated_administrator.this.id
+}
+
+output "recorder_name" {
+  description = "The name of the AWS Config configuration recorder."
+  value       = aws_config_configuration_recorder.this.name
+}
+
+output "delivery_channel_name" {
+  description = "The name of the AWS Config delivery channel."
+  value       = aws_config_delivery_channel.this.name
+}
+
+output "s3_bucket_id" {
+  description = "The ID (name) of the S3 bucket used for AWS Config delivery. Returns null when create_s3_bucket is false."
+  value       = var.create_s3_bucket ? aws_s3_bucket.this[0].id : null
+}
+
+output "s3_bucket_arn" {
+  description = "The ARN of the S3 bucket used for AWS Config delivery. Returns null when create_s3_bucket is false."
+  value       = var.create_s3_bucket ? aws_s3_bucket.this[0].arn : null
+}

--- a/modules/aws/config/organization/outputs.tf
+++ b/modules/aws/config/organization/outputs.tf
@@ -15,10 +15,10 @@ output "delivery_channel_name" {
 
 output "s3_bucket_id" {
   description = "The ID (name) of the S3 bucket used for AWS Config delivery. Returns null when create_s3_bucket is false."
-  value       = var.create_s3_bucket ? aws_s3_bucket.this[0].id : null
+  value       = var.create_s3_bucket ? module.config_bucket[0].s3_bucket_id : null
 }
 
 output "s3_bucket_arn" {
   description = "The ARN of the S3 bucket used for AWS Config delivery. Returns null when create_s3_bucket is false."
-  value       = var.create_s3_bucket ? aws_s3_bucket.this[0].arn : null
+  value       = var.create_s3_bucket ? module.config_bucket[0].s3_bucket_arn : null
 }

--- a/modules/aws/config/organization/variables.tf
+++ b/modules/aws/config/organization/variables.tf
@@ -1,4 +1,18 @@
 ###########################
+# General Variables
+###########################
+variable "name" {
+  type        = string
+  description = "(Required) A name used as the Name tag on all taggable resources created by this module."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "(Optional) A map of additional tags to assign to all taggable resources. Merged with a Name tag derived from var.name."
+  default     = {}
+}
+
+###########################
 # Organizations Variables
 ###########################
 variable "admin_account_id" {
@@ -32,13 +46,47 @@ variable "recorder_role_arn" {
   }
 }
 
+variable "all_supported" {
+  type        = bool
+  description = "(Optional) Specifies whether AWS Config records configuration changes for every supported type of regional resource. Defaults to true. Set to false when using resource_types for inclusion-based recording."
+  default     = true
+}
+
 variable "include_global_resource_types" {
   type        = bool
-  description = "(Optional) Specifies whether AWS Config includes all supported types of global resources (e.g., IAM) with the resources it records. Defaults to true."
+  description = "(Optional) Specifies whether AWS Config includes all supported types of global resources (e.g., IAM) with the resources it records. Only valid when all_supported is true. Defaults to true."
   default     = true
+}
+
+variable "resource_types" {
+  type        = list(string)
+  description = "(Optional) A list of resource types to include for recording when using INCLUSION_BY_RESOURCE_TYPES recording strategy. Leave empty when all_supported is true."
+  default     = []
+}
+
+variable "exclusion_resource_types" {
+  type        = list(string)
+  description = "(Optional) A list of resource types to exclude from recording when using EXCLUSION_BY_RESOURCE_TYPES recording strategy. Leave empty when all_supported is true and no exclusions are needed."
+  default     = []
+}
+
+variable "recording_strategy" {
+  type        = string
+  description = "(Optional) The recording strategy for the recorder. Valid values: ALL_SUPPORTED_RESOURCE_TYPES, EXCLUSION_BY_RESOURCE_TYPES, INCLUSION_BY_RESOURCE_TYPES. Defaults to null (provider uses ALL_SUPPORTED_RESOURCE_TYPES)."
+  default     = null
   validation {
-    condition     = can(regex("^(true|false)$", var.include_global_resource_types))
-    error_message = "The value must be true or false."
+    condition     = var.recording_strategy == null ? true : contains(["ALL_SUPPORTED_RESOURCE_TYPES", "EXCLUSION_BY_RESOURCE_TYPES", "INCLUSION_BY_RESOURCE_TYPES"], var.recording_strategy)
+    error_message = "The recording_strategy must be one of: ALL_SUPPORTED_RESOURCE_TYPES, EXCLUSION_BY_RESOURCE_TYPES, INCLUSION_BY_RESOURCE_TYPES, or null."
+  }
+}
+
+variable "recording_frequency" {
+  type        = string
+  description = "(Optional) The recording frequency for the recorder. Valid values: CONTINUOUS, DAILY. Defaults to CONTINUOUS."
+  default     = "CONTINUOUS"
+  validation {
+    condition     = var.recording_frequency == null ? true : contains(["CONTINUOUS", "DAILY"], var.recording_frequency)
+    error_message = "The recording_frequency must be CONTINUOUS, DAILY, or null."
   }
 }
 
@@ -65,6 +113,16 @@ variable "delivery_frequency" {
   }
 }
 
+variable "s3_kms_key_arn" {
+  type        = string
+  description = "(Optional) The ARN of the AWS KMS key used to encrypt objects delivered by AWS Config to the S3 delivery bucket. Set to null to use the bucket's default encryption. Defaults to null."
+  default     = null
+  validation {
+    condition     = var.s3_kms_key_arn == null ? true : can(regex("^arn:aws[a-z-]*:kms:[a-z0-9-]+:\\d{12}:key/.+$", var.s3_kms_key_arn))
+    error_message = "The s3_kms_key_arn must be a valid KMS key ARN or null."
+  }
+}
+
 variable "sns_topic_arn" {
   type        = string
   description = "(Optional) The ARN of the SNS topic to which AWS Config sends notifications about configuration changes and compliance. Set to null to disable SNS notifications."
@@ -82,10 +140,6 @@ variable "create_s3_bucket" {
   type        = bool
   description = "(Optional) If true, creates a new S3 bucket for AWS Config delivery. If false, the s3_bucket_name variable must reference an existing bucket. Defaults to true."
   default     = true
-  validation {
-    condition     = can(regex("^(true|false)$", var.create_s3_bucket))
-    error_message = "The value must be true or false."
-  }
 }
 
 variable "s3_bucket_name" {
@@ -108,9 +162,39 @@ variable "s3_bucket_prefix" {
   }
 }
 
+variable "s3_bucket_force_destroy" {
+  type        = bool
+  description = "(Optional) If true, all objects are deleted from the bucket when the bucket is destroyed, allowing the bucket to be destroyed without error. Defaults to false."
+  default     = false
+}
+
+variable "s3_bucket_object_lock_enabled" {
+  type        = bool
+  description = "(Optional) Indicates whether this bucket has Object Lock enabled. Valid values are true or false. Defaults to false."
+  default     = false
+}
+
 variable "s3_key_prefix" {
   type        = string
   description = "(Optional) The S3 key prefix (folder path) within the delivery bucket where AWS Config stores configuration snapshots and history files. Set to null to store at bucket root."
+  default     = null
+}
+
+variable "enable_s3_bucket_logging" {
+  type        = bool
+  description = "(Optional) If true, enables S3 server access logging for the Config delivery bucket. Requires s3_logging_target_bucket to be set. Defaults to false."
+  default     = false
+}
+
+variable "s3_logging_target_bucket" {
+  type        = string
+  description = "(Optional) The name of the S3 bucket to receive server access logs from the Config delivery bucket. Required when enable_s3_bucket_logging is true."
+  default     = null
+}
+
+variable "s3_logging_target_prefix" {
+  type        = string
+  description = "(Optional) A prefix for all log object keys when S3 server access logging is enabled. Defaults to null."
   default     = null
 }
 
@@ -121,31 +205,31 @@ variable "enable_conformance_packs" {
   type        = bool
   description = "(Optional) If true, deploys the organization conformance packs defined in the conformance_packs variable. Defaults to false."
   default     = false
-  validation {
-    condition     = can(regex("^(true|false)$", var.enable_conformance_packs))
-    error_message = "The value must be true or false."
-  }
 }
 
 variable "conformance_packs" {
   type = list(object({
-    name            = string
-    template_s3_uri = optional(string)
-    template_body   = optional(string)
+    name              = string
+    template_s3_uri   = optional(string)
+    template_body     = optional(string)
+    excluded_accounts = optional(list(string), [])
+    input_parameters = optional(list(object({
+      parameter_name  = string
+      parameter_value = string
+    })), [])
   }))
-  description = "(Optional) List of organization conformance packs to deploy. Each object requires a name, and either a template_s3_uri (S3 URI to a conformance pack template) or template_body (inline YAML template). Only used when enable_conformance_packs is true."
+  description = "(Optional) List of organization conformance packs to deploy. Each object requires a name and either template_s3_uri or template_body. Optionally supply excluded_accounts (list of account IDs to exclude) and input_parameters (list of name/value pairs to pass to the template). Only used when enable_conformance_packs is true."
   default     = []
 }
 
-###########################
-# General Variables
-###########################
-variable "tags" {
-  type        = map(string)
-  description = "(Optional) A map of tags to assign to all taggable resources created by this module."
-  default = {
-    created_by  = "<YOUR NAME>"
-    environment = "prod"
-    terraform   = "true"
-  }
+variable "conformance_pack_delivery_s3_bucket" {
+  type        = string
+  description = "(Optional) The name of the S3 bucket where AWS Config stores conformance pack templates and results. Set to null to use the main delivery bucket."
+  default     = null
+}
+
+variable "conformance_pack_delivery_s3_key_prefix" {
+  type        = string
+  description = "(Optional) The prefix for the S3 key where conformance pack templates and results are stored. Defaults to null."
+  default     = null
 }

--- a/modules/aws/config/organization/variables.tf
+++ b/modules/aws/config/organization/variables.tf
@@ -1,0 +1,151 @@
+###########################
+# Organizations Variables
+###########################
+variable "admin_account_id" {
+  type        = string
+  description = "(Required) The AWS account ID to register as the delegated administrator for AWS Config in the organization."
+  validation {
+    condition     = can(regex("^\\d{12}$", var.admin_account_id))
+    error_message = "The value of admin_account_id must be a 12-digit AWS account ID."
+  }
+}
+
+###########################
+# Config Recorder Variables
+###########################
+variable "recorder_name" {
+  type        = string
+  description = "(Optional) The name of the AWS Config configuration recorder. Only one recorder per region is allowed. Defaults to 'default'."
+  default     = "default"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_-]{1,256}$", var.recorder_name))
+    error_message = "The recorder_name must be 1-256 alphanumeric characters, hyphens, or underscores."
+  }
+}
+
+variable "recorder_role_arn" {
+  type        = string
+  description = "(Required) ARN of the IAM role that AWS Config uses to record and deliver configuration changes. Must have the AWSConfigRole managed policy or equivalent permissions."
+  validation {
+    condition     = can(regex("^arn:aws[a-z-]*:iam::\\d{12}:role/.+$", var.recorder_role_arn))
+    error_message = "The recorder_role_arn must be a valid IAM role ARN."
+  }
+}
+
+variable "include_global_resource_types" {
+  type        = bool
+  description = "(Optional) Specifies whether AWS Config includes all supported types of global resources (e.g., IAM) with the resources it records. Defaults to true."
+  default     = true
+  validation {
+    condition     = can(regex("^(true|false)$", var.include_global_resource_types))
+    error_message = "The value must be true or false."
+  }
+}
+
+###########################
+# Delivery Channel Variables
+###########################
+variable "delivery_channel_name" {
+  type        = string
+  description = "(Optional) The name of the AWS Config delivery channel. Defaults to 'default'."
+  default     = "default"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_-]{1,256}$", var.delivery_channel_name))
+    error_message = "The delivery_channel_name must be 1-256 alphanumeric characters, hyphens, or underscores."
+  }
+}
+
+variable "delivery_frequency" {
+  type        = string
+  description = "(Optional) The frequency with which AWS Config delivers configuration snapshots to the S3 bucket. Valid values: One_Hour, Three_Hours, Six_Hours, Twelve_Hours, TwentyFour_Hours. Defaults to TwentyFour_Hours."
+  default     = "TwentyFour_Hours"
+  validation {
+    condition     = contains(["One_Hour", "Three_Hours", "Six_Hours", "Twelve_Hours", "TwentyFour_Hours"], var.delivery_frequency)
+    error_message = "The delivery_frequency must be one of: One_Hour, Three_Hours, Six_Hours, Twelve_Hours, TwentyFour_Hours."
+  }
+}
+
+variable "sns_topic_arn" {
+  type        = string
+  description = "(Optional) The ARN of the SNS topic to which AWS Config sends notifications about configuration changes and compliance. Set to null to disable SNS notifications."
+  default     = null
+  validation {
+    condition     = var.sns_topic_arn == null ? true : can(regex("^arn:aws[a-z-]*:sns:[a-z0-9-]+:\\d{12}:.+$", var.sns_topic_arn))
+    error_message = "The sns_topic_arn must be a valid SNS topic ARN or null."
+  }
+}
+
+###########################
+# S3 Bucket Variables
+###########################
+variable "create_s3_bucket" {
+  type        = bool
+  description = "(Optional) If true, creates a new S3 bucket for AWS Config delivery. If false, the s3_bucket_name variable must reference an existing bucket. Defaults to true."
+  default     = true
+  validation {
+    condition     = can(regex("^(true|false)$", var.create_s3_bucket))
+    error_message = "The value must be true or false."
+  }
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "(Optional) The name of an existing S3 bucket to use for AWS Config delivery when create_s3_bucket is false. Must be set when create_s3_bucket is false."
+  default     = null
+  validation {
+    condition     = var.s3_bucket_name == null ? true : can(regex("^[a-z0-9][a-z0-9.\\-]{1,61}[a-z0-9]$", var.s3_bucket_name))
+    error_message = "The s3_bucket_name must be a valid S3 bucket name (lowercase, 3-63 characters) or null."
+  }
+}
+
+variable "s3_bucket_prefix" {
+  type        = string
+  description = "(Optional) Name prefix for the S3 bucket created when create_s3_bucket is true. AWS will append a unique suffix to ensure global uniqueness. Defaults to 'config-'."
+  default     = "config-"
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.\\-]{0,36}$", var.s3_bucket_prefix))
+    error_message = "The s3_bucket_prefix must be lowercase alphanumeric, hyphens, or periods, and no more than 37 characters."
+  }
+}
+
+variable "s3_key_prefix" {
+  type        = string
+  description = "(Optional) The S3 key prefix (folder path) within the delivery bucket where AWS Config stores configuration snapshots and history files. Set to null to store at bucket root."
+  default     = null
+}
+
+###########################
+# Conformance Pack Variables
+###########################
+variable "enable_conformance_packs" {
+  type        = bool
+  description = "(Optional) If true, deploys the organization conformance packs defined in the conformance_packs variable. Defaults to false."
+  default     = false
+  validation {
+    condition     = can(regex("^(true|false)$", var.enable_conformance_packs))
+    error_message = "The value must be true or false."
+  }
+}
+
+variable "conformance_packs" {
+  type = list(object({
+    name            = string
+    template_s3_uri = optional(string)
+    template_body   = optional(string)
+  }))
+  description = "(Optional) List of organization conformance packs to deploy. Each object requires a name, and either a template_s3_uri (S3 URI to a conformance pack template) or template_body (inline YAML template). Only used when enable_conformance_packs is true."
+  default     = []
+}
+
+###########################
+# General Variables
+###########################
+variable "tags" {
+  type        = map(string)
+  description = "(Optional) A map of tags to assign to all taggable resources created by this module."
+  default = {
+    created_by  = "<YOUR NAME>"
+    environment = "prod"
+    terraform   = "true"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `modules/aws/config/organization` — a dual-provider Terraform module that enables AWS Config at the organization level.

**Follows the `guardduty/organization` dual-provider pattern exactly.**

### Resources created
- `aws_organizations_delegated_administrator` — registers the config account as delegated admin for `config.amazonaws.com` (management account provider)
- `aws_config_configuration_recorder` — records all resource types including global resources (config account provider)
- `aws_config_delivery_channel` — delivers snapshots to S3 with configurable frequency and optional SNS topic
- `aws_config_configuration_recorder_status` — enables the recorder (depends on delivery channel)
- `aws_s3_bucket` + `aws_s3_bucket_ownership_controls` + `aws_s3_bucket_public_access_block` + `aws_s3_bucket_server_side_encryption_configuration` + `aws_s3_bucket_versioning` + `aws_s3_bucket_policy` — optional delivery bucket (`count = var.create_s3_bucket ? 1 : 0`), SSE-KMS encrypted, versioned, all public access blocked, Config service principal policy + SSL enforcement
- `aws_config_organization_conformance_pack` — optional org conformance packs (`for_each`, gated by `var.enable_conformance_packs`)

### Design decisions
- Scope is **read/reporting only** — no enforcement Config Rules deployed
- S3 bucket policy includes `AWSConfigBucketPermissionsCheck`, `AWSConfigBucketExistenceCheck`, `AWSConfigBucketDelivery`, and `DenyInsecureTransport` statements
- `terraform validate` produces "Provider configuration not present" for aliased providers — this is **expected behavior** for standalone `configuration_aliases` modules (same as `guardduty/organization`)
- `s3_bucket_prefix` is the bucket name prefix when creating; `s3_key_prefix` is the delivery path prefix within the bucket
- Added `recorder_name` and `delivery_channel_name` variables (both default `"default"`) for import capability

Closes DEVSECOPS-32

Co-Authored-By: Oz <oz-agent@warp.dev>

---
_Conversation: https://app.warp.dev/conversation/92e236f4-81ad-41ac-9b85-e0dd5391e30f_
_Run: https://oz.warp.dev/runs/019e4b0b-0312-777a-b4db-e7a39f209274_
_This PR was generated with [Oz](https://warp.dev/oz)._
