### PR TITLE
fix(aws/cloudtrail): remove invalid empty filter {} from lifecycle rule

### DIFF
--- a/modules/aws/cloudtrail/main.tf
+++ b/modules/aws/cloudtrail/main.tf
@@ -252,7 +252,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail_bucket_lifecycle" {
     id     = var.bucket_lifecycle_rule_id
     status = "Enabled"
 
-    filter {}
     expiration {
       days = var.bucket_lifecycle_expiration_days
     }


### PR DESCRIPTION
# Description
Removes the empty `filter {}` block from `aws_s3_bucket_lifecycle_configuration.cloudtrail_bucket_lifecycle`. Empty filter blocks are a hard error in AWS provider `>= 6.0.0` (the version this repo requires). Omitting the filter block is the correct way to apply a lifecycle rule to all objects — behavior is identical.

## Issue or Ticket
Fixes #231

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Version update

## Breaking Changes
- [ ] Yes
- [x] No

## TODOs
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [x] Validate all tests run successfully, including pre-commit checks.
- [x] Include release notes and description.