### PR TITLE
feat(datadog): add real user monitoring (RUM) modules

### DIFF
--- a/modules/datadog/rum/application/README.md
+++ b/modules/datadog/rum/application/README.md
@@ -1,0 +1,186 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Datadog RUM Application</h3>
+  <p align="center">
+    Manages Datadog Real User Monitoring (RUM) applications via the datadog_rum_application resource.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#description">Description</a></li>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#notes--design-decisions">Notes / Design Decisions</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+## Description
+
+This module manages [Datadog RUM applications](https://docs.datadoghq.com/real_user_monitoring/) using the `datadog_rum_application` resource. It supports creating and managing multiple RUM applications via a single `map(object)` input, enabling scalable management of browser, iOS, Android, React Native, and Flutter applications.
+
+The `client_token` output is marked sensitive and must be embedded in your application's SDK initialization code. It is never logged by Terraform.
+
+## Prerequisites
+
+- A Datadog account with RUM enabled.
+- Datadog provider configured with a valid API key and application key that has RUM write permissions.
+
+## Usage
+
+### Simple Example
+
+```hcl
+module "rum_applications" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/rum/application"
+
+  applications = {
+    web_frontend = {
+      name                              = "web-frontend"
+      type                              = "browser"
+      rum_event_processing_state        = "ALL"
+      product_analytics_retention_state = "MAX"
+    }
+    mobile_ios = {
+      name = "mobile-ios"
+      type = "ios"
+    }
+  }
+}
+
+output "web_client_token" {
+  value     = module.rum_applications.client_tokens["web_frontend"]
+  sensitive = true
+}
+```
+
+## Notes / Design Decisions
+
+- **`required_version = ">= 1.1.5"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5 or later.
+- **`client_token` is sensitive**: The client token is embedded in client-side SDK initialization. All `client_token` values are grouped under the `client_tokens` output which is marked `sensitive = true`. Reference it via `nonsensitive()` only in contexts where exposure is intentional.
+- **`type` defaults to `"browser"`**: Matches the provider default. Override for mobile or cross-platform applications.
+- **`rum_event_processing_state` and `product_analytics_retention_state`**: Both default to `null`, which causes the provider to use its own defaults. Set them explicitly to control event processing and retention behavior.
+- **Validation**: The module validates `type`, `rum_event_processing_state`, and `product_analytics_retention_state` against their allowed values before any Terraform API call is made.
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 4.13.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [datadog_rum_application.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/rum_application) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_applications"></a> [applications](#input\_applications) | Map of RUM applications to create, keyed by a logical name. Each entry maps to one datadog\_rum\_application resource. | <pre>map(object({<br/>    name                              = string<br/>    type                              = optional(string, "browser")<br/>    rum_event_processing_state        = optional(string, null)<br/>    product_analytics_retention_state = optional(string, null)<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_api_key_ids"></a> [api\_key\_ids](#output\_api\_key\_ids) | Map of application logical name to the ID of the API key associated with the application. |
+| <a name="output_client_tokens"></a> [client\_tokens](#output\_client\_tokens) | Map of application logical name to client token. Sensitive — do not log. |
+| <a name="output_ids"></a> [ids](#output\_ids) | Map of application logical name to RUM application ID. |
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/datadog/rum/application/README.md
+++ b/modules/datadog/rum/application/README.md
@@ -92,7 +92,7 @@ output "web_client_token" {
 
 ## Notes / Design Decisions
 
-- **`required_version = ">= 1.1.5"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5 or later.
+- **`required_version = ">= 1.3.0"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5+, but this module uses `optional(type, default)` in variable type constraints, which requires Terraform/OpenTofu 1.3.0 or later.
 - **`client_token` is sensitive**: The client token is embedded in client-side SDK initialization. All `client_token` values are grouped under the `client_tokens` output which is marked `sensitive = true`. Reference it via `nonsensitive()` only in contexts where exposure is intentional.
 - **`type` defaults to `"browser"`**: Matches the provider default. Override for mobile or cross-platform applications.
 - **`rum_event_processing_state` and `product_analytics_retention_state`**: Both default to `null`, which causes the provider to use its own defaults. Set them explicitly to control event processing and retention behavior.
@@ -105,7 +105,7 @@ output "web_client_token" {
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/rum/application/main.tf
+++ b/modules/datadog/rum/application/main.tf
@@ -1,0 +1,25 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.1.5"
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+###########################
+# Module Configuration
+###########################
+
+resource "datadog_rum_application" "this" {
+  for_each = var.applications
+
+  name                              = each.value.name
+  type                              = each.value.type
+  rum_event_processing_state        = each.value.rum_event_processing_state
+  product_analytics_retention_state = each.value.product_analytics_retention_state
+}

--- a/modules/datadog/rum/application/main.tf
+++ b/modules/datadog/rum/application/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.3.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/rum/application/outputs.tf
+++ b/modules/datadog/rum/application/outputs.tf
@@ -1,0 +1,19 @@
+###########################
+# Resource Outputs
+###########################
+
+output "ids" {
+  description = "Map of application logical name to RUM application ID."
+  value       = { for k, v in datadog_rum_application.this : k => v.id }
+}
+
+output "client_tokens" {
+  description = "Map of application logical name to client token. Sensitive — do not log."
+  value       = { for k, v in datadog_rum_application.this : k => v.client_token }
+  sensitive   = true
+}
+
+output "api_key_ids" {
+  description = "Map of application logical name to the ID of the API key associated with the application."
+  value       = { for k, v in datadog_rum_application.this : k => v.api_key_id }
+}

--- a/modules/datadog/rum/application/variables.tf
+++ b/modules/datadog/rum/application/variables.tf
@@ -1,0 +1,38 @@
+###########################
+# Resource Variables
+###########################
+
+variable "applications" {
+  description = "Map of RUM applications to create, keyed by a logical name. Each entry maps to one datadog_rum_application resource."
+  type = map(object({
+    name                              = string
+    type                              = optional(string, "browser")
+    rum_event_processing_state        = optional(string, null)
+    product_analytics_retention_state = optional(string, null)
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.applications :
+      contains(["browser", "ios", "android", "react-native", "flutter"], v.type)
+    ])
+    error_message = "type must be one of: browser, ios, android, react-native, flutter."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.applications :
+      v.rum_event_processing_state == null || contains(["ALL", "ERROR_FOCUSED_MODE", "NONE"], v.rum_event_processing_state)
+    ])
+    error_message = "rum_event_processing_state must be one of: ALL, ERROR_FOCUSED_MODE, NONE."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.applications :
+      v.product_analytics_retention_state == null || contains(["MAX", "NONE"], v.product_analytics_retention_state)
+    ])
+    error_message = "product_analytics_retention_state must be one of: MAX, NONE."
+  }
+}

--- a/modules/datadog/rum/metric/README.md
+++ b/modules/datadog/rum/metric/README.md
@@ -1,0 +1,198 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Datadog RUM Metric</h3>
+  <p align="center">
+    Manages Datadog Real User Monitoring (RUM) metrics via the datadog_rum_metric resource.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#description">Description</a></li>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#notes--design-decisions">Notes / Design Decisions</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+## Description
+
+This module manages [Datadog RUM-based metrics](https://docs.datadoghq.com/real_user_monitoring/generate_metrics/) using the `datadog_rum_metric` resource. RUM-based metrics let you generate custom metrics from RUM events for use in monitors, dashboards, and SLOs.
+
+Multiple metrics can be managed from a single module invocation using the `metrics` map input. Each metric supports optional `compute`, `filter`, `group_by`, and `uniqueness` nested configuration blocks, rendered via `dynamic` blocks.
+
+## Prerequisites
+
+- A Datadog account with RUM enabled.
+- Datadog provider configured with a valid API key and application key that has RUM metrics write permissions.
+
+## Usage
+
+### Simple Example
+
+```hcl
+module "rum_metrics" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/rum/metric"
+
+  metrics = {
+    session_duration = {
+      name       = "rum.session.duration"
+      event_type = "session"
+      compute = {
+        aggregation_type    = "distribution"
+        include_percentiles = true
+        path                = "@duration"
+      }
+      filter = {
+        query = "@service:web-ui"
+      }
+      group_by = [
+        {
+          path     = "@browser.name"
+          tag_name = "browser_name"
+        }
+      ]
+      uniqueness = {
+        when = "match"
+      }
+    }
+    action_count = {
+      name       = "rum.action.count"
+      event_type = "action"
+      compute = {
+        aggregation_type = "count"
+      }
+    }
+  }
+}
+```
+
+## Notes / Design Decisions
+
+- **`required_version = ">= 1.1.5"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5 or later.
+- **`name` is immutable**: The `name` field on `datadog_rum_metric` cannot be changed after creation. Renaming a metric requires destroying and recreating it.
+- **`compute.aggregation_type`**: Required when the `compute` block is specified. Use `"distribution"` for percentile metrics (which also unlocks `include_percentiles` and `path`).
+- **`group_by` is a list**: Multiple grouping dimensions can be specified as a list of objects.
+- **`uniqueness.when`**: Valid values are `"match"` (count on first seen) and `"end"` (count when event completes). Only relevant for updatable event types such as sessions and views.
+- **All nested blocks are optional**: Omitting `compute`, `filter`, `group_by`, or `uniqueness` causes the provider to use its own defaults for those configurations.
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 4.13.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [datadog_rum_metric.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/rum_metric) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_metrics"></a> [metrics](#input\_metrics) | Map of RUM-based metrics to create, keyed by a logical name. Each entry maps to one datadog\_rum\_metric resource. | <pre>map(object({<br/>    name       = string<br/>    event_type = string<br/>    compute = optional(object({<br/>      aggregation_type    = string<br/>      include_percentiles = optional(bool, null)<br/>      path                = optional(string, null)<br/>    }), null)<br/>    filter = optional(object({<br/>      query = optional(string, null)<br/>    }), null)<br/>    group_by = optional(list(object({<br/>      path     = optional(string, null)<br/>      tag_name = optional(string, null)<br/>    })), null)<br/>    uniqueness = optional(object({<br/>      when = optional(string, null)<br/>    }), null)<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_ids"></a> [ids](#output\_ids) | Map of metric logical name to RUM metric ID. |
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/datadog/rum/metric/README.md
+++ b/modules/datadog/rum/metric/README.md
@@ -105,7 +105,7 @@ module "rum_metrics" {
 
 ## Notes / Design Decisions
 
-- **`required_version = ">= 1.1.5"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5 or later.
+- **`required_version = ">= 1.3.0"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5+, but this module uses `optional(type, default)` in variable type constraints, which requires Terraform/OpenTofu 1.3.0 or later.
 - **`name` is immutable**: The `name` field on `datadog_rum_metric` cannot be changed after creation. Renaming a metric requires destroying and recreating it.
 - **`compute.aggregation_type`**: Required when the `compute` block is specified. Use `"distribution"` for percentile metrics (which also unlocks `include_percentiles` and `path`).
 - **`group_by` is a list**: Multiple grouping dimensions can be specified as a list of objects.
@@ -119,7 +119,7 @@ module "rum_metrics" {
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/rum/metric/main.tf
+++ b/modules/datadog/rum/metric/main.tf
@@ -1,0 +1,54 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.1.5"
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+###########################
+# Module Configuration
+###########################
+
+resource "datadog_rum_metric" "this" {
+  for_each = var.metrics
+
+  name       = each.value.name
+  event_type = each.value.event_type
+
+  dynamic "compute" {
+    for_each = each.value.compute != null ? [each.value.compute] : []
+    content {
+      aggregation_type    = compute.value.aggregation_type
+      include_percentiles = compute.value.include_percentiles
+      path                = compute.value.path
+    }
+  }
+
+  dynamic "filter" {
+    for_each = each.value.filter != null ? [each.value.filter] : []
+    content {
+      query = filter.value.query
+    }
+  }
+
+  dynamic "group_by" {
+    for_each = each.value.group_by != null ? each.value.group_by : []
+    content {
+      path     = group_by.value.path
+      tag_name = group_by.value.tag_name
+    }
+  }
+
+  dynamic "uniqueness" {
+    for_each = each.value.uniqueness != null ? [each.value.uniqueness] : []
+    content {
+      when = uniqueness.value.when
+    }
+  }
+}

--- a/modules/datadog/rum/metric/main.tf
+++ b/modules/datadog/rum/metric/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.3.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/rum/metric/outputs.tf
+++ b/modules/datadog/rum/metric/outputs.tf
@@ -1,0 +1,8 @@
+###########################
+# Resource Outputs
+###########################
+
+output "ids" {
+  description = "Map of metric logical name to RUM metric ID."
+  value       = { for k, v in datadog_rum_metric.this : k => v.id }
+}

--- a/modules/datadog/rum/metric/variables.tf
+++ b/modules/datadog/rum/metric/variables.tf
@@ -1,0 +1,27 @@
+###########################
+# Resource Variables
+###########################
+
+variable "metrics" {
+  description = "Map of RUM-based metrics to create, keyed by a logical name. Each entry maps to one datadog_rum_metric resource."
+  type = map(object({
+    name       = string
+    event_type = string
+    compute = optional(object({
+      aggregation_type    = string
+      include_percentiles = optional(bool, null)
+      path                = optional(string, null)
+    }), null)
+    filter = optional(object({
+      query = optional(string, null)
+    }), null)
+    group_by = optional(list(object({
+      path     = optional(string, null)
+      tag_name = optional(string, null)
+    })), null)
+    uniqueness = optional(object({
+      when = optional(string, null)
+    }), null)
+  }))
+  default = {}
+}

--- a/modules/datadog/rum/retention_filter/README.md
+++ b/modules/datadog/rum/retention_filter/README.md
@@ -1,0 +1,218 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Datadog RUM Retention Filter</h3>
+  <p align="center">
+    Manages Datadog RUM retention filters and their evaluation order via datadog_rum_retention_filter and datadog_rum_retention_filters_order.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#description">Description</a></li>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#notes--design-decisions">Notes / Design Decisions</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+## Description
+
+This module manages [Datadog RUM retention filters](https://docs.datadoghq.com/real_user_monitoring/guide/rum-event-retention-filters/) using the `datadog_rum_retention_filter` resource, and optionally manages the evaluation order of all retention filters for a RUM application using the `datadog_rum_retention_filters_order` resource.
+
+Retention filters control which RUM events are stored and at what sampling rate. Multiple filters can be managed from a single module invocation via the `retention_filters` map. The ordering resource (`datadog_rum_retention_filters_order`) is a singleton per RUM application and is opt-in via `enable_filter_order`.
+
+## Prerequisites
+
+- A Datadog account with RUM enabled.
+- At least one RUM application (managed by the `modules/datadog/rum/application` module or created externally).
+- The application ID(s) for the RUM application(s) to which filters belong.
+
+## Usage
+
+### Filters only
+
+```hcl
+module "rum_retention_filters" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/rum/retention_filter"
+
+  retention_filters = {
+    replay_sessions = {
+      application_id = "<APPLICATION_ID>"
+      name           = "Retain sessions with replay"
+      event_type     = "session"
+      sample_rate    = 100
+      query          = "@session.has_replay:true"
+      enabled        = true
+    }
+    error_actions = {
+      application_id = "<APPLICATION_ID>"
+      name           = "Retain error actions at 50%"
+      event_type     = "action"
+      sample_rate    = 50
+      enabled        = true
+    }
+  }
+}
+```
+
+### Filters with order management
+
+```hcl
+module "rum_retention_filters" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/rum/retention_filter"
+
+  retention_filters = {
+    high_value_sessions = {
+      application_id = "<APPLICATION_ID>"
+      name           = "High value sessions"
+      event_type     = "session"
+      sample_rate    = 100
+      query          = "@session.has_replay:true"
+      enabled        = true
+    }
+  }
+
+  enable_filter_order         = true
+  filter_order_application_id = "<APPLICATION_ID>"
+  filter_order_ids = [
+    "default-action",
+    "default-error",
+    module.rum_retention_filters.ids["high_value_sessions"],
+  ]
+}
+```
+
+## Notes / Design Decisions
+
+- **`required_version = ">= 1.1.5"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5 or later.
+- **`datadog_rum_retention_filters_order` is a singleton**: Datadog maintains exactly one ordering resource per RUM application. Only one module instance per application should set `enable_filter_order = true`. Managing it from multiple module instances will cause conflicts.
+- **Default filters**: Datadog automatically creates internal retention filters (with IDs prefixed by `"default"`) for each RUM application. When managing filter order, `filter_order_ids` must include these default filter IDs alongside any custom ones. Use the `datadog_rum_retention_filters` data source to discover the full list of current filter IDs before constructing the order list.
+- **`sample_rate` range**: Must be between 0.1 and 100 (inclusive), supporting one decimal place.
+- **`enabled` defaults to `true`**: Filters are active by default. Set `enabled = false` to create a filter in a disabled state.
+- **`query` defaults to `""`**: An empty query matches all events of the specified type.
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 4.13.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [datadog_rum_retention_filter.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/rum_retention_filter) | resource |
+| [datadog_rum_retention_filters_order.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/rum_retention_filters_order) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_enable_filter_order"></a> [enable\_filter\_order](#input\_enable\_filter\_order) | Whether to manage the retention filter order for a RUM application. When true, filter\_order\_application\_id and filter\_order\_ids must be provided. This is a singleton resource per application — only one module instance per application should set this to true. | `bool` | `false` | no |
+| <a name="input_filter_order_application_id"></a> [filter\_order\_application\_id](#input\_filter\_order\_application\_id) | RUM application ID for the retention filter order resource. Required when enable\_filter\_order is true. | `string` | `null` | no |
+| <a name="input_filter_order_ids"></a> [filter\_order\_ids](#input\_filter\_order\_ids) | Ordered list of all retention filter IDs for the application. Required when enable\_filter\_order is true. Must include all filter IDs for the application, including the default filters created internally by Datadog (those with IDs prefixed by 'default'). The order of IDs in this list defines the evaluation order of the filters. | `list(string)` | `[]` | no |
+| <a name="input_retention_filters"></a> [retention\_filters](#input\_retention\_filters) | Map of RUM retention filters to create, keyed by a logical name. Each entry maps to one datadog\_rum\_retention\_filter resource. | <pre>map(object({<br/>    application_id = string<br/>    name           = string<br/>    event_type     = string<br/>    sample_rate    = number<br/>    enabled        = optional(bool, true)<br/>    query          = optional(string, "")<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_filter_order_id"></a> [filter\_order\_id](#output\_filter\_order\_id) | ID of the retention filters order resource. Only set when enable\_filter\_order is true. |
+| <a name="output_ids"></a> [ids](#output\_ids) | Map of retention filter logical name to retention filter ID. |
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/datadog/rum/retention_filter/README.md
+++ b/modules/datadog/rum/retention_filter/README.md
@@ -93,7 +93,10 @@ module "rum_retention_filters" {
 
 ### Filters with order management
 
+The filter ordering resource is a singleton per application and requires the IDs of **all** filters — including Datadog's internally created default ones. Split this into two separate module invocations: first create the filters, then reference their IDs when managing the order.
+
 ```hcl
+# Step 1 — create the custom filters
 module "rum_retention_filters" {
   source = "github.com/zachreborn/terraform-modules//modules/datadog/rum/retention_filter"
 
@@ -107,6 +110,13 @@ module "rum_retention_filters" {
       enabled        = true
     }
   }
+}
+
+# Step 2 — manage the evaluation order (separate invocation to avoid a dependency cycle)
+module "rum_filter_order" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/rum/retention_filter"
+
+  retention_filters = {} # no new filters in this invocation
 
   enable_filter_order         = true
   filter_order_application_id = "<APPLICATION_ID>"
@@ -120,7 +130,7 @@ module "rum_retention_filters" {
 
 ## Notes / Design Decisions
 
-- **`required_version = ">= 1.1.5"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5 or later.
+- **`required_version = ">= 1.3.0"`**: The Datadog Terraform provider requires Terraform/OpenTofu 1.1.5+, but this module uses `optional(type, default)` in variable type constraints, which requires Terraform/OpenTofu 1.3.0 or later.
 - **`datadog_rum_retention_filters_order` is a singleton**: Datadog maintains exactly one ordering resource per RUM application. Only one module instance per application should set `enable_filter_order = true`. Managing it from multiple module instances will cause conflicts.
 - **Default filters**: Datadog automatically creates internal retention filters (with IDs prefixed by `"default"`) for each RUM application. When managing filter order, `filter_order_ids` must include these default filter IDs alongside any custom ones. Use the `datadog_rum_retention_filters` data source to discover the full list of current filter IDs before constructing the order list.
 - **`sample_rate` range**: Must be between 0.1 and 100 (inclusive), supporting one decimal place.
@@ -134,7 +144,7 @@ module "rum_retention_filters" {
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/rum/retention_filter/main.tf
+++ b/modules/datadog/rum/retention_filter/main.tf
@@ -1,0 +1,34 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.1.5"
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+###########################
+# Module Configuration
+###########################
+
+resource "datadog_rum_retention_filter" "this" {
+  for_each = var.retention_filters
+
+  application_id = each.value.application_id
+  name           = each.value.name
+  event_type     = each.value.event_type
+  sample_rate    = each.value.sample_rate
+  enabled        = each.value.enabled
+  query          = each.value.query
+}
+
+resource "datadog_rum_retention_filters_order" "this" {
+  count = var.enable_filter_order ? 1 : 0
+
+  application_id       = var.filter_order_application_id
+  retention_filter_ids = var.filter_order_ids
+}

--- a/modules/datadog/rum/retention_filter/main.tf
+++ b/modules/datadog/rum/retention_filter/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.3.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
@@ -31,4 +31,11 @@ resource "datadog_rum_retention_filters_order" "this" {
 
   application_id       = var.filter_order_application_id
   retention_filter_ids = var.filter_order_ids
+
+  lifecycle {
+    precondition {
+      condition     = var.filter_order_application_id != null && length(var.filter_order_ids) > 0
+      error_message = "filter_order_application_id and filter_order_ids must be provided (non-null and non-empty) when enable_filter_order is true."
+    }
+  }
 }

--- a/modules/datadog/rum/retention_filter/outputs.tf
+++ b/modules/datadog/rum/retention_filter/outputs.tf
@@ -1,0 +1,13 @@
+###########################
+# Resource Outputs
+###########################
+
+output "ids" {
+  description = "Map of retention filter logical name to retention filter ID."
+  value       = { for k, v in datadog_rum_retention_filter.this : k => v.id }
+}
+
+output "filter_order_id" {
+  description = "ID of the retention filters order resource. Only set when enable_filter_order is true."
+  value       = var.enable_filter_order ? datadog_rum_retention_filters_order.this[0].id : null
+}

--- a/modules/datadog/rum/retention_filter/variables.tf
+++ b/modules/datadog/rum/retention_filter/variables.tf
@@ -1,0 +1,50 @@
+###########################
+# Resource Variables
+###########################
+
+variable "retention_filters" {
+  description = "Map of RUM retention filters to create, keyed by a logical name. Each entry maps to one datadog_rum_retention_filter resource."
+  type = map(object({
+    application_id = string
+    name           = string
+    event_type     = string
+    sample_rate    = number
+    enabled        = optional(bool, true)
+    query          = optional(string, "")
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.retention_filters :
+      contains(["action", "error", "long_task", "resource", "session", "view"], v.event_type)
+    ])
+    error_message = "event_type must be one of: action, error, long_task, resource, session, view."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.retention_filters :
+      v.sample_rate >= 0.1 && v.sample_rate <= 100
+    ])
+    error_message = "sample_rate must be between 0.1 and 100."
+  }
+}
+
+variable "enable_filter_order" {
+  description = "Whether to manage the retention filter order for a RUM application. When true, filter_order_application_id and filter_order_ids must be provided. This is a singleton resource per application — only one module instance per application should set this to true."
+  type        = bool
+  default     = false
+}
+
+variable "filter_order_application_id" {
+  description = "RUM application ID for the retention filter order resource. Required when enable_filter_order is true."
+  type        = string
+  default     = null
+}
+
+variable "filter_order_ids" {
+  description = "Ordered list of all retention filter IDs for the application. Required when enable_filter_order is true. Must include all filter IDs for the application, including the default filters created internally by Datadog (those with IDs prefixed by 'default'). The order of IDs in this list defines the evaluation order of the filters."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## What modules were added

Adds 3 new submodules under \`modules/datadog/rum/\`:

| Module | Resource(s) | Description |
|---|---|---|
| \`rum/application\` | \`datadog_rum_application\` | Manages RUM applications (browser, iOS, Android, React Native, Flutter) with sensitive \`client_token\` output |
| \`rum/metric\` | \`datadog_rum_metric\` | Manages RUM-based custom metrics with dynamic blocks for \`compute\`, \`filter\`, \`group_by\`, \`uniqueness\` |
| \`rum/retention_filter\` | \`datadog_rum_retention_filter\` + \`datadog_rum_retention_filters_order\` | Manages RUM retention filters and their evaluation order (singleton per application) |

All three modules follow the \`map(object({...}))\` + \`for_each\` scalability pattern from AGENTS.md.

## Validation

| Module | fmt | init | validate | terraform-docs |
|---|---|---|---|---|
| \`rum/application\` | ✓ | ✓ | ✓ | ✓ |
| \`rum/metric\` | ✓ | ✓ | ✓ | ✓ |
| \`rum/retention_filter\` | ✓ | ✓ | ✓ | ✓ |

Provider version installed during validation: \`datadog/datadog v4.13.0\`

## Part of Datadog module library series

This PR is part of the Datadog module library series, adding Real User Monitoring (RUM) support. Each module uses the Datadog provider (\`DataDog/datadog >= 4.0.0\`), requires \`terraform >= 1.1.5\` (Datadog provider requirement), and follows all AGENTS.md conventions.

---

Generated by Oz · [Conversation](https://app.warp.dev/conversation/bd966746-c997-4cb1-bd55-3a00af11901a) · [Run](https://oz.warp.dev/runs/019f01a8-1a52-783e-ac0c-ccc6c07f030f)