### PR TITLE
feat: add invisible unicode character CI check

### DIFF
--- a/.github/scripts/check_unicode.sh
+++ b/.github/scripts/check_unicode.sh
@@ -53,6 +53,9 @@ echo ""
 # We run without error suppression so that any grep failure (unsupported
 # --perl-regexp, bad locale, unreadable path, etc.) surfaces immediately
 # rather than silently appearing as a clean scan.
+# Initialize to 0 so an inherited GREP_EXIT in the caller's environment
+# cannot produce a false positive error result.
+GREP_EXIT=0
 MATCHES=$(grep \
 	--recursive \
 	--perl-regexp \

--- a/.github/scripts/check_unicode.sh
+++ b/.github/scripts/check_unicode.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# check_unicode.sh
+#
+# Scans the repository for invisible and dangerous Unicode characters that can
+# silently corrupt Terraform configs, scripts, or documentation.
+#
+# Categories checked:
+#   - Byte Order Mark (BOM)              U+FEFF
+#   - Soft Hyphen                        U+00AD
+#   - Zero-Width Space                   U+200B
+#   - Zero-Width Non-Joiner              U+200C
+#   - Zero-Width Non-Breaking Space      U+FEFF (also caught by BOM pattern)
+#   - Zero-Width Joiner                  U+200D
+#   - Word Joiner                        U+2060
+#   - Left-to-Right / Right-to-Left marks U+200E, U+200F
+#   - Bidirectional control characters   U+202A–U+202E  (LRE, RLE, PDF, LRO, RLO)
+#   - Bidirectional isolates             U+2066–U+2069  (LRI, RLI, FSI, PDI)
+#   - "Trojan Source" bidi overrides     U+202D, U+202E (LRO, RLO — subset of above)
+#
+# Exit codes:
+#   0 — no matches found (clean)
+#   1 — one or more matches found (CI failure)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# PCRE pattern — matches any of the code points listed above.
+# Each \x{NNNN} escape matches one Unicode scalar value.
+PATTERN=$(cat <<'EOF'
+[\x{00AD}\x{200B}\x{200C}\x{200D}\x{200E}\x{200F}\x{202A}\x{202B}\x{202C}\x{202D}\x{202E}\x{2060}\x{2066}\x{2067}\x{2068}\x{2069}\x{FEFF}]
+EOF
+)
+# Trim trailing newline introduced by the heredoc
+PATTERN="${PATTERN%$'\n'}"
+
+echo "Scanning for invisible Unicode characters in: ${REPO_ROOT}"
+echo "Pattern: ${PATTERN}"
+echo ""
+
+# grep flags:
+#   -r  recursive
+#   -P  Perl-compatible regex (required for \x{NNNN} Unicode escapes)
+#   -n  print line numbers
+#   -l  (not used) — we want file:line detail, not just filenames
+#   --include is omitted intentionally — scan all text files
+#   -I  skip binary files
+#   --exclude-dir skips .git to avoid false positives in git internals
+MATCHES=$(grep \
+  --recursive \
+  --perl-regexp \
+  --line-number \
+  --binary-files=without-match \
+  --exclude-dir=".git" \
+  -- "${PATTERN}" "${REPO_ROOT}" 2>/dev/null || true)
+
+if [[ -z "${MATCHES}" ]]; then
+  echo "✓ No invisible Unicode characters found."
+  exit 0
+fi
+
+echo "✗ Invisible Unicode characters detected. Remove them before merging."
+echo ""
+echo "Matches (file:line:content):"
+echo "----------------------------------------------------------------------"
+echo "${MATCHES}"
+echo "----------------------------------------------------------------------"
+echo ""
+echo "To locate and remove these manually, run locally:"
+echo "  grep -rPn '${PATTERN}' <file>"
+echo ""
+exit 1

--- a/.github/scripts/check_unicode.sh
+++ b/.github/scripts/check_unicode.sh
@@ -27,7 +27,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # PCRE pattern — matches any of the code points listed above.
 # Each \x{NNNN} escape matches one Unicode scalar value.
-PATTERN=$(cat <<'EOF'
+PATTERN=$(
+	cat <<'EOF'
 [\x{00AD}\x{200B}\x{200C}\x{200D}\x{200E}\x{200F}\x{202A}\x{202B}\x{202C}\x{202D}\x{202E}\x{2060}\x{2066}\x{2067}\x{2068}\x{2069}\x{FEFF}]
 EOF
 )
@@ -47,16 +48,16 @@ echo ""
 #   -I  skip binary files
 #   --exclude-dir skips .git to avoid false positives in git internals
 MATCHES=$(grep \
-  --recursive \
-  --perl-regexp \
-  --line-number \
-  --binary-files=without-match \
-  --exclude-dir=".git" \
-  -- "${PATTERN}" "${REPO_ROOT}" 2>/dev/null || true)
+	--recursive \
+	--perl-regexp \
+	--line-number \
+	--binary-files=without-match \
+	--exclude-dir=".git" \
+	-- "${PATTERN}" "${REPO_ROOT}" 2>/dev/null || true)
 
 if [[ -z "${MATCHES}" ]]; then
-  echo "✓ No invisible Unicode characters found."
-  exit 0
+	echo "✓ No invisible Unicode characters found."
+	exit 0
 fi
 
 echo "✗ Invisible Unicode characters detected. Remove them before merging."

--- a/.github/scripts/check_unicode.sh
+++ b/.github/scripts/check_unicode.sh
@@ -20,6 +20,7 @@
 # Exit codes:
 #   0 — no matches found (clean)
 #   1 — one or more matches found (CI failure)
+#   2 — grep itself encountered an error (e.g. unsupported flag, PCRE not available)
 
 set -euo pipefail
 
@@ -47,13 +48,25 @@ echo ""
 #   --include is omitted intentionally — scan all text files
 #   -I  skip binary files
 #   --exclude-dir skips .git to avoid false positives in git internals
+#
+# grep exit codes: 0 = matches found, 1 = no matches, 2+ = error.
+# We run without error suppression so that any grep failure (unsupported
+# --perl-regexp, bad locale, unreadable path, etc.) surfaces immediately
+# rather than silently appearing as a clean scan.
 MATCHES=$(grep \
 	--recursive \
 	--perl-regexp \
 	--line-number \
 	--binary-files=without-match \
 	--exclude-dir=".git" \
-	-- "${PATTERN}" "${REPO_ROOT}" 2>/dev/null || true)
+	-- "${PATTERN}" "${REPO_ROOT}") || GREP_EXIT=$?
+
+# grep exits 1 when it finds no matches — that is the success case.
+# Any other non-zero exit means grep itself failed; abort.
+if [[ "${GREP_EXIT:-0}" -ge 2 ]]; then
+	echo "✗ grep encountered an error (exit ${GREP_EXIT}). Check that grep supports --perl-regexp (GNU grep required)."
+	exit 2
+fi
 
 if [[ -z "${MATCHES}" ]]; then
 	echo "✓ No invisible Unicode characters found."

