### PR TITLE
feat(waf): Phase 1 — non-breaking compliance improvements

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -156,7 +156,7 @@ skip-check:
   - CKV2_AWS_47 # WAFv2 WebACL with Log4j rule - optional caller configuration
 
   # WAFv2
-  - CKV2_AWS_31 # WAF logging configuration - exposed as optional; caller provides log destination ARN
+  - CKV2_AWS_31 # WAF logging configuration - exposed via logging_configuration variable; suppressed because logging is optional (callers must provide a log destination)
 
   # CloudTrail
   - CKV2_AWS_10 # CloudWatch Logs integration - exposed as cloud_watch_logs_group_arn variable

--- a/.github/specs/issue-233-aws-waf-module.md
+++ b/.github/specs/issue-233-aws-waf-module.md
@@ -23,7 +23,7 @@ No reusable WAFv2 module exists in the library. DEVSECOPS-4 requires a WAF modul
 |---|---|---|---|
 | `name` | `string` | required | Web ACL name |
 | `scope` | `string` | `"REGIONAL"` | REGIONAL or CLOUDFRONT |
-| `default_action` | `string` | `"allow"` | allow or block — validated string (not object) |
+| `default_action` | `string` | `"block"` | allow or block — validated string (not object); defaults to block for secure posture |
 | `description` | `string` | `null` | Web ACL description |
 | `ip_sets` | `map(object)` | `{}` | Map of IP set definitions (name → addresses, ip_address_version) |
 | `rule` | `list(any)` | `[]` | List of rule objects; supports managed_rule_group_statement and ip_set_reference_statement |

--- a/modules/aws/waf/README.md
+++ b/modules/aws/waf/README.md
@@ -166,15 +166,15 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.47.0 |
 
 ## Modules
 
