### PR TITLE
docs(readme): document Oz-powered agentic contribution pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,78 @@ See the [open issues](https://github.com/zachreborn/terraform-modules/issues) fo
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
 
-If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
-Don't forget to give the project a star! Thank you!
+This project uses an **Oz-powered agentic development pipeline** that turns well-formed issues into reviewed specs, and approved specs into implementation PRs. You can contribute either by filing an issue and letting the pipeline drive the work, or by opening a PR yourself. Both paths go through the same CI and codeowner review.
 
-1. Fork the Project
-2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the Branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+The authoritative reference for repo conventions, the pipeline design, labels, and trust gating is [`AGENTS.md`](./AGENTS.md). The sections below summarize what you need to know to participate.
+
+### Pipeline overview
+
+The diagram below shows the end-to-end flow from issue creation to a merged implementation PR. Each transition is driven by a label that the corresponding workflow either applies or reacts to.
+
+```mermaid
+stateDiagram-v2
+    [*] --> triage: issue opened/edited
+    triage --> needs_info: missing required info
+    triage --> ready_for_spec: meets minimum standards
+    needs_info --> triage: author edits issue
+    ready_for_spec --> spec_in_progress: Spec Generation (Oz) runs
+    spec_in_progress --> spec_ready_for_review: spec PR opened
+    spec_in_progress --> ready_for_spec: failure (label restored)
+    spec_ready_for_review --> spec_approved: codeowner merges spec PR
+    spec_approved --> implementation_in_progress: Implementation (Oz) runs
+    implementation_in_progress --> [*]: implementation PR merged
+    implementation_in_progress --> spec_approved: failure (label restored)
+```
+
+The four Oz workflows that drive these transitions are:
+
+- [`issue-triage.yml`](./.github/workflows/issue-triage.yml) — validates new and edited issues against the minimum standards, then applies `needs-info` or `ready-for-spec`.
+- [`spec-generation.yml`](./.github/workflows/spec-generation.yml) — opens a spec PR under `.github/specs/issue-<N>-<slug>.md` based on `_template.md`.
+- [`spec-approved.yml`](./.github/workflows/spec-approved.yml) — when a spec PR is merged, flips the originating issue to `spec-approved` and dispatches the next stage.
+- [`implementation.yml`](./.github/workflows/implementation.yml) — reads the merged spec from `main` and opens an implementation PR with `Fixes #<N>`.
+
+All three Oz-agent workflows (`issue-triage`, `spec-generation`, `implementation`) gate on the issue author's `author_association` being one of `OWNER`, `MEMBER`, or `COLLABORATOR`. Issues from external contributors are not auto-advanced through the pipeline; a maintainer must shepherd them manually. Apply the `skip-oz` label at any time to opt an issue out of all Oz workflows.
+
+### Filing an issue
+
+Use the issue templates under [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE) and include everything the triage agent looks for. Issues that meet the minimum standards are auto-labeled `ready-for-spec` and the pipeline takes over from there.
+
+**Bug** issues must include:
+
+1. Affected module path (e.g. `modules/aws/ec2_instance`).
+2. Terraform version and relevant provider versions.
+3. Reproduction steps.
+4. Expected vs. actual behavior.
+5. One of: error message, stack trace, or `plan`/`apply` output.
+6. Acceptance criteria for "fixed."
+
+**Feature** issues must include:
+
+1. Target module path (existing or proposed under `modules/<provider>/<name>/`).
+2. Motivation / problem being solved.
+3. High-level proposed inputs and outputs.
+4. Breaking-change assessment (yes/no + scope).
+5. Acceptance criteria for "done."
+
+If anything is missing, the triage agent will comment listing the gaps and apply `needs-info`. Edit the issue body and the agent will re-evaluate.
+
+### Reviewing an Oz-generated spec
+
+Spec PRs land under [`.github/specs/`](./.github/specs) and are opened **ready-for-review** (not draft) so CODEOWNERS are auto-assigned. Review them as you would any other PR — focus on the proposed `variables.tf` / `outputs.tf` / `main.tf` shape, the breaking-change assessment, and the acceptance criteria. Merging the spec PR is what triggers the implementation stage; do not merge until the design is what you want built.
+
+### Reviewing an Oz-generated implementation
+
+Implementation PRs are opened from branches named `feat/issue-<N>-<slug>` or `fix/issue-<N>-<slug>`, include `Fixes #<N>` in the body, and run through the standard CI (`build.yml`, `test.yml`, `scan.yml`) like any other PR. The same review and merge rules apply. Squash-and-merge is preferred.
+
+### Contributing a PR directly (no pipeline)
+
+You are always free to skip the pipeline and submit a PR the traditional way. This is the right path for small fixes, dependency bumps, or any change where writing a spec first would be more friction than value.
+
+1. Fork the project.
+2. Create your feature branch: `git switch -c feat/short-description` (or `fix/...`).
+3. Make your changes following the conventions in [`AGENTS.md`](./AGENTS.md) — the four-file module layout, `terraform fmt -recursive`, the tagging pattern, and tfsec/Checkov suppression style.
+4. Validate locally: `terraform -chdir=<module_path> init -backend=false` then `terraform -chdir=<module_path> validate`.
+5. Push and open a PR. Fill in every section of [`.github/pull_request_template.md`](./.github/pull_request_template.md). CI will auto-regenerate the `terraform-docs` block and auto-commit it.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The authoritative reference for repo conventions, the pipeline design, labels, a
 
 ### Pipeline overview
 
-The diagram below shows the end-to-end flow from issue creation to a merged implementation PR. Each named state corresponds to a GitHub label of the same name on the originating issue. Transitions are triggered by a mix of GitHub events (an issue being opened/edited, or the spec PR being merged) and labels that the Oz workflows apply and react to.
+The diagram below shows the end-to-end flow from issue creation to a merged implementation PR. Every hyphenated state in the diagram (`needs-info`, `ready-for-spec`, `spec-in-progress`, `spec-ready-for-review`, `spec-approved`, `implementation-in-progress`) corresponds to a GitHub label of the same name on the originating issue. The `triage` node is **not** a label — it represents an active run of the `Issue Triage (Oz)` workflow. Transitions are triggered by a mix of GitHub events (an issue being opened/edited, or the spec PR being merged) and labels that the Oz workflows apply and react to.
 
 ```mermaid
 stateDiagram-v2
@@ -175,11 +175,11 @@ stateDiagram-v2
     needs_info --> triage: author edits issue
     ready_for_spec --> spec_in_progress: Spec Generation (Oz) runs
     spec_in_progress --> spec_ready_for_review: spec PR opened
-    spec_in_progress --> ready_for_spec: failure (label restored)
+    spec_in_progress --> ready_for_spec: failure (spec-in-progress removed)
     spec_ready_for_review --> spec_approved: spec PR merged (pull_request: closed)
     spec_approved --> implementation_in_progress: Implementation (Oz) runs
     implementation_in_progress --> [*]: implementation PR merged
-    implementation_in_progress --> spec_approved: failure (label restored)
+    implementation_in_progress --> spec_approved: failure (implementation-in-progress removed)
 ```
 
 The four Oz workflows that drive these transitions are:
@@ -189,7 +189,7 @@ The four Oz workflows that drive these transitions are:
 - [`spec-approved.yml`](./.github/workflows/spec-approved.yml) — when a spec PR is merged, flips the originating issue to `spec-approved` and dispatches the next stage.
 - [`implementation.yml`](./.github/workflows/implementation.yml) — reads the merged spec from `main` and opens an implementation PR with `Fixes #<N>`.
 
-All three Oz-agent workflows (`issue-triage`, `spec-generation`, `implementation`) gate on the issue author's `author_association` being one of `OWNER`, `MEMBER`, or `COLLABORATOR`. Issues from external contributors are not auto-advanced through the pipeline; a maintainer must shepherd them manually. Apply the `skip-oz` label at any time to opt an issue out of all Oz workflows.
+All three Oz-agent workflows (`issue-triage`, `spec-generation`, `implementation`) gate on the issue author's `author_association` being one of `OWNER`, `MEMBER`, or `COLLABORATOR`. Issues from external contributors are not auto-advanced through the pipeline; a maintainer must shepherd them manually. Apply the `skip-oz` label at any time and each Oz agent will abort at the start of its run. Note that `spec-approved.yml` itself does **not** check `skip-oz`, so merging a spec PR will still dispatch `implementation.yml`; the dispatched run then aborts during its eligibility step, producing a (harmless but visible) failed workflow run in the Actions tab.
 
 ### Filing an issue
 
@@ -232,7 +232,7 @@ You are always free to skip the pipeline and submit a PR the traditional way. Th
 4. Validate locally: `terraform -chdir=<module_path> init -backend=false` then `terraform -chdir=<module_path> validate`.
 5. Push and open a PR, filling in every section of [`.github/pull_request_template.md`](./.github/pull_request_template.md).
 
-**A note on `terraform-docs` and `terraform fmt`:** for PRs opened from a branch in this repo, the `Build` workflow ([`build.yml`](./.github/workflows/build.yml)) runs `terraform fmt -recursive` and regenerates each module's `<!-- BEGIN_TF_DOCS -->` block, then auto-commits the result back to your branch. For PRs opened from a **fork**, `GITHUB_TOKEN` is read-only and the workflow cannot push back, so you must run these locally before opening the PR:
+**A note on `terraform-docs` and `terraform fmt`:** for PRs opened from a branch in this repo, the `Build` workflow ([`build.yml`](./.github/workflows/build.yml)) runs `terraform fmt -recursive` and regenerates each module's `<!-- BEGIN_TF_DOCS -->` block, then auto-commits the result back to your branch. The current `build.yml` is **not fork-compatible** — it checks out `${{ github.event.pull_request.head.ref }}` against the base repository without setting `repository: head.repo.full_name`, so the checkout fails for PRs opened from a fork. Until that is addressed, fork contributors must run these locally before opening the PR:
 
 ```sh
 terraform fmt -recursive

--- a/README.md
+++ b/README.md
@@ -158,10 +158,17 @@ The authoritative reference for repo conventions, the pipeline design, labels, a
 
 ### Pipeline overview
 
-The diagram below shows the end-to-end flow from issue creation to a merged implementation PR. Each transition is driven by a label that the corresponding workflow either applies or reacts to.
+The diagram below shows the end-to-end flow from issue creation to a merged implementation PR. Each named state corresponds to a GitHub label of the same name on the originating issue. Transitions are triggered by a mix of GitHub events (an issue being opened/edited, or the spec PR being merged) and labels that the Oz workflows apply and react to.
 
 ```mermaid
 stateDiagram-v2
+    state "needs-info" as needs_info
+    state "ready-for-spec" as ready_for_spec
+    state "spec-in-progress" as spec_in_progress
+    state "spec-ready-for-review" as spec_ready_for_review
+    state "spec-approved" as spec_approved
+    state "implementation-in-progress" as implementation_in_progress
+
     [*] --> triage: issue opened/edited
     triage --> needs_info: missing required info
     triage --> ready_for_spec: meets minimum standards
@@ -169,7 +176,7 @@ stateDiagram-v2
     ready_for_spec --> spec_in_progress: Spec Generation (Oz) runs
     spec_in_progress --> spec_ready_for_review: spec PR opened
     spec_in_progress --> ready_for_spec: failure (label restored)
-    spec_ready_for_review --> spec_approved: codeowner merges spec PR
+    spec_ready_for_review --> spec_approved: spec PR merged (pull_request: closed)
     spec_approved --> implementation_in_progress: Implementation (Oz) runs
     implementation_in_progress --> [*]: implementation PR merged
     implementation_in_progress --> spec_approved: failure (label restored)
@@ -223,7 +230,14 @@ You are always free to skip the pipeline and submit a PR the traditional way. Th
 2. Create your feature branch: `git switch -c feat/short-description` (or `fix/...`).
 3. Make your changes following the conventions in [`AGENTS.md`](./AGENTS.md) — the four-file module layout, `terraform fmt -recursive`, the tagging pattern, and tfsec/Checkov suppression style.
 4. Validate locally: `terraform -chdir=<module_path> init -backend=false` then `terraform -chdir=<module_path> validate`.
-5. Push and open a PR. Fill in every section of [`.github/pull_request_template.md`](./.github/pull_request_template.md). CI will auto-regenerate the `terraform-docs` block and auto-commit it.
+5. Push and open a PR, filling in every section of [`.github/pull_request_template.md`](./.github/pull_request_template.md).
+
+**A note on `terraform-docs` and `terraform fmt`:** for PRs opened from a branch in this repo, the `Build` workflow ([`build.yml`](./.github/workflows/build.yml)) runs `terraform fmt -recursive` and regenerates each module's `<!-- BEGIN_TF_DOCS -->` block, then auto-commits the result back to your branch. For PRs opened from a **fork**, `GITHUB_TOKEN` is read-only and the workflow cannot push back, so you must run these locally before opening the PR:
+
+```sh
+terraform fmt -recursive
+terraform-docs markdown table --output-file README.md --output-mode inject <module_path>
+```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
# Description
Rewrites the **Contributing** section of `README.md` around the Oz-powered agentic development pipeline introduced in #207, #211, and #214.

The previous section was a generic 5-step fork/branch/commit/push/PR list that no longer reflects how work actually flows through this repo. The new section:

- Adds a mermaid `stateDiagram-v2` showing the full issue → spec → implementation lifecycle and every label transition, including the failure-restoration edges from `spec-generation.yml` and `implementation.yml`.
- Links each of the four Oz workflows (`issue-triage.yml`, `spec-generation.yml`, `spec-approved.yml`, `implementation.yml`) directly.
- Documents the `author_association` trust gate (`OWNER`/`MEMBER`/`COLLABORATOR`) and the `skip-oz` opt-out so contributors know how the gating works.
- Pulls the **bug** and **feature** minimum standards straight from the triage prompt in `issue-triage.yml` so contributors know exactly what unlocks `ready-for-spec`.
- Adds review guidance for Oz-generated spec PRs (under `.github/specs/`, opened ready-for-review, merging triggers implementation) and Oz-generated implementation PRs (`feat|fix/issue-<N>-<slug>` branches with `Fixes #<N>`).
- Preserves a manual PR path for small fixes/dependency bumps and updates it to reference `AGENTS.md`, `git switch`, per-module `terraform init -backend=false` + `validate`, and the existing `pull_request_template.md`.
- Points contributors at `AGENTS.md` as the authoritative source for the full pipeline design rather than duplicating it.

## Issue or Ticket
No tracking issue — docs-only follow-up to the workflow changes already merged in #207, #211, and #214.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Version update
- [x] Documentation

## Breaking Changes
- [ ] Yes
- [x] No

### Breaking Changes Description
N/A — README-only change. No module code, no CI, no consumer-facing inputs/outputs touched.

## TODOs
- [x] Validate your code matches the style of the project.
- [x] Update the docs.
- [x] Validate all tests run successfull, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.

---

Generated with [Warp](https://app.warp.dev/conversation/2a535ebf-3da7-47a3-bba9-1c715e376ecf).

Co-Authored-By: Oz <oz-agent@warp.dev>
