### PR TITLE
docs(github): update issue templates to meet triage minimum standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/terraform-bug.md
+++ b/.github/ISSUE_TEMPLATE/terraform-bug.md
@@ -25,9 +25,10 @@ assignees: zachreborn
 
 <!-- Required. Minimal steps to reproduce the behavior. -->
 
-1.
-2.
-3.
+1. <!-- e.g. Add the following module block to main.tf ... -->
+2. <!-- e.g. Run `tofu init && tofu plan` -->
+3. <!-- e.g. Observe the error -->
+<!-- Add or remove steps as needed -->
 
 ### Expected behavior
 
@@ -41,15 +42,17 @@ assignees: zachreborn
 
 <!-- Required. Paste the full error message, stack trace, or relevant plan/apply output. -->
 
-```
-
+```hcl
+# Paste the full error message, stack trace, or plan/apply output here.
+# Do not truncate — the triage agent reads the full output.
 ```
 
 ### Acceptance criteria
 
 <!-- Required. How will we know this bug is fixed? List specific, verifiable conditions. -->
 
-- [ ]
+- [ ] <!-- e.g. `tofu apply` completes without error on the affected module -->
+- [ ] <!-- e.g. The previously failing resource is created/updated as expected -->
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/terraform-bug.md
+++ b/.github/ISSUE_TEMPLATE/terraform-bug.md
@@ -1,32 +1,56 @@
 ---
 name: Bug
-about: Bug template for tracking issues, next steps, and solutions.
-title: ''
+about: Report a bug in an existing module.
+title: 'bug: <short description>'
 labels: bug
 assignees: zachreborn
 ---
 
-### Describe the bug
-A clear and concise description of what the bug is.
+### Affected module path
 
-### To Reproduce
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+<!-- Required. Provide the path to the module, e.g. modules/aws/ec2_instance -->
+
+### Tool and provider versions
+
+<!-- Required. List the OpenTofu or Terraform version and the relevant provider versions. -->
+
+- OpenTofu / Terraform version:
+- AWS (or other) provider version:
+
+### Describe the bug
+
+<!-- Required. A clear and concise description of what the bug is. -->
+
+### Reproduction steps
+
+<!-- Required. Minimal steps to reproduce the behavior. -->
+
+1.
+2.
+3.
 
 ### Expected behavior
-A clear and concise description of what you expected to happen.
 
-### Problems
-Description of what needs to be solved. 
+<!-- Required. What did you expect to happen? -->
 
-### Solution
-Description of solution, leave blank if not yet found.
+### Actual behavior
 
-### Confirmation
-Confirmation that proposed solution is successful. 
+<!-- Required. What actually happened? -->
 
-### Current Workaround
-A clear and concise description of any alternative solutions or features you've considered.
+### Error / stack trace / plan output
+
+<!-- Required. Paste the full error message, stack trace, or relevant plan/apply output. -->
+
+```
+
+```
+
+### Acceptance criteria
+
+<!-- Required. How will we know this bug is fixed? List specific, verifiable conditions. -->
+
+- [ ]
+
+### Additional context
+
+<!-- Optional. Workarounds, related issues, screenshots, etc. -->

--- a/.github/ISSUE_TEMPLATE/terraform-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/terraform-feature-request.md
@@ -39,7 +39,8 @@ assignees: zachreborn
 
 <!-- Required. How will we know this feature is complete? List specific, verifiable conditions. -->
 
-- [ ]
+- [ ] <!-- e.g. The new variable is accepted and applied without error -->
+- [ ] <!-- e.g. Existing callers are unaffected / migrate successfully -->
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/terraform-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/terraform-feature-request.md
@@ -1,22 +1,46 @@
 ---
 name: Feature Request
-about: Feature template for tracking issues, next steps, and solutions.
-title: ''
+about: Propose a new module or an enhancement to an existing one.
+title: 'feat: <short description>'
 labels: feature
 assignees: zachreborn
 ---
 
-### Describe the feature
-A clear and concise description of what the feature is.
+### Target module path
 
-Considerations: 
-What is the issue we are solving with this request?
-Does it require modifying an existing module or adding a new module?
-What will be the most scalable, repeatable way to create and add/edit/modify this feature?
-What is the desired outcome?
+<!-- Required. Path to the existing module or proposed path for a new module,
+     e.g. modules/aws/s3/bucket or modules/aws/new_service -->
 
-### Examples
-Example branches/successful runs/working versions demonstrating this prior to completion.
+### Motivation
 
-### Confirmation
-Confirmation that proposed solution is successful. 
+<!-- Required. What problem does this solve? Why is this needed? -->
+
+### Proposed inputs and outputs
+
+<!-- Required. List the key variables (inputs) and outputs this change would add or modify.
+     High-level is fine — exact types can be refined in the spec. -->
+
+**Inputs:**
+
+- `variable_name` — description
+
+**Outputs:**
+
+- `output_name` — description
+
+### Breaking-change assessment
+
+<!-- Required. Would this change break existing callers? Answer yes or no and explain the scope. -->
+
+- Breaking change: yes / no
+- Scope:
+
+### Acceptance criteria
+
+<!-- Required. How will we know this feature is complete? List specific, verifiable conditions. -->
+
+- [ ]
+
+### Additional context
+
+<!-- Optional. Examples, related issues, prior art, links to provider docs, etc. -->


### PR DESCRIPTION
## Summary

Updates both GitHub issue templates so that every field the issue-triage agent checks is present and clearly labeled, preventing issues from being stuck in \`needs-info\` due to missing required information.

## Changes

### Bug template
- Added **Affected module path** (required by triage: item 1)
- Added **Tool and provider versions** with pre-filled bullet list (required: item 2)
- Renamed and restructured **Reproduction steps** (required: item 3)
- Split **Expected behavior** and **Actual behavior** into separate sections (required: item 4)
- Added **Error / stack trace / plan output** fenced code block (required: item 5)
- Added **Acceptance criteria** checklist (required: item 6)
- Removed post-triage fields (Solution, Confirmation) that don't belong in the initial report
- Added an optional **Additional context** catch-all section

### Feature template
- Added **Target module path** with guidance on new vs. existing modules (required: item 1)
- Renamed to **Motivation** (required: item 2)
- Added **Proposed inputs and outputs** with placeholder structure (required: item 3)
- Added **Breaking-change assessment** yes/no + scope (required: item 4)
- Added **Acceptance criteria** checklist (required: item 5)
- Removed post-triage fields (Examples, Confirmation) 
- Added an optional **Additional context** catch-all section
- Updated default title prefix to \`feat:\` for conventional commit alignment

## Testing

Verified by comparing each template section against the triage skill's numbered minimum-standards checklist (both bug and feature) — all items are now present.

---
_Generated with [Oz](https://app.warp.dev/conversation/c2d135e0-71af-46fd-9db7-4d222bdeac72)_

Co-Authored-By: Oz <oz-agent@warp.dev>