### PR TITLE
ci: add impl-complete workflow to resolve issues on implementation PR merge

### DIFF
--- a/.github/workflows/impl-complete.yml
+++ b/.github/workflows/impl-complete.yml
@@ -1,0 +1,163 @@
+---
+name: Implementation Complete
+# ======================================================================================
+# Workflow: Implementation Complete
+# ======================================================================================
+# Triggered when a pull request is merged whose head branch follows the
+# implementation naming convention: `feat/issue-N-*` or `fix/issue-N-*`.
+#
+# What it does:
+#   1. Extracts the originating issue number from the branch name (primary)
+#      or from a "Fixes #N" / "Closes #N" line in the PR body (fallback).
+#   2. Swaps labels on the issue:
+#        Remove: implementation-in-progress, spec-approved
+#        Add:    implemented
+#   3. Posts a closing summary comment on the issue with:
+#        - A link to the merged PR
+#        - The merge commit SHA
+#        - The list of changed files (module paths)
+#        - A link to this workflow run
+#   4. Closes the issue with reason "completed" as an explicit backstop
+#      (GitHub's "Fixes #N" auto-close is relied on by the agent but is not
+#      guaranteed if the keyword is omitted or the PR was opened as a draft).
+# ======================================================================================
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-issue:
+    name: Close issue after implementation merge
+    runs-on: ubuntu-latest
+
+    # Only run on actual merges of branches that follow the implementation
+    # naming convention. Closed-but-not-merged PRs are ignored.
+    if: >-
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'feat/issue-') ||
+       startsWith(github.event.pull_request.head.ref, 'fix/issue-'))
+
+    steps:
+      - name: Resolve issue, swap labels, post summary, and close
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+
+            // ── 1. Resolve issue number ──────────────────────────────────────
+            // Primary: parse from branch name (feat/issue-N-slug or fix/issue-N-slug)
+            let issueNumber = null;
+            const branchMatch = branch.match(/\/issue-(\d+)-/);
+            if (branchMatch) {
+              issueNumber = Number(branchMatch[1]);
+              core.info(`Resolved issue #${issueNumber} from branch name.`);
+            }
+
+            // Fallback: scan the PR body for "Fixes #N" or "Closes #N"
+            if (!issueNumber && pr.body) {
+              const bodyMatch = pr.body.match(/(?:Fixes|Closes|Resolves)\s+#(\d+)/i);
+              if (bodyMatch) {
+                issueNumber = Number(bodyMatch[1]);
+                core.info(`Resolved issue #${issueNumber} from PR body keyword.`);
+              }
+            }
+
+            if (!issueNumber) {
+              core.warning(
+                `Could not determine an issue number from branch "${branch}" or PR body. ` +
+                `Skipping issue cleanup.`
+              );
+              return;
+            }
+
+            // Verify the issue actually exists before doing anything.
+            let issue;
+            try {
+              ({ data: issue } = await github.rest.issues.get({
+                owner, repo, issue_number: issueNumber,
+              }));
+            } catch (e) {
+              core.warning(`Issue #${issueNumber} not found (${e.message}). Skipping.`);
+              return;
+            }
+
+            // ── 2. Swap labels ───────────────────────────────────────────────
+            // Add "implemented" first so there is never a moment with no label.
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: issueNumber,
+                labels: ['implemented'],
+              });
+              core.info(`Added "implemented" label to #${issueNumber}.`);
+            } catch (e) {
+              // A 422 most likely means the label does not exist in the repo.
+              // Warn rather than fail so the rest of the cleanup still runs.
+              core.warning(`Failed to add "implemented" label to #${issueNumber}: ${e.message}`);
+            }
+
+            for (const label of ['implementation-in-progress', 'spec-approved']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: issueNumber, name: label,
+                });
+                core.info(`Removed "${label}" from #${issueNumber}.`);
+              } catch (e) {
+                if (e.status !== 404) {
+                  core.warning(`Failed to remove "${label}" from #${issueNumber}: ${e.message}`);
+                }
+                // 404 just means the label was not present — that is fine.
+              }
+            }
+
+            // ── 3. Collect changed files ─────────────────────────────────────
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const changedFiles = files.map(f => `\`${f.filename}\``).join('\n- ');
+
+            // ── 4. Post closing summary comment ──────────────────────────────
+            const sha = pr.merge_commit_sha;
+            const shortSha = sha ? sha.substring(0, 7) : 'unknown';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              `## Implementation complete`,
+              ``,
+              `The implementation PR for this issue has been merged.`,
+              ``,
+              `| | |`,
+              `|---|---|`,
+              `| **Pull request** | #${pr.number} — ${pr.title} |`,
+              `| **Merge commit** | [\`${shortSha}\`](${context.serverUrl}/${owner}/${repo}/commit/${sha}) |`,
+              `| **Workflow run** | [${context.runId}](${runUrl}) |`,
+              ``,
+              `### Changed files`,
+              `- ${changedFiles}`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber, body,
+            });
+            core.info(`Posted closing summary comment on #${issueNumber}.`);
+
+            // ── 5. Close the issue ───────────────────────────────────────────
+            // Explicit close is a backstop for cases where "Fixes #N" was
+            // omitted or the PR was converted from draft after the keyword
+            // was parsed by GitHub. Skip if already closed.
+            if (issue.state === 'open') {
+              await github.rest.issues.update({
+                owner, repo, issue_number: issueNumber,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.info(`Closed issue #${issueNumber} as completed.`);
+            } else {
+              core.info(`Issue #${issueNumber} is already closed; skipping close call.`);
+            }

--- a/.github/workflows/impl-complete.yml
+++ b/.github/workflows/impl-complete.yml
@@ -88,6 +88,16 @@ jobs:
               return;
             }
 
+            // Guard: the Issues API returns pull requests too. Skip if the
+            // resolved number points to a PR rather than a plain issue to
+            // avoid accidentally labelling or closing a pull request.
+            if (issue.pull_request) {
+              core.warning(
+                `#${issueNumber} is a pull request, not an issue. Skipping cleanup.`
+              );
+              return;
+            }
+
             // ── 2. Swap labels ───────────────────────────────────────────────
             // Add "implemented" first so there is never a moment with no label.
             try {
@@ -117,14 +127,27 @@ jobs:
             }
 
             // ── 3. Collect changed files ─────────────────────────────────────
+            const MAX_FILES = 50;
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: pr.number, per_page: 100,
             });
