### PR TITLE
refactor(ci): extract Oz agent prompts into reusable skills

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,28 +2,39 @@
 <!-- Description of the changes introduced by this Pull Request (PR). Link to an issue or ticket where possible for more context.-->
 A brief description of the changes introduced by this Pull Request.
 
+> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/):** `<type>(optional scope): <description>` (for example `feat(vpc): add flow log support`). This repository squash-merges, so the PR title becomes the commit subject that drives release notes and the SemVer bump. Append `!` after the type/scope for a breaking change (for example `feat(api)!: ...`).
+
 ## Issue or Ticket
-<!-- Link to the issue or ticket this PR addresses.-->
+<!-- Link to the issue or ticket this PR addresses. Use "Fixes #N" to auto-close it on merge, or "Refs #N" to keep it open. -->
 Fixes #000
 
 ## Type of change
-<!-- What type of change does your code introduce? -->
-- [ ] Bugfix
-- [ ] New feature
-- [ ] Version update
+<!-- Select the Conventional Commit type that matches your PR title. Only `feat`, `fix`, and breaking changes affect the released version. -->
+- [ ] `feat` — a new user-facing feature (SemVer MINOR)
+- [ ] `fix` — a bug fix (SemVer PATCH)
+- [ ] `docs` — documentation only
+- [ ] `style` — formatting/whitespace; no logic change
+- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
+- [ ] `perf` — performance improvement
+- [ ] `test` — adding or correcting tests
+- [ ] `build` — build system or dependency changes
+- [ ] `ci` — CI configuration (GitHub Actions, etc.)
+- [ ] `chore` — maintenance task that does not fit elsewhere
+- [ ] `revert` — reverts a previous commit
 
 ## Breaking Changes
-<!-- Does this PR introduce any breaking changes? -->
-- [ ] Yes
+<!-- A breaking change triggers a SemVer MAJOR bump. Signal it with `!` in the PR title or a `BREAKING CHANGE:` footer. -->
+- [ ] Yes — this is a breaking change
 - [ ] No
 
 ### Breaking Changes Description
-<!-- If yes, describe the breaking changes introduced by this PR. -->
+<!-- If yes, describe what breaks and the migration path. This becomes the BREAKING CHANGE footer. -->
 
 
 ## TODOs
 <!-- Complete these tasks prior to requesting a review.-->
-- [ ] Validate your code matches the style of the project.
-- [ ] Update the docs.
-- [ ] Validate all tests run successfull, including pre-commit checks.
+- [ ] PR title follows Conventional Commits (`<type>(scope): description`).
+- [ ] Validate your code matches the style of the project (`tofu fmt -recursive`).
+- [ ] Update the docs (regenerate the `terraform-docs` block where applicable).
+- [ ] Validate all tests run successfully, including pre-commit checks.
 - [ ] Include release notes and description. This should include both a summary of the changes and any necessary context.

--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -132,58 +132,15 @@ jobs:
         with:
           warp_api_key: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
           profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+          # Canonical implementation instructions live in
+          # .warp/skills/spec-implementation/SKILL.md and are referenced via `skill:`.
+          # Pass only per-run context through `prompt:` below.
+          skill: zachreborn/terraform-modules:spec-implementation
           prompt: |
