### PR TITLE
ci: add dynamic run-name and job names to Oz pipeline workflows

### DIFF
--- a/.github/workflows/implementation.yml
+++ b/.github/workflows/implementation.yml
@@ -1,5 +1,6 @@
 ---
 name: Implementation (Oz)
+run-name: "Implementation (Oz) — Issue #${{ github.event.issue.number || inputs.issue_number }}"
 on:
   issues:
     types: [labeled]
@@ -21,7 +22,7 @@ permissions:
 
 jobs:
   implement:
-    name: Implement spec with Oz
+    name: "Implement spec for Issue #${{ github.event.issue.number || inputs.issue_number }}"
     runs-on: ubuntu-latest
 
     # For labeled events, only trigger on the spec-approved label, skip if

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,5 +1,6 @@
 ---
 name: Issue Triage (Oz)
+run-name: "Issue Triage (Oz) — Issue #${{ github.event.issue.number }}"
 on:
   issues:
     types: [opened, edited]
@@ -22,7 +23,7 @@ permissions:
 
 jobs:
   triage:
-    name: Triage issue with Oz
+    name: "Triage Issue #${{ github.event.issue.number }}"
     runs-on: ubuntu-latest
 
     # Skip when:

--- a/.github/workflows/spec-generation.yml
+++ b/.github/workflows/spec-generation.yml
@@ -1,5 +1,6 @@
 ---
 name: Spec Generation (Oz)
+run-name: "Spec Generation (Oz) — Issue #${{ github.event.issue.number || inputs.issue_number }}"
 on:
   issues:
     types: [labeled]
@@ -22,7 +23,7 @@ permissions:
 
 jobs:
   generate-spec:
-    name: Generate spec with Oz
+    name: "Generate spec for Issue #${{ github.event.issue.number || inputs.issue_number }}"
     runs-on: ubuntu-latest
 
     # For labeled events, only trigger on the ready-for-spec label, skip if


### PR DESCRIPTION
## Summary

Add \`run-name\` expressions and dynamic job names to the three Oz agent workflows so each run in the GitHub Actions tab is clearly labeled with the issue number it is operating on, rather than showing the generic workflow name.

## Changes

- **\`issue-triage.yml\`**: run-name → \`Issue Triage (Oz) — Issue #N\`; job name → \`Triage Issue #N\`
- **\`spec-generation.yml\`**: run-name → \`Spec Generation (Oz) — Issue #N\`; job name → \`Generate spec for Issue #N\`
- **\`implementation.yml\`**: run-name → \`Implementation (Oz) — Issue #N\`; job name → \`Implement spec for Issue #N\`

Both \`run-name\` (the run title in the Actions list) and the job \`name\` (shown inside the run) resolve the issue number from \`github.event.issue.number\` for label-triggered runs and \`inputs.issue_number\` for \`workflow_dispatch\` runs, using the same expression already used for concurrency groups.

---
[Warp conversation](https://app.warp.dev/conversation/f77c62c9-550a-42d0-8c6d-41b21e39f40f)