### PR TITLE
ci(release): replace softprops/action-gh-release with gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
+          gh release create "$TAG_NAME" \
             --generate-notes \
             --verify-tag


### PR DESCRIPTION
## Summary

Replaces the third-party \`softprops/action-gh-release\` action with a native \`gh release create\` script step, resolving the zizmor \`superfluous-actions\` finding for \`release.yml\`.

## Changes

- Removed: \`softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda\`
- Added: \`run:\` step using \`gh release create\` with:
  - \`--generate-notes\` — preserves existing auto-generated release notes behavior
  - \`--verify-tag\` — safety guard ensuring the tag exists on the remote before creating the release
  - \`GH_TOKEN\` set to \`${{ secrets.GITHUB_TOKEN }}\` for authentication
- No changes to the trigger (\`push: tags: ["v*.*.*"]\`), permissions (\`contents: write\`), or checkout step

## Acceptance criteria

- [x] \`.github/workflows/release.yml\` no longer uses \`softprops/action-gh-release\`
- [x] The workflow uses a \`run:\` step with \`gh release create\` instead
- [x] Release creation still triggers on pushed \`v*.*.*\` tags
- [x] Auto-generated release notes are enabled (\`--generate-notes\`)
- [x] \`GH_TOKEN\` is set via \`${{ secrets.GITHUB_TOKEN }}\`
- [x] Permissions remain \`contents: write\` (least-privilege)

## References

- Fixes #260
- Spec: #261
- Conversation: https://app.warp.dev/conversation/71cb9525-e10e-49d2-a598-574a07f64721

Co-Authored-By: Oz <oz-agent@warp.dev>