-            You are implementing an approved spec in zachreborn/terraform-modules.
-
-            ## Target issue and spec
-            Issue: #${{ steps.ctx.outputs.issue_number }}
-            Spec file (already in `main`): ${{ steps.spec.outputs.path }}
-
-            Read the spec file in full before making any changes. Treat it
-            as the source of truth for what to build.
-
-            ## Required reading
-            - `AGENTS.md` — repo conventions (four-file module layout,
-              `opentofu >= 1.6.0` / `terraform >= 1.0.0`, `aws >= 6.0.0`,
-              section header style,
-              `tags = merge(tomap({ Name = var.name }), var.tags)` pattern,
-              `count = var.enable_x ? 1 : 0` conditional pattern, lifecycle
-              ignores, tfsec suppression style).
-            - `modules/module_template/` — starting point for new modules.
-            - `.github/pull_request_template.md` — required PR body shape.
-
-            ## Implementation rules
-            - Stay within the scope defined by the spec. Do not modify
-              unrelated modules.
-            - Run `tofu fmt -recursive` before committing.
-            - Do not run `terraform-docs` locally — CI (`build.yml`) will
-              auto-inject the README block.
-            - Run `tofu -chdir=<module_path> init -backend=false` and
-              `tofu -chdir=<module_path> validate` for any module you
-              create or modify, and ensure both succeed.
-            - If you add a Checkov suppression, document the rationale in a
-              comment per the convention in `AGENTS.md`.
-
-            ## Commit and PR
-            - Branch name: `feat/issue-${{ steps.ctx.outputs.issue_number }}-<slug>`
-              for features, `fix/issue-${{ steps.ctx.outputs.issue_number }}-<slug>`
-              for bugs.
-            - Commit messages follow conventional-commit style and include
-              a Co-Authored-By line for Oz.
-            - Open the PR as **ready-for-review** (NOT a draft) so that
-              CODEOWNERS are auto-assigned via the `pull_request:
-              ready_for_review` event. If your tooling defaults to draft,
-              flip it to ready before exiting. The workflow also runs a
-              post-step that calls `gh pr ready` as a safety net.
-            - Title: per the spec. The PR body MUST fill in the existing
-              `.github/pull_request_template.md` sections (Description,
-              Issue or Ticket with `Fixes #${{ steps.ctx.outputs.issue_number }}`,
-              Type of change, Breaking Changes, TODOs).
-            - Post a comment on the originating issue with the PR URL.
-
-            Implementation PRs go through the same CI as any other PR
-            (`build.yml`, `test.yml`, `scan.yml`). Do not attempt to
-            bypass any check.
+            ## Run context
+            Issue number: #${{ steps.ctx.outputs.issue_number }}
+            Repository: ${{ github.repository }}
+            Spec file path (already on `main`): ${{ steps.spec.outputs.path }}
 
       - name: Mark implementation PR ready-for-review
         # The Oz agent action tends to open PRs as drafts when invoked from

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -66,14 +66,14 @@ jobs:
         with:
           warp_api_key: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
           profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+          # Canonical triage instructions live in
+          # .warp/skills/issue-triage/SKILL.md and are referenced via `skill:`.
+          # Pass only per-run context through `prompt:` below.
+          skill: zachreborn/terraform-modules:issue-triage
           prompt: |
-            You are triaging a GitHub issue in zachreborn/terraform-modules,
-            a Terraform/OpenTofu module library (OpenTofu is the default;
-            Terraform is also supported). Validate the issue against the
-            minimum standards below and update its state via the `gh` CLI.
-
-            ## Issue
-            Number: #${{ github.event.issue.number }}
+            ## Run context
+            Issue number: #${{ github.event.issue.number }}
+            Repository: ${{ github.repository }}
             URL: ${{ github.event.issue.html_url }}
             Title: ${{ github.event.issue.title }}
             Labels: ${{ join(github.event.issue.labels.*.name, ', ') }}
@@ -82,58 +82,6 @@ jobs:
             ---
             ${{ github.event.issue.body }}
             ---