--- a/.github/scripts/check_unicode.sh
+++ b/.github/scripts/check_unicode.sh
@@ -44,7 +44,9 @@ echo ""
 #   -r  recursive
 #   -P  Perl-compatible regex (required for \x{NNNN} Unicode escapes)
 #   -n  print line numbers
-#   -l  (not used) — we want file:line detail, not just filenames
+#   -o  print only the matched character, not the full surrounding line;
+#       this prevents sensitive line content (tokens, credentials) from
+#       leaking into CI logs
 #   --include is omitted intentionally — scan all text files
 #   -I  skip binary files
 #   --exclude-dir skips .git to avoid false positives in git internals
@@ -60,6 +62,7 @@ MATCHES=$(grep \
 	--recursive \
 	--perl-regexp \
 	--line-number \
+	--only-matching \
 	--binary-files=without-match \
 	--exclude-dir=".git" \
 	-- "${PATTERN}" "${REPO_ROOT}") || GREP_EXIT=$?
@@ -78,12 +81,47 @@ fi
 
 echo "✗ Invisible Unicode characters detected. Remove them before merging."
 echo ""
-echo "Matches (file:line:content):"
+echo "Matches (file:line: U+XXXX name):"
 echo "----------------------------------------------------------------------"
-echo "${MATCHES}"
+# Decode each matched invisible character to its Unicode code point name.
+# Raw line content is intentionally omitted to avoid leaking sensitive
+# text (tokens, credentials, keys) that may appear on the same line.
+echo "${MATCHES}" | python3 -c "
+import sys
+NAMES = {
+    0x00AD: 'SOFT HYPHEN',
+    0x200B: 'ZERO WIDTH SPACE',
+    0x200C: 'ZERO WIDTH NON-JOINER',
+    0x200D: 'ZERO WIDTH JOINER',
+    0x200E: 'LEFT-TO-RIGHT MARK',
+    0x200F: 'RIGHT-TO-LEFT MARK',
+    0x202A: 'LEFT-TO-RIGHT EMBEDDING',
+    0x202B: 'RIGHT-TO-LEFT EMBEDDING',
+    0x202C: 'POP DIRECTIONAL FORMATTING',
+    0x202D: 'LEFT-TO-RIGHT OVERRIDE',
+    0x202E: 'RIGHT-TO-LEFT OVERRIDE',
+    0x2060: 'WORD JOINER',
+    0x2066: 'LEFT-TO-RIGHT ISOLATE',
+    0x2067: 'RIGHT-TO-LEFT ISOLATE',
+    0x2068: 'FIRST STRONG ISOLATE',
+    0x2069: 'POP DIRECTIONAL ISOLATE',
+    0xFEFF: 'ZERO WIDTH NO-BREAK SPACE (BOM)',
+}
+for line in sys.stdin:
+    line = line.rstrip()
+    # grep -n -o output: filepath:linenum:CHAR
+    # rsplit from right so filepaths containing colons are preserved
+    parts = line.rsplit(':', 2)
+    if len(parts) == 3:
+        filepath, linenum, char = parts
+        if char:
+            cp = ord(char[0])
+            name = NAMES.get(cp, 'UNKNOWN')
+            print(f'{filepath}:{linenum}: U+{cp:04X} ({name})')
+"
 echo "----------------------------------------------------------------------"
 echo ""
 echo "To locate and remove these manually, run locally:"
