### PR TITLE
Build(deps): bump oz-agent-action to v1.0.17, actions/checkout to v6.0.2, and codeql-action to v4.36.0

### DIFF
--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -42,7 +42,7 @@ jobs:
       # implementation branch back to origin. zizmor's artipacked warning is
       # acknowledged.
       - name: Checkout # zizmor: ignore[artipacked]
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -126,7 +126,7 @@ jobs:
             --add-label implementation-in-progress
 
       - name: Run Oz implementation agent
-        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
+        uses: warpdotdev/oz-agent-action@cc32546e933acdc86dd6a9b4dd02ec956dcd8a5b # v1.0.17
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Run Oz triage agent
-        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
+        uses: warpdotdev/oz-agent-action@cc32546e933acdc86dd6a9b4dd02ec956dcd8a5b # v1.0.17
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,14 @@ on:
 jobs:
   build_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,7 +35,7 @@ jobs:
           soft_fail: true
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         # Results are generated only on a success or failure
         # this is required since GitHub by default won't run the next step
         # when the previous one has failed. Security checks that do not pass will 'fail'.

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -40,7 +40,7 @@ jobs:
       # Credentials are intentionally persisted so the Oz agent can push the
       # spec branch back to origin. zizmor's artipacked warning is acknowledged.
       - name: Checkout # zizmor: ignore[artipacked]
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Needed so the agent can create a new branch and push.
           fetch-depth: 0

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -112,7 +112,7 @@ jobs:
             --add-label spec-in-progress
 
       - name: Run Oz spec-generation agent
-        uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
+        uses: warpdotdev/oz-agent-action@cc32546e933acdc86dd6a9b4dd02ec956dcd8a5b # v1.0.17
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Description

Consolidates all recent GitHub Actions dependency updates into a single PR:

**1. \`warpdotdev/oz-agent-action\` → v1.0.17**
Updated in \`implementation.yml\`, \`issue-triage.yml\`, and \`spec-generation.yml\` from the unpinned \`main\` branch SHA to the \`v1.0.17\` tagged release (\`cc32546e933acdc86dd6a9b4dd02ec956dcd8a5b\`).

**2. \`actions/checkout\` → v6.0.2 (SHA-pinned)**
- Fixed \`ref-version-mismatch\` zizmor lint failures in \`implementation.yml\`, \`issue-triage.yml\`, and \`spec-generation.yml\` by correcting the version comment from \`# v6\` to \`# v6.0.2\` (SHA \`de0fac2e4500dabe0009e67214ff5f5447ce83dd\`).
- Replaced the floating \`@v6\` tag in \`release.yml\` with the same immutable SHA pin (\`de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2\`).

**3. \`github/codeql-action\` → v4.36.0**
Updated \`upload-sarif\` SHA in \`scan.yml\` from \`68bde559\` (v4.35.4) to \`7211b7c8\` (v4.36.0) and corrected the version comment from \`# v4\` to \`# v4.36.0\`.

Supersedes dependabot PRs #256, #257, and #258.

## Type of change
- [x] Dependency update / maintenance
- [x] CI/workflow improvement

## Breaking Changes
None.

## TODOs
None.