-
-            ## Classification
-            Classify as `bug` or `feature` based on the existing labels and
-            body content. If both/neither, ask in a comment and apply
-            `needs-info`.
-
-            ## Minimum standards
-            BUG must include:
-              1. Affected module path (e.g. `modules/aws/ec2_instance`).
-              2. OpenTofu or Terraform version and relevant provider versions.
-              3. Reproduction steps.
-              4. Expected vs. actual behavior.
-              5. One of: error message, stack trace, or plan/apply output.
-              6. Acceptance criteria for "fixed."
-
-            FEATURE must include:
-              1. Target module path (existing or proposed under
-                 `modules/<provider>/<name>/`).
-              2. Motivation / problem being solved.
-              3. High-level proposed inputs and outputs.
-              4. Breaking-change assessment (yes/no + scope).
-              5. Acceptance criteria for "done."
-
-            ## Actions you must take
-            Use the `gh` CLI (already authenticated via GH_TOKEN).
-
-            If ANY required item is missing:
-              - Post a single comment listing each missing item by name and
-                briefly explaining what is needed. End the comment with:
-                "Please **edit the issue body** (not a comment reply) to add the items above — editing the body re-triggers triage automatically."
-              - Run:
-                gh issue edit ${{ github.event.issue.number }} \
-                  --repo ${{ github.repository }} \
-                  --add-label needs-info
-
-            If ALL required items are present:
-              - Post a single short comment with:
-                  * Classification (bug/feature)
-                  * Affected module path(s)
-                  * Breaking-change risk (none/low/medium/high) with one
-                    sentence of rationale
-              - Run:
-                gh issue edit ${{ github.event.issue.number }} \
-                  --repo ${{ github.repository }} \
-                  --remove-label needs-info || true
-                gh issue edit ${{ github.event.issue.number }} \
-                  --repo ${{ github.repository }} \
-                  --add-label ready-for-spec
-
-            Do not edit any files. Do not push commits. Do not open PRs.
-            Do not invoke `terraform`. Your only side effects are issue
-            comments and label changes via `gh`.
 
       - name: Chain to Spec Generation if ready-for-spec was applied
         # Labels applied with GITHUB_TOKEN do not trigger downstream

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -118,73 +118,14 @@ jobs:
         with:
           warp_api_key: ${{ secrets.WARP_API_KEY }} # zizmor: ignore[secrets-outside-env]
           profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+          # Canonical spec-generation instructions live in
+          # .warp/skills/spec-generation/SKILL.md and are referenced via `skill:`.
+          # Pass only per-run context through `prompt:` below.
+          skill: zachreborn/terraform-modules:spec-generation
           prompt: |
-            You are generating a technical specification for an issue in
-            zachreborn/terraform-modules. The repository is a
-            Terraform/OpenTofu modules library (OpenTofu is the default;
-            Terraform is also supported). Conventions are documented in
-            `AGENTS.md`.
-
-            ## Target issue
+            ## Run context
             Issue number: #${{ steps.ctx.outputs.issue_number }}
             Repository: ${{ github.repository }}