-            const changedFiles = files.map(f => `\`${f.filename}\``).join('\n- ');
+            let fileSection;
+            if (files.length === 0) {
+              fileSection = '_No files changed._';
+            } else {
+              const displayed = files.slice(0, MAX_FILES);
+              const overflow = files.length - displayed.length;
+              const fileList = displayed.map(f => `\`${f.filename}\``).join('\n- ');
+              fileSection = `- ${fileList}` +
+                (overflow > 0 ? `\n- _...and ${overflow} more file(s)_` : '');
+            }
 
             // ── 4. Post closing summary comment ──────────────────────────────
             const sha = pr.merge_commit_sha;
-            const shortSha = sha ? sha.substring(0, 7) : 'unknown';
+            const shortSha = sha ? sha.substring(0, 7) : null;
+            const commitCell = sha
+              ? `[\`${shortSha}\`](${context.serverUrl}/${owner}/${repo}/commit/${sha})`
+              : '_not available_';
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
             const body = [
@@ -135,11 +158,11 @@ jobs:
               `| | |`,
               `|---|---|`,
               `| **Pull request** | #${pr.number} — ${pr.title} |`,
-              `| **Merge commit** | [\`${shortSha}\`](${context.serverUrl}/${owner}/${repo}/commit/${sha}) |`,
+              `| **Merge commit** | ${commitCell} |`,
               `| **Workflow run** | [${context.runId}](${runUrl}) |`,
               ``,
               `### Changed files`,
-              `- ${changedFiles}`,
+              fileSection,
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,7 @@ tags = merge(tomap({ Name = var.name }), var.tags)
 | `spec-generation.yml` | Issue labeled `ready-for-spec` (or manual) | Oz agent opens a spec PR under `.github/specs/` |
 | `spec-approved.yml` | Spec PR merged | Flips originating issue to `spec-approved` |
 | `implementation.yml` | Issue labeled `spec-approved` (or manual) | Oz agent opens an implementation PR per the merged spec |
+| `impl-complete.yml` | Implementation PR merged | Swaps labels (`implementation-in-progress` → `implemented`), posts a closing summary comment (PR, commit, changed files), and closes the issue as completed |
 
 ## Release & Tag Strategy
 
@@ -343,7 +344,8 @@ stateDiagram-v2
     spec_in_progress --> ready_for_spec: failure (label restored)
     spec_ready_for_review --> spec_approved: codeowner merges spec PR
     spec_approved --> implementation_in_progress: Implementation runs
-    implementation_in_progress --> [*]: implementation PR merged
+    implementation_in_progress --> implemented: impl-complete.yml (PR merged)
+    implemented --> [*]: issue closed as completed
 ```
 
 **Stages and the label that drives each transition**:
@@ -353,7 +355,8 @@ stateDiagram-v2
    - Complete → label `ready-for-spec` + classification comment.
 2. `ready-for-spec` → spec-generation agent runs; opens a PR under `.github/specs/issue-<N>-<slug>.md`; issue moves to `spec-in-progress` then `spec-ready-for-review`.
 3. Spec PR merged → `spec-approved.yml` flips the issue to `spec-approved`.
-4. `spec-approved` → implementation agent runs; opens an implementation PR with `Fixes #<N>`; issue moves to `implementation-in-progress` and closes on PR merge.
+4. `spec-approved` → implementation agent runs; opens an implementation PR with `Fixes #<N>`; issue moves to `implementation-in-progress`.
+5. Implementation PR merged → `impl-complete.yml` runs; removes `implementation-in-progress` and `spec-approved` labels, adds `implemented`, posts a closing summary comment (PR link, merge commit SHA, changed files), and closes the issue as completed.
 
 **Running CI on Oz PRs**: Spec and implementation PRs are opened by `github-actions[bot]` using the built-in `GITHUB_TOKEN`. GitHub suppresses cascading workflow runs triggered by `GITHUB_TOKEN`, so as of GitHub's 2026-06-11 change ("Bot-created pull requests can run workflows if approved") these PRs create the required checks (`Linter`, `Test OpenTofu`, `Verify - terraform-docs`, `Invisible Unicode Check`) in an **approval-required** state instead of running them automatically. A maintainer with **write access** must click **Approve workflows to run** in the PR's merge-box banner (or the Actions tab) to start them. This approval is required **per PR**, also applies to any later push the agent makes to the PR branch, and cannot be performed by the agent itself. (Before this change the only option was to manually re-trigger CI, e.g. by closing and reopening the PR.)
 
@@ -369,7 +372,7 @@ stateDiagram-v2
 - Apply the `skip-oz` label to any issue to disable all Oz workflows for it (label-triggered runs *and* `workflow_dispatch`).
 - Use `workflow_dispatch` on `spec-generation.yml` or `implementation.yml` to re-run a stage manually with an `issue_number` input. Manual dispatch still re-checks `skip-oz` and the trust gate at runtime.
 
-**Required repo config** (one-time): set `WARP_API_KEY` (secret), optional `WARP_AGENT_PROFILE` (variable), and create the labels listed above plus `needs-info` and `skip-oz`. The three Oz-agent workflows fail fast with a clear error if `WARP_API_KEY` is missing, so the PR is safe to merge before configuration is done. Note: `spec-approved.yml` does *not* use `WARP_API_KEY` (it is a plain `actions/github-script` job) and will act on merged spec PRs as soon as it lands, regardless of secret configuration.
+**Required repo config** (one-time): set `WARP_API_KEY` (secret), optional `WARP_AGENT_PROFILE` (variable), and create the labels listed above plus `needs-info`, `skip-oz`, and `implemented` (color `#0E8A16`). The three Oz-agent workflows fail fast with a clear error if `WARP_API_KEY` is missing, so the PR is safe to merge before configuration is done. `spec-approved.yml` and `impl-complete.yml` do not use `WARP_API_KEY` (they are plain `actions/github-script` jobs) and will act on merged PRs as soon as they land, regardless of secret configuration.
 
 **Specs directory**: see `.github/specs/README.md` for naming and `.github/specs/_template.md` for the canonical layout.
 


### PR DESCRIPTION
## Description
Add \`.github/workflows/impl-complete.yml\` — a lightweight \`actions/github-script\` workflow that fires whenever a PR whose head branch matches \`feat/issue-N-*\` or \`fix/issue-N-*\` is merged. It closes out the originating issue cleanly so the pipeline tells a full story.

## Issue or Ticket
Refs: no formal issue — closes the label-cleanup gap identified in the automated issue/spec/impl pipeline.

## Type of change
- [x] \`ci\` — CI configuration (GitHub Actions, etc.)

## Breaking Changes
- [x] No

## What the workflow does
1. **Resolves the issue number** from the branch name (\`feat/issue-N-slug\`) with a fallback to \`Fixes #N\` / \`Closes #N\` in the PR body.
2. **Swaps labels** — removes \`implementation-in-progress\` and \`spec-approved\`; adds \`implemented\` (created in the repo, color \`#0E8A16\`).
3. **Posts a closing summary comment** on the issue with the PR link, merge commit SHA, and full list of changed files.
4. **Closes the issue** as \`completed\` (explicit backstop for cases where \`Fixes #N\` was omitted or the PR was converted from draft after GitHub parsed the keyword).

## AGENTS.md changes
- Added \`impl-complete.yml\` row to the CI/CD Pipelines table.
- Extended the pipeline state-machine diagram with the \`implemented\` terminal state.
- Added step 5 to the numbered stage list.
- Updated the Required repo config note to include the \`implemented\` label and note that \`impl-complete.yml\` requires no \`WARP_API_KEY\`.

## TODOs
- [x] PR title follows Conventional Commits.
- [x] No HCL changes — fmt/docs not applicable.
- [x] \`implemented\` label created in the repo (\`#0E8A16\`).
- [x] AGENTS.md updated as the single source of truth for the pipeline.

---
_Generated with [Warp](https://app.warp.dev/conversation/1fc8703d-c40c-4185-8da3-c6867c66c299)_
Co-Authored-By: Oz <oz-agent@warp.dev>