### PR TITLE
fix(issue-triage): instruct users to edit issue body on needs-info

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -110,7 +110,11 @@ jobs:
 
             If ANY required item is missing:
               - Post a single comment listing each missing item by name and
-                briefly explaining what is needed.
+                briefly explaining what is needed. End the comment with this
+                exact sentence (replacing the bracketed items with the actual
+                list): "Please **edit the issue body** (not a comment reply)
+                to add the items above — editing the body re-triggers triage
+                automatically."
               - Run:
                 gh issue edit ${{ github.event.issue.number }} \
                   --repo ${{ github.repository }} \

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -110,11 +110,8 @@ jobs:
 
             If ANY required item is missing:
               - Post a single comment listing each missing item by name and
-                briefly explaining what is needed. End the comment with this
-                exact sentence (replacing the bracketed items with the actual
-                list): "Please **edit the issue body** (not a comment reply)
-                to add the items above — editing the body re-triggers triage
-                automatically."
+                briefly explaining what is needed. End the comment with:
+                "Please **edit the issue body** (not a comment reply) to add the items above — editing the body re-triggers triage automatically."
               - Run:
                 gh issue edit ${{ github.event.issue.number }} \
                   --repo ${{ github.repository }} \

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -211,6 +211,43 @@ jobs:
           echo "::notice::Marking spec PR #${pr_number} ready-for-review."
           gh pr ready "${pr_number}" --repo "${{ github.repository }}" || true
 
+      - name: Notify issue author on spec PR
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+        run: |
+          # Resolve the issue author's login via the REST API so this works
+          # for both the labeled trigger and manual workflow_dispatch (where
+          # github.event.issue is unavailable).
+          author=$(gh api "/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" \
+            --jq '.user.login')
+
+          # Find the spec PR for this issue (most recently created, any draft state).
+          pr_number=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,headRefName,createdAt \
+            --jq "[.[] | select(.headRefName | startswith(\"spec/issue-${ISSUE_NUMBER}-\"))] | sort_by(.createdAt) | last | .number // empty")
+
+          if [ -z "${pr_number}" ]; then
+            echo "::notice::No open spec PR found for issue #${ISSUE_NUMBER}; skipping notification."
+            exit 0
+          fi
+
+          # Request a review from the issue author. This may be a no-op if
+          # GitHub prevents requesting review from non-collaborators; the
+          # || true ensures the step does not fail in that case.
+          gh pr edit "${pr_number}" \
+            --repo "${{ github.repository }}" \
+            --add-reviewer "${author}" || true
+
+          # Post a comment on the spec PR so the author is notified regardless
+          # of whether the review request above succeeded.
+          gh pr comment "${pr_number}" \
+            --repo "${{ github.repository }}" \
+            --body "@${author} A spec has been generated from issue #${ISSUE_NUMBER}. Please review it and approve the PR so the implementation phase can begin."
+
       - name: On success - drop ready-for-spec
         if: success()
         env:


### PR DESCRIPTION
## Summary

Two related improvements to the Oz automation pipeline discovered while working through issue #244.

## Changes

### 1. `issue-triage.yml` — instruct users to edit the issue body on needs-info

The triage bot's \`needs-info\` comment listed missing items but gave no guidance on *how* to respond. The natural instinct is to reply in a comment — which does not re-trigger triage. The workflow fires on \`opened\` and \`edited\` issue events only; editing the body is the correct path.

Adds a closing sentence to every \`needs-info\` comment instructing users to **edit the issue body** (not reply in a comment), and explains that doing so re-triggers triage automatically. The sentence is kept on a single line in the YAML literal block to avoid embedded newlines in the prompt.

### 2. \`spec-generation.yml\` — notify issue author when spec PR is ready

After the spec PR is flipped to ready-for-review, a new post-step:
- Resolves the issue author's login via the REST API (works for both the \`labeled\` trigger and manual \`workflow_dispatch\` where \`github.event.issue\` is unavailable)
- Requests their review with \`gh pr edit --add-reviewer\` (\`|| true\` so it doesn't fail if GitHub rejects the request for non-collaborators)
- Posts an \`@mention\` comment on the spec PR as a guaranteed notification fallback

## Context

Discovered while working through issue #244, where the bot asked for version and reproduction info and received a comment reply rather than a body edit, requiring manual intervention to re-trigger triage.

---

[Warp conversation](https://app.warp.dev/conversation/fe4a2184-2584-4041-8778-c4ccb9468f31)

Co-Authored-By: Oz <oz-agent@warp.dev>