-
-            Fetch the issue body and comments with:
-              gh issue view ${{ steps.ctx.outputs.issue_number }} \
-                --repo ${{ github.repository }} \
-                --json title,body,labels,comments
-
-            ## Required reading (consult before writing)
-            - `AGENTS.md` (root) — repo conventions, four-file module layout,
-              tagging pattern, lifecycle ignores, tfsec suppression style.
-            - `.github/specs/_template.md` — canonical spec layout.
-            - `modules/module_template/` — starting point for new modules.
-
-            ## Output
-            Create a new branch named:
-              spec/issue-${{ steps.ctx.outputs.issue_number }}-<short-kebab-slug>
-
-            Write the spec to:
-              .github/specs/issue-${{ steps.ctx.outputs.issue_number }}-<slug>.md
-
-            The spec MUST be based on `_template.md` and MUST contain:
-              - Background
-              - Non-goals
-              - Affected module path(s)
-              - Proposed `variables.tf` / `outputs.tf` / `main.tf` shape
-                (SIGNATURES ONLY — variable names, types, descriptions,
-                resource block names. NO full implementation.)
-              - Breaking-change assessment
-              - Checkov / tfsec suppression considerations (state "none"
-                if no new suppressions are needed)
-              - terraform-docs impact (will the auto-generated README change?)
-              - Acceptance criteria
-
-            ## Commit and PR
-            - Commit message: `spec: <issue title>` with body
-              `Refs #${{ steps.ctx.outputs.issue_number }}`
-              and the Co-Authored-By line for Oz.
-            - Push the branch.
-            - Open the PR as **ready-for-review** (NOT a draft) so that
-              CODEOWNERS are auto-assigned via the `pull_request:
-              ready_for_review` event. If your tooling defaults to draft,
-              flip it to ready before exiting. The workflow also runs a
-              post-step that calls `gh pr ready` as a safety net.
-            - Title: `spec: <issue title>`.
-            - PR body MUST include `Refs #${{ steps.ctx.outputs.issue_number }}`
-              (not `Fixes`) so the issue stays open through implementation.
-            - Apply `spec-ready-for-review` to the originating issue:
-                gh issue edit ${{ steps.ctx.outputs.issue_number }} \
-                  --repo ${{ github.repository }} \
-                  --add-label spec-ready-for-review
-                gh issue edit ${{ steps.ctx.outputs.issue_number }} \
-                  --repo ${{ github.repository }} \
-                  --remove-label spec-in-progress || true
-            - Post a comment on the issue with the spec PR URL.
-
-            Do NOT modify any Terraform/OpenTofu files. Do NOT modify existing modules.
-            The only files you should create or modify live under
-            `.github/specs/`.
 
       - name: Mark spec PR ready-for-review
         # The Oz agent action tends to open PRs as drafts when invoked from

--- a/.warp/skills/issue-triage/SKILL.md
+++ b/.warp/skills/issue-triage/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: issue-triage
+description: >-
+  Triage a GitHub issue in the zachreborn/terraform-modules Terraform/OpenTofu
+  module library: classify it as a bug or feature, validate it against the
+  repository's minimum reporting standards, and move it through the
+  issue-to-implementation pipeline by posting a single comment and applying the
+  correct label (needs-info or ready-for-spec) via the gh CLI. Use this skill
+  whenever you are asked to triage, validate, classify, or label an incoming
+  issue for this repo, or when an issue is opened or edited and needs its
+  pipeline state set. This skill is the canonical source for the triage agent;
+  the Issue Triage GitHub Actions workflow invokes it with per-run context.
+---
+
+# Issue triage
+
+You triage a single GitHub issue for `zachreborn/terraform-modules`, a
+Terraform/OpenTofu module library (OpenTofu is the default; Terraform is also
+supported). Your job is to decide whether the issue is actionable, and to move
+it one step through the issue → spec → implementation pipeline by labeling it
+and leaving exactly one comment.
+
+Getting this right matters because the next pipeline stage (spec generation) is
+triggered off the `ready-for-spec` label. Promoting an under-specified issue
+wastes a spec run; over-asking for info on a complete issue stalls the author.
+
+## Run context
+
+The specific issue is provided in the invoking prompt. Expect these fields:
+
+- **Issue number** — the issue to act on.
+- **Repository** — the target repo (e.g. `zachreborn/terraform-modules`).
+- **URL**, **Title**, **Labels**, **Body** — the issue contents to evaluate.
+
+If the body is not included in the prompt, fetch it first:
+
+```sh
+gh issue view <issue_number> --repo <repository> \
+  --json title,body,labels,comments
+```
+
+## Classification
+
+Classify the issue as `bug` or `feature` based on the existing labels and body
+content. If it is clearly both or neither, do not guess — ask in your comment
+and apply `needs-info`.
+
+## Minimum standards
+
+A **bug** must include all of:
+
+1. Affected module path (e.g. `modules/aws/ec2_instance`).
+2. OpenTofu or Terraform version and relevant provider versions.
+3. Reproduction steps.
+4. Expected vs. actual behavior.
+5. One of: error message, stack trace, or plan/apply output.
+6. Acceptance criteria for "fixed."
+
+A **feature** must include all of:
+
+1. Target module path (existing or proposed under `modules/<provider>/<name>/`).
+2. Motivation / problem being solved.
+3. High-level proposed inputs and outputs.
+4. Breaking-change assessment (yes/no + scope).
+5. Acceptance criteria for "done."
+
+Check the standards exhaustively: walk the numbered list for the chosen
+classification one item at a time and record every item that is absent or
+inadequate. Do not stop at the first gap. Listing all missing items at once lets
+the author fix everything in a single edit instead of cycling through repeated
+re-triage rounds.
+
+## Actions you must take
+
+Use the `gh` CLI (it is already authenticated in your environment). Substitute
+the issue number and repository from the run context.
+
+**If ANY required item is missing:**
+
+- Post a single comment listing each missing item by name and briefly
+  explaining what is needed. End the comment with exactly:
+
+  > Please **edit the issue body** (not a comment reply) to add the items above — editing the body re-triggers triage automatically.
+
+- Then apply the `needs-info` label:
+
+  ```sh
+  gh issue edit <issue_number> --repo <repository> --add-label needs-info
+  ```
+
+**If ALL required items are present:**
+
+- Post a single short comment containing:
+  - Classification (bug/feature)
+  - Affected module path(s)
+  - Breaking-change risk (none/low/medium/high) with one sentence of rationale
+- Then advance the issue:
+
+  ```sh
+  gh issue edit <issue_number> --repo <repository> --remove-label needs-info || true
+  gh issue edit <issue_number> --repo <repository> --add-label ready-for-spec
+  ```
+
+## Guardrails
+
+Your only side effects are issue comments and label changes via `gh`. Do not
+edit any files. Do not push commits. Do not open PRs. Do not invoke `terraform`
+or `tofu`. Post exactly one comment per run.