-echo "  grep -rPn '${PATTERN}' <file>"
+echo "  grep -rPno '${PATTERN}' <file>"
 echo ""
 exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,21 @@ jobs:
         id: fmt
         run: terraform fmt -check -diff -recursive
 
+  test_unicode:
+    name: Invisible Unicode Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Check for invisible Unicode characters
+        run: bash .github/scripts/check_unicode.sh
+
   test_linter:
     name: Linter
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
 
     steps:
       - name: HashiCorp - Setup Terraform
@@ -33,6 +31,8 @@ jobs:
 
       - name: Terraform fmt
         id: fmt
+        env:
+          TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
         run: terraform fmt -check -diff -recursive
 
   test_unicode:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Terraform fmt
         id: fmt
-        env:
-          TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
         run: terraform fmt -check -diff -recursive
 
   test_unicode:


### PR DESCRIPTION
## Summary

Adds a CI gate that blocks invisible and dangerous Unicode characters from being merged into the repository.

### Changes
- **New script** \`.github/scripts/check_unicode.sh\`: A standalone bash script using \`grep -rPn\` (PCRE) to scan all text files for invisible code points, excluding \`.git/\` and binary files. Exits 0 (clean) or 1 (matches found with file:line detail).
- **New CI job** \`test_unicode\` in \`.github/workflows/test.yml\`: Runs on every PR and push to \`main\`, alongside the existing \`test_terraform\` and \`test_linter\` jobs.

### Characters detected
| Category | Code Points |
|---|---|
| BOM | U+FEFF |
| Soft hyphen | U+00AD |
| Zero-width space/joiner/non-joiner | U+200B, U+200C, U+200D |
| LTR/RTL marks | U+200E, U+200F |
| Bidi controls (Trojan Source) | U+202A–U+202E |
| Bidi isolates | U+2066–U+2069 |
| Word joiner | U+2060 |

Blocks CVE-2021-42574 (Trojan Source) style attacks and prevents invisible characters from silently corrupting Terraform configs or documentation.

---
[Warp conversation](https://app.warp.dev/conversation/d5c07a75-a347-43b0-8824-71151d9baf16) | [Plan: CI: Block Invisible Unicode Characters](https://app.warp.dev/drive/notebook/dohnOB3JFe4l7onScvWr3h)

Co-Authored-By: Oz <oz-agent@warp.dev>