### PR TITLE
ci: eliminate redundant push-to-main CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+  # Weekly regression run: catches terraform-docs output format drift
+  # without requiring a PR.
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   # Weekly regression run: catches terraform-docs output format drift
   # without requiring a PR.
   schedule:
-    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,9 @@
 name: Test
 on:
   pull_request:
-  # Weekly regression run: catches upstream drift in linter rules, tofu
-  # version changes, and terraform-docs output format without requiring a PR.
+  # Weekly regression run: catches upstream drift in linter rules and tofu
+  # version changes without requiring a PR. terraform-docs drift is covered
+  # by the equivalent schedule in build.yml.
   schedule:
     - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,10 @@
 name: Test
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  # Weekly regression run: catches upstream drift in linter rules, tofu
+  # version changes, and terraform-docs output format without requiring a PR.
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,10 @@ jobs:
         uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
+          # On pull_request events, only lint changed files for speed.
+          # On schedule events there is no diff, so scan the full codebase
+          # to make the weekly regression run meaningful.
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'schedule' }}
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_BIOME_LINT: false
           VALIDATE_JSCPD: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   # version changes without requiring a PR. terraform-docs drift is covered
   # by the equivalent schedule in build.yml.
   schedule:
-    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
 
 permissions:
   contents: read
@@ -69,7 +69,7 @@ jobs:
 
       # Run Linter against code base
       - name: Run linter against all changed files
-        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
## Description
Removes the redundant post-merge CI double-run and closes the integration gap that justified it, replacing it with a weekly regression schedule.

**The problem:** \`build.yml\` and \`test.yml\` both trigger on \`pull_request\` AND \`push: branches: main\`. With squash-and-merge, every merge fires the same four checks twice — once on the PR and once on the identical commit that lands on main — doubling Actions minutes and leaving a "pending" state on main after every merge.

**Why it wasn't safe to just remove it:** Branch protection had \`strict: false\` ("Require branches to be up to date before merging" was OFF). A PR could pass CI, then another PR could merge, and the first PR could still merge without re-testing against the updated main. The push-to-main run was the only safety net for that gap.

**What this PR does:**
1. **Enables strict branch protection on main** — applied directly to the repo via the GitHub API alongside this PR. Every PR must now be rebased on current \`main\` before the merge button is active, making the PR's CI run authoritative for what lands on \`main\`.
2. **Removes \`push: branches: main\`** from \`build.yml\` and \`test.yml\`. CI now runs exactly once per change.
3. **Adds a weekly scheduled run** to \`test.yml\` (Monday 06:00 UTC) as a regression safety net for upstream drift — new linter rules, \`tofu\` version changes, \`terraform-docs\` format updates.

\`release-please.yml\` is unchanged — its \`push: main\` trigger initiates releases, not validation.

## Issue or Ticket
Refs: no issue — identified during CI pipeline review.

## Type of change
- [x] \`ci\` — CI configuration (GitHub Actions, etc.)

## Breaking Changes
- [x] No

## TODOs
- [x] PR title follows Conventional Commits.
- [x] No HCL changes — fmt/docs not applicable.
- [x] Strict branch protection already enabled on main (verified via API).
- [x] Weekly schedule added to \`test.yml\` as regression backstop.

---
_Generated with [Warp](https://app.warp.dev/conversation/1fc8703d-c40c-4185-8da3-c6867c66c299)_
Co-Authored-By: Oz <oz-agent@warp.dev>