--- a/.warp/skills/spec-generation/SKILL.md
+++ b/.warp/skills/spec-generation/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: spec-generation
+description: >-
+  Generate a technical specification for a triaged GitHub issue in the
+  zachreborn/terraform-modules Terraform/OpenTofu module library, following the
+  repository's spec template and conventions, then open a spec PR and advance
+  the issue to spec-ready-for-review. Use this skill whenever you are asked to
+  write, author, or generate a spec for an issue in this repo, or when an issue
+  reaches the ready-for-spec stage of the pipeline. This skill is the canonical
+  source for the spec-generation agent; the Spec Generation GitHub Actions
+  workflow invokes it with per-run context.
+---
+
+# Spec generation
+
+You generate a technical specification for one issue in
+`zachreborn/terraform-modules`, a Terraform/OpenTofu module library (OpenTofu is
+the default; Terraform is also supported). The spec becomes the source of truth
+for the later implementation stage, so it must be precise about interfaces and
+deliberately silent about full implementation — signatures, not code.
+
+Repository conventions are documented in `AGENTS.md`; consult it rather than
+assuming, because the spec is reviewed against those conventions.
+
+## Run context
+
+The invoking prompt provides:
+
+- **Issue number** — the issue to spec.
+- **Repository** — the target repo (e.g. `zachreborn/terraform-modules`).
+
+Fetch the issue body and comments before writing:
+
+```sh
+gh issue view <issue_number> --repo <repository> \
+  --json title,body,labels,comments
+```
+
+## Required reading (consult before writing)
+
+- `AGENTS.md` (root) — repo conventions: four-file module layout, tagging
+  pattern, lifecycle ignores, tfsec suppression style.
+- `.github/specs/_template.md` — the canonical spec layout your spec must follow.
+- `modules/module_template/` — the starting point for new modules.
+
+## Output
+
+Create a new branch named:
+
+```
+spec/issue-<issue_number>-<short-kebab-slug>
+```
+
+Write the spec to:
+
+```
+.github/specs/issue-<issue_number>-<slug>.md
+```
+
+The spec MUST be based on `_template.md` and MUST contain:
+
+- Background
+- Non-goals
+- Affected module path(s)
+- Proposed `variables.tf` / `outputs.tf` / `main.tf` shape — **signatures only**:
+  variable names, types, descriptions, and resource block names. No full
+  implementation.
+- Breaking-change assessment
+- Checkov / tfsec suppression considerations (state "none" if no new
+  suppressions are needed)
+- terraform-docs impact (will the auto-generated README change?)
+- Acceptance criteria
+
+Check completeness exhaustively: walk this required-section list one item at a
+time and confirm each section is present and substantive before opening the PR.
+Do not skip a section or leave it as a placeholder. A spec that drops a section
+stalls review and forces another round, so it is worth completing every section
+now.
+
+## Commit and PR
+
+- Commit message: `spec: <issue title>` with body `Refs #<issue_number>` and the
+  `Co-Authored-By` line for Oz.
+- Push the branch.
+- Open the PR as **ready-for-review** (NOT a draft) so that CODEOWNERS are
+  auto-assigned via the `pull_request: ready_for_review` event. If your tooling
+  defaults to draft, flip it to ready before exiting (the workflow also runs a
+  `gh pr ready` safety net).
+- Title: `spec: <issue title>`.
+- The PR body MUST include `Refs #<issue_number>` (not `Fixes`) so the issue
+  stays open through implementation.
+- Advance the originating issue:
+
+  ```sh
+  gh issue edit <issue_number> --repo <repository> --add-label spec-ready-for-review
+  gh issue edit <issue_number> --repo <repository> --remove-label spec-in-progress || true
+  ```
+
+- Post a comment on the issue with the spec PR URL.
+
+## Guardrails
+
+Do NOT modify any Terraform/OpenTofu files. Do NOT modify existing modules. The
+only files you create or modify live under `.github/specs/`.

