### PR TITLE
chore(ci): improve dependabot config with groups, labels, and terraform ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,55 @@
 version: 2
 updates:
+  # ─── GitHub Actions ──────────────────────────────────────────────────────────
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
     reviewers:
       - "zachreborn"
       - "Jakeasaurus"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ─── Terraform / OpenTofu providers and registry modules ─────────────────────
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    reviewers:
+      - "zachreborn"
+      - "Jakeasaurus"
+    labels:
+      - "dependencies"
+      - "terraform"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      terraform-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,7 @@ updates:
       - "Jakeasaurus"
     labels:
       - "dependencies"
-      - "terraform"
+      - "opentofu-terraform"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary

Improves the existing Dependabot configuration with best practices to reduce noise and expand coverage.

### Changes

**GitHub Actions ecosystem (existing, improved):**
- Added explicit \`day: monday\` to make the schedule predictable
- Added \`open-pull-requests-limit: 10\` to prevent PR pile-up
- Added labels (\`dependencies\`, \`github-actions\`) for filtering/triage
- Added \`commit-message\` prefix \`chore\` with \`include: scope\` to align with Conventional Commits (chore does not trigger a release)
- Added \`groups\` to batch all minor/patch updates into a single weekly PR; major version bumps remain individual PRs for visibility

**Terraform ecosystem (new):**
- Covers all \`required_providers\` blocks across \`modules/\` and \`global/\`
- Same schedule, cooldown, grouping, and commit-message conventions
- Will surface alerts when provider major versions (e.g., AWS v7) require updating the floor constraint; minor/patch updates are batched

### Why these settings?
- **Groups**: reduces PR noise from 10+ individual weekly action bumps to 1-2 grouped PRs
- **\`chore\` prefix**: matches the repo's Conventional Commits standard and does not trigger a \`release-please\` version bump on its own
- **\`cooldown: 7 days\`**: preserves the existing setting; avoids creating PRs for packages published in the last week (catches bad releases early)
- **Terraform ecosystem**: the \`>= X.Y.Z\` constraint style means Dependabot won't flood the repo with PRs — it will only act when a new major version drops or a registry module has a new tag

---
Co-Authored-By: Oz <oz-agent@warp.dev>