@@ -183,34 +183,40 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_wafv2_ip_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_wafv2_web_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_wafv2_web_acl_logging_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_associate_with_resource"></a> [associate\_with\_resource](#input\_associate\_with\_resource) | The ARN of the resource to associate with the web ACL. Supported resources include ALB, API Gateway REST API, AppSync GraphQL API, or Cognito user pool. | `string` | `null` | no |
+| <a name="input_association_config"></a> [association\_config](#input\_association\_config) | Specifies custom configurations for the associations between the web ACL and protected resources. Controls request body inspection size limits per resource type. | <pre>object({<br/>    request_body = optional(object({<br/>      api_gateway = optional(object({<br/>        default_size_inspection_limit = optional(string, "KB_16")<br/>      }))<br/>      app_runner_service = optional(object({<br/>        default_size_inspection_limit = optional(string, "KB_16")<br/>      }))<br/>      cognito_user_pool = optional(object({<br/>        default_size_inspection_limit = optional(string, "KB_16")<br/>      }))<br/>      verified_access_instance = optional(object({<br/>        default_size_inspection_limit = optional(string, "KB_16")<br/>      }))<br/>    }))<br/>  })</pre> | `null` | no |
+| <a name="input_captcha_config"></a> [captcha\_config](#input\_captcha\_config) | Specifies how AWS WAF should handle CAPTCHA evaluations at the Web ACL level. | <pre>object({<br/>    immunity_time_property = optional(object({<br/>      immunity_time = optional(number, 300)<br/>    }), { immunity_time = 300 })<br/>  })</pre> | `null` | no |
+| <a name="input_challenge_config"></a> [challenge\_config](#input\_challenge\_config) | Specifies how AWS WAF should handle Challenge evaluations at the Web ACL level. | <pre>object({<br/>    immunity_time_property = optional(object({<br/>      immunity_time = optional(number, 300)<br/>    }), { immunity_time = 300 })<br/>  })</pre> | `null` | no |
+| <a name="input_custom_response_body"></a> [custom\_response\_body](#input\_custom\_response\_body) | Map of custom response bodies that can be referenced by custom\_response block actions. Key is the unique response body key used in rule actions. | <pre>map(object({<br/>    content      = string<br/>    content_type = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_default_action"></a> [default\_action](#input\_default\_action) | The action to perform if none of the rules contained in the WebACL match. Valid values are 'allow' or 'block'. | `string` | `"block"` | no |
 | <a name="input_description"></a> [description](#input\_description) | A friendly description of the WebACL. | `string` | `"WAF WebACL managed by Terraform"` | no |
 | <a name="input_ip_sets"></a> [ip\_sets](#input\_ip\_sets) | Map of IP sets to create and manage alongside the WAF WebACL. | <pre>map(object({<br/>    name               = string<br/>    description        = optional(string, "IP set created by WAF module")<br/>    ip_address_version = optional(string, "IPV4")<br/>    addresses          = list(string)<br/>  }))</pre> | `{}` | no |
+| <a name="input_logging_configuration"></a> [logging\_configuration](#input\_logging\_configuration) | WAF logging configuration. Set log\_destination\_configs to a list of Kinesis Firehose, CloudWatch Logs, or S3 ARNs. redacted\_fields and logging\_filter are optional. | <pre>object({<br/>    log_destination_configs = list(string)<br/>    redacted_fields = optional(list(object({<br/>      single_header = optional(object({ name = string }))<br/>      uri_path      = optional(object({}))<br/>      query_string  = optional(object({}))<br/>      method        = optional(object({}))<br/>    })), [])<br/>    logging_filter = optional(object({<br/>      default_behavior = string<br/>      filter = list(object({<br/>        behavior    = string<br/>        requirement = string<br/>        condition = list(object({<br/>          action_condition     = optional(object({ action = string }))<br/>          label_name_condition = optional(object({ label_name = string }))<br/>        }))<br/>      }))<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | A friendly name of the WebACL. Must be unique within the AWS region. | `string` | n/a | yes |
 | <a name="input_rule"></a> [rule](#input\_rule) | Map of rules to configure on the WAF WebACL. Use 'action' for IP set and regex rules; use 'override\_action' for managed rule group rules. | <pre>map(object({<br/>    name            = string<br/>    priority        = number<br/>    action          = optional(string) # "allow", "block", or "count" — used for non-managed-rule-group statements<br/>    override_action = optional(string) # "none" or "count" — used with managed_rule_group_statement<br/>    statement = object({<br/>      managed_rule_group_statement = optional(object({<br/>        name                  = string<br/>        vendor_name           = string<br/>        rule_action_overrides = optional(list(string), []) # rule names to override to count mode<br/>      }))<br/>      not_statement = optional(object({<br/>        ip_set_reference_statement = object({<br/>          arn = string<br/>        })<br/>      }))<br/>      ip_set_reference_statement = optional(object({<br/>        arn = string<br/>      }))<br/>    })<br/>    captcha_config = optional(object({<br/>      immunity_time_property = optional(object({<br/>        immunity_time = optional(number, 300)<br/>      }), { immunity_time = 300 })<br/>    }), { immunity_time_property = { immunity_time = 300 } })<br/>    challenge_config = optional(object({<br/>      immunity_time_property = optional(object({<br/>        immunity_time = optional(number, 300)<br/>      }), { immunity_time = 300 })<br/>    }), { immunity_time_property = { immunity_time = 300 } })<br/>    visibility_config = object({<br/>      cloudwatch_metrics_enabled = bool<br/>      metric_name                = string<br/>      sampled_requests_enabled   = bool<br/>    })<br/>  }))</pre> | `{}` | no |
 | <a name="input_scope"></a> [scope](#input\_scope) | Specifies whether this is for an AWS CloudFront distribution or a regional application. Valid values are CLOUDFRONT or REGIONAL. | `string` | `"REGIONAL"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to all resources. | `map(string)` | `{}` | no |
+| <a name="input_token_domains"></a> [token\_domains](#input\_token\_domains) | Specifies the domains to use for CAPTCHA and Challenge token sharing. Required when using CAPTCHA or Challenge across multiple domains. | `list(string)` | `null` | no |
 | <a name="input_visibility_config"></a> [visibility\_config](#input\_visibility\_config) | Visibility configuration for the WAF ACL. metric\_name defaults to the WAF name if not specified. | <pre>object({<br/>    cloudwatch_metrics_enabled = optional(bool, true)<br/>    metric_name                = optional(string)<br/>    sampled_requests_enabled   = optional(bool, true)<br/>  })</pre> | <pre>{<br/>  "cloudwatch_metrics_enabled": true,<br/>  "metric_name": null,<br/>  "sampled_requests_enabled": true<br/>}</pre> | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_associated_resource_arn"></a> [associated\_resource\_arn](#output\_associated\_resource\_arn) | The ARN of the associated resource (if any) |
 | <a name="output_association_id"></a> [association\_id](#output\_association\_id) | The ID of the WAF association (if created) |
 | <a name="output_ip_sets"></a> [ip\_sets](#output\_ip\_sets) | Map of created IP sets |
+| <a name="output_logging_configuration_id"></a> [logging\_configuration\_id](#output\_logging\_configuration\_id) | The ARN of the WAF WebACL used as the logging configuration resource ID (if logging is configured) |
 | <a name="output_waf_acl_arn"></a> [waf\_acl\_arn](#output\_waf\_acl\_arn) | The ARN of the WAF WebACL |
 | <a name="output_waf_acl_id"></a> [waf\_acl\_id](#output\_waf\_acl\_id) | The ID of the WAF WebACL |
 | <a name="output_waf_acl_name"></a> [waf\_acl\_name](#output\_waf\_acl\_name) | The name of the WAF WebACL |

--- a/modules/aws/waf/README.md
+++ b/modules/aws/waf/README.md
@@ -60,6 +60,13 @@
 
 
 <!-- USAGE EXAMPLES -->
+## Prerequisites
+
+- An AWS provider configured for the target region.
+- **CloudFront WAFs** (`scope = "CLOUDFRONT"`) require the AWS provider to be configured for `us-east-1` regardless of where your other resources reside. Pass the provider explicitly or alias it.
+- For WAF logging, a Kinesis Data Firehose delivery stream, CloudWatch Logs log group, or S3 bucket must exist before passing its ARN via `logging_configuration.log_destination_configs`.
+- IP set ARNs referenced in `rule` statements must already be created (either by this module's `ip_sets` input or externally).
+
 ## Usage
 
 ### Simple Example
@@ -143,6 +150,15 @@ module "waf" {
 _For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Notes / Design Decisions
+
+- **`default_action = "block"`**: The module defaults to blocking all requests not matched by a rule. This is the most secure posture. Override to `"allow"` if your rules are not yet exhaustive and you want to start in monitoring mode.
+- **`action` vs. `override_action`**: Use `action` for rules that use IP set, regex, geo, rate, byte, or custom statement types. Use `override_action` for rules that use `managed_rule_group_statement` — AWS WAFv2 requires managed rule groups to use `override_action`, not `action`. Setting both on the same rule will cause a WAFv2 API error.
+- **`visibility_config.metric_name`**: If left null, the metric name falls back to the WebACL `name` via `coalesce()`. Rule-level metric names must be specified explicitly in each rule's `visibility_config`.
+- **Scope**: REGIONAL WAFs can be attached to ALBs, API Gateways, AppSync APIs, Cognito user pools, and App Runner services. CLOUDFRONT WAFs attach to CloudFront distributions and must be created in `us-east-1`.
+- **WAF Logging**: Logging is optional. When provided, the module creates an `aws_wafv2_logging_configuration` resource. You must pre-create the log destination (Firehose, CloudWatch Logs, or S3). Checkov check `CKV2_AWS_31` is suppressed because the log destination is caller-supplied.
+- **`rule_action_overrides`**: Currently only supports overriding individual managed rules to `count` mode. Phase 3 of the refactor will expand this to support all action types.
 
 <!-- terraform-docs output will be input automatically below-->
 <!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->

--- a/modules/aws/waf/README.md
+++ b/modules/aws/waf/README.md
@@ -157,7 +157,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 - **`action` vs. `override_action`**: Use `action` for rules that use IP set, regex, geo, rate, byte, or custom statement types. Use `override_action` for rules that use `managed_rule_group_statement` — AWS WAFv2 requires managed rule groups to use `override_action`, not `action`. Setting both on the same rule will cause a WAFv2 API error.
 - **`visibility_config.metric_name`**: If left null, the metric name falls back to the WebACL `name` via `coalesce()`. Rule-level metric names must be specified explicitly in each rule's `visibility_config`.
 - **Scope**: REGIONAL WAFs can be attached to ALBs, API Gateways, AppSync APIs, Cognito user pools, and App Runner services. CLOUDFRONT WAFs attach to CloudFront distributions and must be created in `us-east-1`.
-- **WAF Logging**: Logging is optional. When provided, the module creates an `aws_wafv2_logging_configuration` resource. You must pre-create the log destination (Firehose, CloudWatch Logs, or S3). Checkov check `CKV2_AWS_31` is suppressed because the log destination is caller-supplied.
+- **WAF Logging**: Logging is optional. When provided, the module creates an `aws_wafv2_web_acl_logging_configuration` resource. You must pre-create the log destination (Firehose, CloudWatch Logs, or S3). Checkov check `CKV2_AWS_31` is suppressed because the log destination is caller-supplied.
 - **`rule_action_overrides`**: Currently only supports overriding individual managed rules to `count` mode. Phase 3 of the refactor will expand this to support all action types.
 
 <!-- terraform-docs output will be input automatically below-->
@@ -216,7 +216,7 @@ No modules.
 | <a name="output_associated_resource_arn"></a> [associated\_resource\_arn](#output\_associated\_resource\_arn) | The ARN of the associated resource (if any) |
 | <a name="output_association_id"></a> [association\_id](#output\_association\_id) | The ID of the WAF association (if created) |
 | <a name="output_ip_sets"></a> [ip\_sets](#output\_ip\_sets) | Map of created IP sets |
-| <a name="output_logging_configuration_id"></a> [logging\_configuration\_id](#output\_logging\_configuration\_id) | The ARN of the WAF WebACL used as the logging configuration resource ID (if logging is configured) |
+| <a name="output_logging_configuration_id"></a> [logging\_configuration\_id](#output\_logging\_configuration\_id) | The ID of the WAF logging configuration resource (null if logging is not configured) |
 | <a name="output_waf_acl_arn"></a> [waf\_acl\_arn](#output\_waf\_acl\_arn) | The ARN of the WAF WebACL |
 | <a name="output_waf_acl_id"></a> [waf\_acl\_id](#output\_waf\_acl\_id) | The ID of the WAF WebACL |
 | <a name="output_waf_acl_name"></a> [waf\_acl\_name](#output\_waf\_acl\_name) | The name of the WAF WebACL |

--- a/modules/aws/waf/main.tf
+++ b/modules/aws/waf/main.tf
@@ -39,9 +39,10 @@ resource "aws_wafv2_ip_set" "this" {
 ############################
 
 resource "aws_wafv2_web_acl" "this" {
-  name        = var.name
-  scope       = var.scope # REGIONAL or CLOUDFRONT
-  description = var.description
+  name          = var.name
+  scope         = var.scope # REGIONAL or CLOUDFRONT
+  description   = var.description
+  token_domains = var.token_domains
 
   dynamic "default_action" {
     for_each = [var.default_action]
@@ -149,6 +150,24 @@ resource "aws_wafv2_web_acl" "this" {
         cloudwatch_metrics_enabled = rule.value.visibility_config.cloudwatch_metrics_enabled
         metric_name                = rule.value.visibility_config.metric_name
         sampled_requests_enabled   = rule.value.visibility_config.sampled_requests_enabled
+      }
+    }
+  }
+
+  dynamic "captcha_config" {
+    for_each = var.captcha_config != null ? [var.captcha_config] : []
+    content {
+      immunity_time_property {
+        immunity_time = captcha_config.value.immunity_time_property.immunity_time
+      }
+    }
+  }
+
+  dynamic "challenge_config" {
+    for_each = var.challenge_config != null ? [var.challenge_config] : []
+    content {
+      immunity_time_property {
+        immunity_time = challenge_config.value.immunity_time_property.immunity_time
       }
     }
   }

--- a/modules/aws/waf/main.tf
+++ b/modules/aws/waf/main.tf
@@ -58,6 +58,15 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
+  dynamic "custom_response_body" {
+    for_each = var.custom_response_body
+    content {
+      key          = custom_response_body.key
+      content      = custom_response_body.value.content
+      content_type = custom_response_body.value.content_type
+    }
+  }
+
   dynamic "rule" {
     for_each = var.rule
     content {
@@ -150,6 +159,41 @@ resource "aws_wafv2_web_acl" "this" {
         cloudwatch_metrics_enabled = rule.value.visibility_config.cloudwatch_metrics_enabled
         metric_name                = rule.value.visibility_config.metric_name
         sampled_requests_enabled   = rule.value.visibility_config.sampled_requests_enabled
+      }
+    }
+  }
+
+  dynamic "association_config" {
+    for_each = var.association_config != null ? [var.association_config] : []
+    content {
+      dynamic "request_body" {
+        for_each = association_config.value.request_body != null ? [association_config.value.request_body] : []
+        content {
+          dynamic "api_gateway" {
+            for_each = request_body.value.api_gateway != null ? [request_body.value.api_gateway] : []
+            content {
+              default_size_inspection_limit = api_gateway.value.default_size_inspection_limit
+            }
+          }
+          dynamic "app_runner_service" {
+            for_each = request_body.value.app_runner_service != null ? [request_body.value.app_runner_service] : []
+            content {
+              default_size_inspection_limit = app_runner_service.value.default_size_inspection_limit
+            }
+          }
+          dynamic "cognito_user_pool" {
+            for_each = request_body.value.cognito_user_pool != null ? [request_body.value.cognito_user_pool] : []
+            content {
+              default_size_inspection_limit = cognito_user_pool.value.default_size_inspection_limit
+            }
+          }
+          dynamic "verified_access_instance" {
+            for_each = request_body.value.verified_access_instance != null ? [request_body.value.verified_access_instance] : []
+            content {
+              default_size_inspection_limit = verified_access_instance.value.default_size_inspection_limit
+            }
+          }
+        }
       }
     }
   }

--- a/modules/aws/waf/main.tf
+++ b/modules/aws/waf/main.tf
@@ -172,3 +172,69 @@ resource "aws_wafv2_web_acl_association" "this" {
   resource_arn = var.associate_with_resource
   web_acl_arn  = aws_wafv2_web_acl.this.arn
 }
+
+############################
+# WAF Logging
+############################
+
+resource "aws_wafv2_logging_configuration" "this" {
+  count = var.logging_configuration != null ? 1 : 0
+
+  log_destination_configs = var.logging_configuration.log_destination_configs
+  resource_arn            = aws_wafv2_web_acl.this.arn
+
+  dynamic "redacted_fields" {
+    for_each = var.logging_configuration.redacted_fields
+    content {
+      dynamic "single_header" {
+        for_each = redacted_fields.value.single_header != null ? [redacted_fields.value.single_header] : []
+        content {
+          name = single_header.value.name
+        }
+      }
+      dynamic "uri_path" {
+        for_each = redacted_fields.value.uri_path != null ? [1] : []
+        content {}
+      }
+      dynamic "query_string" {
+        for_each = redacted_fields.value.query_string != null ? [1] : []
+        content {}
+      }
+      dynamic "method" {
+        for_each = redacted_fields.value.method != null ? [1] : []
+        content {}
+      }
+    }
+  }
+
+  dynamic "logging_filter" {
+    for_each = var.logging_configuration.logging_filter != null ? [var.logging_configuration.logging_filter] : []
+    content {
+      default_behavior = logging_filter.value.default_behavior
+      dynamic "filter" {
+        for_each = logging_filter.value.filter
+        content {
+          behavior    = filter.value.behavior
+          requirement = filter.value.requirement
+          dynamic "condition" {
+            for_each = filter.value.condition
+            content {
+              dynamic "action_condition" {
+                for_each = condition.value.action_condition != null ? [condition.value.action_condition] : []
+                content {
+                  action = action_condition.value.action
+                }
+              }
+              dynamic "label_name_condition" {
+                for_each = condition.value.label_name_condition != null ? [condition.value.label_name_condition] : []
+                content {
+                  label_name = label_name_condition.value.label_name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/aws/waf/main.tf
+++ b/modules/aws/waf/main.tf
@@ -240,7 +240,7 @@ resource "aws_wafv2_web_acl_association" "this" {
 # WAF Logging
 ############################
 
-resource "aws_wafv2_logging_configuration" "this" {
+resource "aws_wafv2_web_acl_logging_configuration" "this" {
   count = var.logging_configuration != null ? 1 : 0
 
   log_destination_configs = var.logging_configuration.log_destination_configs

--- a/modules/aws/waf/outputs.tf
+++ b/modules/aws/waf/outputs.tf
@@ -33,3 +33,8 @@ output "associated_resource_arn" {
   description = "The ARN of the associated resource (if any)"
   value       = var.associate_with_resource
 }
+
+output "logging_configuration_id" {
+  description = "The ARN of the WAF WebACL used as the logging configuration resource ID (if logging is configured)"
+  value       = length(aws_wafv2_logging_configuration.this) > 0 ? aws_wafv2_logging_configuration.this[0].id : null
+}

--- a/modules/aws/waf/outputs.tf
+++ b/modules/aws/waf/outputs.tf
@@ -36,5 +36,5 @@ output "associated_resource_arn" {
 
 output "logging_configuration_id" {
   description = "The ARN of the WAF WebACL used as the logging configuration resource ID (if logging is configured)"
-  value       = length(aws_wafv2_logging_configuration.this) > 0 ? aws_wafv2_logging_configuration.this[0].id : null
+  value       = length(aws_wafv2_web_acl_logging_configuration.this) > 0 ? aws_wafv2_web_acl_logging_configuration.this[0].id : null
 }

--- a/modules/aws/waf/outputs.tf
+++ b/modules/aws/waf/outputs.tf
@@ -35,6 +35,6 @@ output "associated_resource_arn" {
 }
 
 output "logging_configuration_id" {
-  description = "The ARN of the WAF WebACL used as the logging configuration resource ID (if logging is configured)"
+  description = "The ID of the WAF logging configuration resource (null if logging is not configured)"
   value       = length(aws_wafv2_web_acl_logging_configuration.this) > 0 ? aws_wafv2_web_acl_logging_configuration.this[0].id : null
 }

--- a/modules/aws/waf/variables.tf
+++ b/modules/aws/waf/variables.tf
@@ -118,6 +118,35 @@ variable "ip_sets" {
 }
 
 ############################################
+# Logging Configuration
+############################################
+
+variable "logging_configuration" {
+  description = "WAF logging configuration. Set log_destination_configs to a list of Kinesis Firehose, CloudWatch Logs, or S3 ARNs. redacted_fields and logging_filter are optional."
+  type = object({
+    log_destination_configs = list(string)
+    redacted_fields = optional(list(object({
+      single_header = optional(object({ name = string }))
+      uri_path      = optional(object({}))
+      query_string  = optional(object({}))
+      method        = optional(object({}))
+    })), [])
+    logging_filter = optional(object({
+      default_behavior = string
+      filter = list(object({
+        behavior    = string
+        requirement = string
+        condition = list(object({
+          action_condition     = optional(object({ action = string }))
+          label_name_condition = optional(object({ label_name = string }))
+        }))
+      }))
+    }))
+  })
+  default = null
+}
+
+############################################
 # Association Configuration
 ############################################
 

--- a/modules/aws/waf/variables.tf
+++ b/modules/aws/waf/variables.tf
@@ -8,6 +8,12 @@ variable "description" {
   default     = "WAF WebACL managed by Terraform"
 }
 
+variable "token_domains" {
+  description = "Specifies the domains to use for CAPTCHA and Challenge token sharing. Required when using CAPTCHA or Challenge across multiple domains."
+  type        = list(string)
+  default     = null
+}
+
 variable "name" {
   description = "A friendly name of the WebACL. Must be unique within the AWS region."
   type        = string
@@ -115,6 +121,30 @@ variable "ip_sets" {
     addresses          = list(string)
   }))
   default = {}
+}
+
+############################################
+# ACL-Level Captcha and Challenge Configuration
+############################################
+
+variable "captcha_config" {
+  description = "Specifies how AWS WAF should handle CAPTCHA evaluations at the Web ACL level."
+  type = object({
+    immunity_time_property = optional(object({
+      immunity_time = optional(number, 300)
+    }), { immunity_time = 300 })
+  })
+  default = null
+}
+
+variable "challenge_config" {
+  description = "Specifies how AWS WAF should handle Challenge evaluations at the Web ACL level."
+  type = object({
+    immunity_time_property = optional(object({
+      immunity_time = optional(number, 300)
+    }), { immunity_time = 300 })
+  })
+  default = null
 }
 
 ############################################

--- a/modules/aws/waf/variables.tf
+++ b/modules/aws/waf/variables.tf
@@ -39,6 +39,19 @@ variable "tags" {
 # Rule Configuration
 ############################################
 
+variable "custom_response_body" {
+  description = "Map of custom response bodies that can be referenced by custom_response block actions. Key is the unique response body key used in rule actions."
+  type = map(object({
+    content      = string
+    content_type = string
+  }))
+  default = {}
+  validation {
+    condition     = alltrue([for v in values(var.custom_response_body) : contains(["TEXT_PLAIN", "TEXT_HTML", "APPLICATION_JSON"], v.content_type)])
+    error_message = "content_type must be one of TEXT_PLAIN, TEXT_HTML, or APPLICATION_JSON."
+  }
+}
+
 variable "default_action" {
   description = "The action to perform if none of the rules contained in the WebACL match. Valid values are 'allow' or 'block'."
   type        = string
@@ -179,6 +192,27 @@ variable "logging_configuration" {
 ############################################
 # Association Configuration
 ############################################
+
+variable "association_config" {
+  description = "Specifies custom configurations for the associations between the web ACL and protected resources. Controls request body inspection size limits per resource type."
+  type = object({
+    request_body = optional(object({
+      api_gateway = optional(object({
+        default_size_inspection_limit = optional(string, "KB_16")
+      }))
+      app_runner_service = optional(object({
+        default_size_inspection_limit = optional(string, "KB_16")
+      }))
+      cognito_user_pool = optional(object({
+        default_size_inspection_limit = optional(string, "KB_16")
+      }))
+      verified_access_instance = optional(object({
+        default_size_inspection_limit = optional(string, "KB_16")
+      }))
+    }))
+  })
+  default = null
+}
 
 variable "associate_with_resource" {
   description = "The ARN of the resource to associate with the web ACL. Supported resources include ALB, API Gateway REST API, AppSync GraphQL API, or Cognito user pool."


### PR DESCRIPTION
## Phase 1 — Non-breaking compliance improvements for the WAF module

This PR adds missing AWS WAFv2 Web ACL attributes and supporting infrastructure to the \`modules/aws/waf/\` module. All changes are additive — no existing variables or resources were modified.

### What's included

**New resources**
- \`aws_wafv2_web_acl_logging_configuration\` — optional WAF logging, count-gated on \`logging_configuration\` variable. Supports \`redacted_fields\` and \`logging_filter\` with full dynamic block coverage.

**New \`aws_wafv2_web_acl\` arguments**
- \`token_domains\` — for cross-domain CAPTCHA/Challenge token sharing
- \`captcha_config\` / \`challenge_config\` — ACL-level immunity time overrides (separate from per-rule configs that already existed)
- \`association_config\` — request body inspection size limits per resource type (API Gateway, App Runner, Cognito, Verified Access)
- \`custom_response_body\` — reusable response body definitions with \`content_type\` validation

**New outputs**
- \`logging_configuration_id\`

**Documentation**
- \`README.md\`: Added Prerequisites and Notes/Design Decisions sections.

**Spec and config fixes**
- \`.github/specs/issue-233-aws-waf-module.md\`: Correct \`default_action\` default from \`"allow"\` to \`"block"\`.
- \`.checkov.yaml\`: Clarify \`CKV2_AWS_31\` suppression comment.

### Validation

- \`tofu fmt -recursive\` — no changes needed
- \`tofu -chdir=modules/aws/waf validate\` — Success! The configuration is valid.
- \`pre-commit run --all-files\` — Terraform fmt: Passed, Terraform docs: Passed

### Related

Phase 1 of a planned WAF module refactor. Phase 2 and 3 will address additional statement types and rule action overrides per the spec.

---

_Conversation: https://app.warp.dev/conversation/483e36b8-991b-4993-91de-d0f4857fd28f_
_Run: https://oz.warp.dev/runs/019e6f3b-d205-747f-8db5-f1b31151dd61_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