--- a/.warp/skills/spec-implementation/SKILL.md
+++ b/.warp/skills/spec-implementation/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: spec-implementation
+description: >-
+  Implement an approved spec in the zachreborn/terraform-modules
+  Terraform/OpenTofu module library, treating the committed spec file as the
+  source of truth, then open an implementation PR that fills the repo PR
+  template and links the originating issue. Use this skill whenever you are
+  asked to implement, build, or code an approved spec for this repo, or when an
+  issue reaches the spec-approved stage of the pipeline. This skill is the
+  canonical source for the implementation agent; the Implementation GitHub
+  Actions workflow invokes it with per-run context.
+---
+
+# Spec implementation
+
+You implement an approved spec in `zachreborn/terraform-modules`, a
+Terraform/OpenTofu module library (OpenTofu is the default; Terraform is also
+supported). The spec was reviewed and merged precisely so that implementation
+stays within agreed bounds — treat it as the source of truth and do not expand
+scope beyond it.
+
+## Run context
+
+The invoking prompt provides:
+
+- **Issue number** — the originating issue.
+- **Repository** — the target repo (e.g. `zachreborn/terraform-modules`).
+- **Spec file path** — the approved spec already on `main`
+  (e.g. `.github/specs/issue-<issue_number>-<slug>.md`).
+
+Read the spec file in full before making any changes.
+
+## Required reading
+
+- `AGENTS.md` — repo conventions: four-file module layout,
+  `opentofu >= 1.6.0` / `terraform >= 1.0.0`, `aws >= 6.0.0`, section header
+  style, `tags = merge(tomap({ Name = var.name }), var.tags)` pattern,
+  `count = var.enable_x ? 1 : 0` conditional pattern, lifecycle ignores, and
+  tfsec suppression style.
+- `modules/module_template/` — the starting point for new modules.
+- `.github/pull_request_template.md` — the required PR body shape.
+
+## Implementation rules
+
+- Stay within the scope defined by the spec. Do not modify unrelated modules.
+- Run `tofu fmt -recursive` before committing.
+- Do not run `terraform-docs` locally — CI (`build.yml`) auto-injects the
+  README block.
+- Run `tofu -chdir=<module_path> init -backend=false` and
+  `tofu -chdir=<module_path> validate` for any module you create or modify, and
+  ensure both succeed.
+- If you add a Checkov suppression, document the rationale in a comment per the
+  convention in `AGENTS.md`.
+
+## Commit and PR
+
+- Branch name: `feat/issue-<issue_number>-<slug>` for features, or
+  `fix/issue-<issue_number>-<slug>` for bugs.
+- Commit messages follow conventional-commit style and include a
+  `Co-Authored-By` line for Oz.
+- Open the PR as **ready-for-review** (NOT a draft) so that CODEOWNERS are
+  auto-assigned via the `pull_request: ready_for_review` event. If your tooling
+  defaults to draft, flip it to ready before exiting (the workflow also runs a
+  `gh pr ready` safety net).
+- Title: per the spec. The PR body MUST fill in the existing
+  `.github/pull_request_template.md` sections: Description, Issue or Ticket
+  (with `Fixes #<issue_number>`), Type of change, Breaking Changes, and TODOs.
+- Post a comment on the originating issue with the PR URL.
+
+Before marking the PR ready, walk the implementation rules above and every
+required PR-template section one item at a time and confirm each is satisfied.
+Do not stop at the first gap or leave a template section blank. An incomplete
+change fails CI or review and forces another round, so complete every item now.
+
+## CI expectations
+
+Implementation PRs go through the same CI as any other PR (`build.yml`,
+`test.yml`, `scan.yml`). Do not attempt to bypass any check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,7 @@ stateDiagram-v2
 - `.warp/skills/spec-generation/` — spec authoring + spec PR (used by `spec-generation.yml`)
 - `.warp/skills/spec-implementation/` — implementation + impl PR (used by `implementation.yml`)
 
-Each workflow references its skill via the `skill:` input of `warpdotdev/oz-agent-action` (e.g. `skill: zachreborn/terraform-modules:issue-triage`) and passes only per-run context (issue number, title, body, labels, spec path) through `prompt:`. Edit the `SKILL.md` files to change agent behavior — do **not** re-embed instructions in the workflow YAML. Because the skills live in this repo, the same stages can also be launched from the Oz CLI, web app, or a schedule, e.g. `oz agent run-cloud --skill "zachreborn/terraform-modules:issue-triage" --prompt "Triage issue #NNN"`.
+Each workflow references its skill via the `skill:` input of `warpdotdev/oz-agent-action` (e.g. `skill: zachreborn/terraform-modules:issue-triage`) and passes only the run-specific context each stage needs through `prompt:` — triage receives the issue number, repository, and the issue title/body/labels; spec-generation receives the issue number and repository; implementation also receives the resolved spec-file path. Edit the `SKILL.md` files to change agent behavior — do **not** re-embed instructions in the workflow YAML. Because the skills live in this repo, the same stages can also be launched from the Oz CLI, web app, or a schedule, e.g. `oz agent run-cloud --skill "zachreborn/terraform-modules:issue-triage" --prompt "Triage issue #NNN"`.
 
 ## Security Posture Philosophy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,14 @@ stateDiagram-v2
 
 **Specs directory**: see `.github/specs/README.md` for naming and `.github/specs/_template.md` for the canonical layout.
 
+**Agent instructions live in skills**: the canonical instructions for each pipeline stage are versioned [skills](https://docs.warp.dev/agent-platform/cloud-agents/skills-as-agents) under `.warp/skills/`:
+
+- `.warp/skills/issue-triage/` — triage/classification/labeling (used by `issue-triage.yml`)
+- `.warp/skills/spec-generation/` — spec authoring + spec PR (used by `spec-generation.yml`)
+- `.warp/skills/spec-implementation/` — implementation + impl PR (used by `implementation.yml`)
+
+Each workflow references its skill via the `skill:` input of `warpdotdev/oz-agent-action` (e.g. `skill: zachreborn/terraform-modules:issue-triage`) and passes only per-run context (issue number, title, body, labels, spec path) through `prompt:`. Edit the `SKILL.md` files to change agent behavior — do **not** re-embed instructions in the workflow YAML. Because the skills live in this repo, the same stages can also be launched from the Oz CLI, web app, or a schedule, e.g. `oz agent run-cloud --skill "zachreborn/terraform-modules:issue-triage" --prompt "Triage issue #NNN"`.
+
 ## Security Posture Philosophy
 
 This is a **module library** — security enforcement is the caller's responsibility. Many Checkov checks are suppressed in `.checkov.yaml` because modules must accept any value for variables like CIDR ranges, ports, encryption settings, etc. When adding new suppressions, document the reason in the same format as existing entries.


### PR DESCRIPTION
# Description
Extracts the large, near-identical instruction blocks that were embedded as inline `prompt:` inputs in the three Oz pipeline workflows (`issue-triage`, `spec-generation`, `implementation`) into versioned **skills** under `.warp/skills/`, referenced via the `oz-agent-action` `skill:` input. Each prompt now has a single source of truth and can also be launched from the Oz CLI, web app, or a schedule. The workflows now pass only per-run context (issue number, title, body, labels, spec path); the surrounding label state machine, trust gate, draft→ready flip, workflow chaining, and failure recovery are unchanged. Net result: roughly −146 lines across the three workflows.

Skills added:
- `.warp/skills/issue-triage/`
- `.warp/skills/spec-generation/`
- `.warp/skills/spec-implementation/`

The `issue-triage` skill was validated with a with-skill vs. baseline eval against issues #267/#72/#109: decisions matched expectations in all cases, and the skill additionally enforces the exact comment/label protocol (notably the "edit the issue body to re-trigger triage" instruction) that an unguided agent dropped. All three skills share the same exhaustive-completeness instruction. The pipeline section of `AGENTS.md` documents the new layout.

**Also included (docs):** `.github/pull_request_template.md` is updated to conform to [Conventional Commits](https://www.conventionalcommits.org/). Because this repo squash-merges, the PR title becomes the commit subject that drives release notes and the SemVer bump, so the template now requires a CC-formatted title, replaces the ad-hoc Type-of-change options with the standard CC types mapped to their SemVer impact, and reframes the Breaking Changes section around the `!` / `BREAKING CHANGE:` convention.

A Copilot review comment on `AGENTS.md` was also addressed: the per-stage prompt-context description now states what each workflow actually passes (triage: issue number/repo/title/body/labels; spec-generation: issue number/repo; implementation: also the spec-file path) instead of implying all stages pass the same fields.

This is a refactor / CI + docs change — no Terraform/OpenTofu module behavior changes.

## Issue or Ticket
N/A — no tracking issue. Originated from an agent-workflow efficiency review.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Version update

> Refactor / CI + docs — none of the listed options map cleanly; no module or version change, so no SemVer bump.

## Breaking Changes
- [ ] Yes
- [x] No

### Breaking Changes Description
None. Rollout note: the `skill: org/repo:name` reference resolves from the repository's default branch, so the skills and the slimmed workflows land together on merge — `main` keeps working with the old inline prompts until then, with no broken in-between state.

## TODOs
- [x] Validate your code matches the style of the project.
- [x] Update the docs. (`AGENTS.md` pipeline section)
- [x] Validate all tests run successfully, including pre-commit checks. (Workflow YAML + skill frontmatter validated locally; no module `.tf` files changed, so `tofu fmt` / `terraform-docs` are unaffected. CI will confirm.)
- [x] Include release notes and description.

---
🤖 Generated with [Oz](https://app.warp.dev) — [agent conversation](https://app.warp.dev/conversation/5359b338-afb8-4a85-ab10-fa034d3d284b) · [design plan](https://app.warp.dev/drive/notebook/obt3YgZPEmwAis2rvWHOkM)

Co-Authored-By: Oz <oz-agent@warp.dev>
