### PR TITLE
feat(datadog): add synthetics modules

### DIFF
--- a/modules/datadog/synthetics/concurrency_cap/README.md
+++ b/modules/datadog/synthetics/concurrency_cap/README.md
@@ -76,7 +76,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Notes / Design Decisions
 
 - **Singleton resource**: There is exactly **one** concurrency cap per Datadog organization. Only a single instance of this module should be used per Datadog org. Creating multiple instances will cause API conflicts.
-- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
+- **required_version >= 1.3.0**: The two-argument `optional(type, default)` syntax used in `variables.tf` requires Terraform >= 1.3.0 or OpenTofu >= 1.6.0 (since OpenTofu 1.6.x >= 1.3.0). This matches the version floor used by the other Datadog modules in this library (`rum`, `monitors`, `cloud_cost`).
 - **Import**: An existing concurrency cap can be imported with `terraform import datadog_synthetics_concurrency_cap.this <name>` where `<name>` is any string you choose (Datadog does not store the resource name server-side).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -88,7 +88,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/concurrency_cap/README.md
+++ b/modules/datadog/synthetics/concurrency_cap/README.md
@@ -76,7 +76,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Notes / Design Decisions
 
 - **Singleton resource**: There is exactly **one** concurrency cap per Datadog organization. Only a single instance of this module should be used per Datadog org. Creating multiple instances will cause API conflicts.
-- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
 - **Import**: An existing concurrency cap can be imported with `terraform import datadog_synthetics_concurrency_cap.this <name>` where `<name>` is any string you choose (Datadog does not store the resource name server-side).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -88,7 +88,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/concurrency_cap/README.md
+++ b/modules/datadog/synthetics/concurrency_cap/README.md
@@ -1,0 +1,156 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Datadog Synthetics Concurrency Cap</h3>
+  <p align="center">
+    Manages the Datadog Synthetics on-demand concurrency cap for an organization.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#description">Description</a></li>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#notes--design-decisions">Notes / Design Decisions</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+## Description
+
+Manages the `datadog_synthetics_concurrency_cap` resource, which controls the maximum number of Datadog Synthetic tests that can run in parallel on demand for an entire organization.
+
+## Prerequisites
+
+- A Datadog account with Synthetics enabled.
+- A Datadog provider configured with an API key and Application key that has the `synthetics_write` permission.
+
+## Usage
+
+### Simple Example
+
+```hcl
+module "synthetics_concurrency_cap" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/concurrency_cap"
+
+  on_demand_concurrency_cap = 10
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Notes / Design Decisions
+
+- **Singleton resource**: There is exactly **one** concurrency cap per Datadog organization. Only a single instance of this module should be used per Datadog org. Creating multiple instances will cause API conflicts.
+- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+- **Import**: An existing concurrency cap can be imported with `terraform import datadog_synthetics_concurrency_cap.this <name>` where `<name>` is any string you choose (Datadog does not store the resource name server-side).
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 4.13.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [datadog_synthetics_concurrency_cap.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_concurrency_cap) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_on_demand_concurrency_cap"></a> [on\_demand\_concurrency\_cap](#input\_on\_demand\_concurrency\_cap) | Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel. Value must be at least 1. | `number` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the Synthetics concurrency cap resource. |
+<!-- END_TF_DOCS -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/

--- a/modules/datadog/synthetics/concurrency_cap/main.tf
+++ b/modules/datadog/synthetics/concurrency_cap/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.0.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/concurrency_cap/main.tf
+++ b/modules/datadog/synthetics/concurrency_cap/main.tf
@@ -1,0 +1,23 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.1.5"
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+###########################
+# Locals
+###########################
+
+###########################
+# Module Configuration
+###########################
+resource "datadog_synthetics_concurrency_cap" "this" {
+  on_demand_concurrency_cap = var.on_demand_concurrency_cap
+}

--- a/modules/datadog/synthetics/concurrency_cap/main.tf
+++ b/modules/datadog/synthetics/concurrency_cap/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/concurrency_cap/outputs.tf
+++ b/modules/datadog/synthetics/concurrency_cap/outputs.tf
@@ -1,0 +1,7 @@
+###########################
+# Resource Outputs
+###########################
+output "id" {
+  description = "The ID of the Synthetics concurrency cap resource."
+  value       = datadog_synthetics_concurrency_cap.this.id
+}

--- a/modules/datadog/synthetics/concurrency_cap/variables.tf
+++ b/modules/datadog/synthetics/concurrency_cap/variables.tf
@@ -1,0 +1,12 @@
+###########################
+# Resource Variables
+###########################
+variable "on_demand_concurrency_cap" {
+  description = "Value of the on-demand concurrency cap, customizing the number of Synthetic tests run in parallel. Value must be at least 1."
+  type        = number
+
+  validation {
+    condition     = var.on_demand_concurrency_cap >= 1
+    error_message = "on_demand_concurrency_cap must be at least 1."
+  }
+}

--- a/modules/datadog/synthetics/global_variable/README.md
+++ b/modules/datadog/synthetics/global_variable/README.md
@@ -161,7 +161,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 - **`restricted_roles` deprecated**: This field is deprecated by the Datadog API. Use a `datadog_restriction_policy` resource instead.
 - **Name format**: Global variable names must be all uppercase with underscores (e.g., `MY_VARIABLE`). Datadog enforces this constraint.
 - **`is_totp` / `is_fido`**: Setting either to `true` automatically sets `secure = true` at the API level.
-- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
+- **required_version >= 1.3.0**: The two-argument `optional(type, default)` syntax used in `variables.tf` requires Terraform >= 1.3.0 or OpenTofu >= 1.6.0 (since OpenTofu 1.6.x >= 1.3.0). This matches the version floor used by the other Datadog modules in this library (`rum`, `monitors`, `cloud_cost`).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -172,7 +172,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/global_variable/README.md
+++ b/modules/datadog/synthetics/global_variable/README.md
@@ -161,7 +161,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 - **`restricted_roles` deprecated**: This field is deprecated by the Datadog API. Use a `datadog_restriction_policy` resource instead.
 - **Name format**: Global variable names must be all uppercase with underscores (e.g., `MY_VARIABLE`). Datadog enforces this constraint.
 - **`is_totp` / `is_fido`**: Setting either to `true` automatically sets `secure = true` at the API level.
-- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -172,7 +172,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/global_variable/README.md
+++ b/modules/datadog/synthetics/global_variable/README.md
@@ -1,0 +1,240 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Datadog Synthetics Global Variable</h3>
+  <p align="center">
+    Manages Datadog Synthetics global variables using a scalable map/for_each pattern.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#description">Description</a></li>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#notes--design-decisions">Notes / Design Decisions</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+## Description
+
+Manages `datadog_synthetics_global_variable` resources. Global variables in Datadog Synthetics can be reused across multiple tests and support freeform values, secure (hidden) values, multi-factor authentication (MFA)/time-based one-time password (TOTP) tokens, FIDO2 variables, and variables populated from test results via `parse_test_options`.
+
+## Prerequisites
+
+- A Datadog account with Synthetics enabled.
+- A Datadog provider configured with an API key and Application key that has the `synthetics_write` permission.
+- If using `parse_test_options`, the referenced Synthetics test must exist before this resource is created.
+
+## Usage
+
+### Simple Freeform Variable
+
+```hcl
+module "synthetics_global_variables" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/global_variable"
+
+  global_variables = {
+    base_url = {
+      name        = "BASE_URL"
+      description = "Base URL for API tests"
+      tags        = ["env:production", "team:platform"]
+      value       = "https://api.example.com"
+    }
+
+    api_version = {
+      name        = "API_VERSION"
+      description = "Current API version"
+      tags        = ["env:production"]
+      value       = "v2"
+    }
+  }
+}
+```
+
+### Secure Variable (Secret)
+
+```hcl
+module "synthetics_global_variables" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/global_variable"
+
+  global_variables = {
+    api_token = {
+      name        = "API_TOKEN"
+      description = "API authentication token"
+      tags        = ["env:production", "team:platform"]
+      value       = "<YOUR_VALUE_HERE>"
+      secure      = true
+    }
+  }
+}
+```
+
+### Multi-Factor Authentication (Time-based One-time Password) Variable
+
+```hcl
+module "synthetics_global_variables" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/global_variable"
+
+  global_variables = {
+    mfa_token = {
+      name        = "MFA_TOKEN"
+      description = "Time-based one-time password token for MFA login tests"
+      tags        = ["env:production"]
+      value       = "<TOTP_SEED_VALUE>"
+      is_totp     = true
+      options = {
+        totp_parameters = {
+          digits           = 6
+          refresh_interval = 30
+        }
+      }
+    }
+  }
+}
+```
+
+### Variable Parsed from Test Result
+
+```hcl
+module "synthetics_global_variables" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/global_variable"
+
+  global_variables = {
+    auth_token = {
+      name          = "AUTH_TOKEN"
+      description   = "Authentication token extracted from login test response"
+      tags          = ["env:production"]
+      parse_test_id = "abc-123-def"
+      parse_test_options = {
+        type  = "http_body"
+        parser = {
+          type  = "json_path"
+          value = "$.token"
+        }
+      }
+    }
+  }
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Notes / Design Decisions
+
+- **Sensitive `value` field**: The `value` attribute can contain secrets (API tokens, passwords, etc.). When `secure = true`, Datadog hides the value in the UI and API responses. Regardless of `secure`, the value is stored in Terraform state — enable state encryption when managing secrets with this module.
+- **`value_wo` / write-only support**: The Datadog provider supports a `value_wo` write-only attribute (Terraform >= 1.11 only; not currently supported in OpenTofu). To use write-only values, set `value_wo_version` to trigger updates, and pass `value_wo` directly to the underlying resource. This module exposes `value_wo_version` to control update triggering. To use `value_wo`, consume the `datadog_synthetics_global_variable` resource directly until OpenTofu adds write-only attribute support.
+- **`restricted_roles` deprecated**: This field is deprecated by the Datadog API. Use a `datadog_restriction_policy` resource instead.
+- **Name format**: Global variable names must be all uppercase with underscores (e.g., `MY_VARIABLE`). Datadog enforces this constraint.
+- **`is_totp` / `is_fido`**: Setting either to `true` automatically sets `secure = true` at the API level.
+- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 4.13.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [datadog_synthetics_global_variable.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_global_variable) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_global_variables"></a> [global\_variables](#input\_global\_variables) | Map of Synthetics global variable configurations keyed by logical name. The 'value' field may contain sensitive data — enable Terraform state encryption when storing secrets. | <pre>map(object({<br/>    name             = string<br/>    description      = optional(string, "")<br/>    tags             = optional(list(string), [])<br/>    value            = optional(string, null)<br/>    value_wo_version = optional(string, null)<br/>    secure           = optional(bool, false)<br/>    is_totp          = optional(bool, false)<br/>    is_fido          = optional(bool, false)<br/>    restricted_roles = optional(set(string), null)<br/>    parse_test_id    = optional(string, null)<br/><br/>    options = optional(object({<br/>      totp_parameters = optional(object({<br/>        digits           = number<br/>        refresh_interval = number<br/>      }), null)<br/>    }), null)<br/><br/>    parse_test_options = optional(object({<br/>      type                = string<br/>      field               = optional(string, null)<br/>      local_variable_name = optional(string, null)<br/>      parser = optional(object({<br/>        type  = string<br/>        value = optional(string, null)<br/>      }), null)<br/>    }), null)<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_ids"></a> [ids](#output\_ids) | Map of global variable IDs keyed by logical name. |
+<!-- END_TF_DOCS -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/

--- a/modules/datadog/synthetics/global_variable/main.tf
+++ b/modules/datadog/synthetics/global_variable/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.0.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/global_variable/main.tf
+++ b/modules/datadog/synthetics/global_variable/main.tf
@@ -1,0 +1,64 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.1.5"
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+###########################
+# Locals
+###########################
+
+###########################
+# Module Configuration
+###########################
+resource "datadog_synthetics_global_variable" "this" {
+  for_each = var.global_variables
+
+  name             = each.value.name
+  description      = each.value.description
+  tags             = each.value.tags
+  value            = each.value.value
+  value_wo_version = each.value.value_wo_version
+  secure           = each.value.secure
+  is_totp          = each.value.is_totp
+  is_fido          = each.value.is_fido
+  restricted_roles = each.value.restricted_roles
+  parse_test_id    = each.value.parse_test_id
+
+  dynamic "options" {
+    for_each = each.value.options != null ? [each.value.options] : []
+    content {
+      dynamic "totp_parameters" {
+        for_each = options.value.totp_parameters != null ? [options.value.totp_parameters] : []
+        content {
+          digits           = totp_parameters.value.digits
+          refresh_interval = totp_parameters.value.refresh_interval
+        }
+      }
+    }
+  }
+
+  dynamic "parse_test_options" {
+    for_each = each.value.parse_test_options != null ? [each.value.parse_test_options] : []
+    content {
+      type                = parse_test_options.value.type
+      field               = parse_test_options.value.field
+      local_variable_name = parse_test_options.value.local_variable_name
+
+      dynamic "parser" {
+        for_each = parse_test_options.value.parser != null ? [parse_test_options.value.parser] : []
+        content {
+          type  = parser.value.type
+          value = parser.value.value
+        }
+      }
+    }
+  }
+}

--- a/modules/datadog/synthetics/global_variable/main.tf
+++ b/modules/datadog/synthetics/global_variable/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/global_variable/outputs.tf
+++ b/modules/datadog/synthetics/global_variable/outputs.tf
@@ -1,0 +1,7 @@
+###########################
+# Resource Outputs
+###########################
+output "ids" {
+  description = "Map of global variable IDs keyed by logical name."
+  value       = { for k, v in datadog_synthetics_global_variable.this : k => v.id }
+}

--- a/modules/datadog/synthetics/global_variable/variables.tf
+++ b/modules/datadog/synthetics/global_variable/variables.tf
@@ -1,0 +1,53 @@
+###########################
+# Resource Variables
+###########################
+variable "global_variables" {
+  description = "Map of Synthetics global variable configurations keyed by logical name. The 'value' field may contain sensitive data — enable Terraform state encryption when storing secrets."
+  type = map(object({
+    name             = string
+    description      = optional(string, "")
+    tags             = optional(list(string), [])
+    value            = optional(string, null)
+    value_wo_version = optional(string, null)
+    secure           = optional(bool, false)
+    is_totp          = optional(bool, false)
+    is_fido          = optional(bool, false)
+    restricted_roles = optional(set(string), null)
+    parse_test_id    = optional(string, null)
+
+    options = optional(object({
+      totp_parameters = optional(object({
+        digits           = number
+        refresh_interval = number
+      }), null)
+    }), null)
+
+    parse_test_options = optional(object({
+      type                = string
+      field               = optional(string, null)
+      local_variable_name = optional(string, null)
+      parser = optional(object({
+        type  = string
+        value = optional(string, null)
+      }), null)
+    }), null)
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.global_variables :
+      v.parse_test_options == null || contains(["http_body", "http_header", "http_status_code", "local_variable"], v.parse_test_options.type)
+    ])
+    error_message = "parse_test_options.type must be one of: http_body, http_header, http_status_code, local_variable."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.global_variables :
+      v.parse_test_options == null || v.parse_test_options.parser == null ||
+      contains(["raw", "json_path", "regex", "x_path"], v.parse_test_options.parser.type)
+    ])
+    error_message = "parse_test_options.parser.type must be one of: raw, json_path, regex, x_path."
+  }
+}

--- a/modules/datadog/synthetics/private_location/README.md
+++ b/modules/datadog/synthetics/private_location/README.md
@@ -1,0 +1,197 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Datadog Synthetics Private Location</h3>
+  <p align="center">
+    Manages Datadog Synthetics private locations using a scalable map/for_each pattern.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#description">Description</a></li>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#notes--design-decisions">Notes / Design Decisions</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+## Description
+
+Manages `datadog_synthetics_private_location` resources. Private locations allow you to run Datadog Synthetic tests against internal endpoints that are not accessible from the public internet. Each private location generates an installation JSON blob (the `config` output) that is used to configure the private location worker in your infrastructure.
+
+## Prerequisites
+
+- A Datadog account with Synthetics enabled.
+- A Datadog provider configured with an API key and Application key that has the `synthetics_write` permission.
+- Infrastructure to run the private location Docker container or Helm chart (the installation JSON from the `configs` output is required during setup).
+
+## Usage
+
+### Simple Example
+
+```hcl
+module "synthetics_private_locations" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/private_location"
+
+  private_locations = {
+    datacenter_east = {
+      name        = "US East Datacenter"
+      description = "Private location for the US East datacenter"
+      tags        = ["env:production", "region:us-east"]
+    }
+
+    datacenter_west = {
+      name        = "US West Datacenter"
+      description = "Private location for the US West datacenter"
+      tags        = ["env:production", "region:us-west"]
+    }
+  }
+}
+
+# Use the configs output to install the private location workers
+output "private_location_configs" {
+  value     = module.synthetics_private_locations.configs
+  sensitive = true
+}
+```
+
+### Example with Metadata
+
+```hcl
+module "synthetics_private_location" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/private_location"
+
+  private_locations = {
+    internal_api = {
+      name        = "Internal API Location"
+      description = "Private location for internal API testing"
+      tags        = ["env:staging", "team:platform"]
+      metadata = {
+        restricted_roles = ["role-id-1", "role-id-2"]
+      }
+    }
+  }
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Notes / Design Decisions
+
+- **Sensitive `configs` output**: The `configs` output contains installation JSON blobs that include credentials. This output is marked `sensitive = true`. Ensure your Terraform state is encrypted when using this module.
+- **`api_key` field**: The optional `api_key` field allows specifying an existing Datadog API key for generating the private location configuration. If omitted, Datadog generates an API key automatically. Because this field can contain a sensitive API key, pass it from a `sensitive` variable and ensure state encryption is enabled.
+- **`restricted_roles` deprecated**: The `metadata.restricted_roles` field is deprecated by the Datadog API. Use a `datadog_restriction_policy` resource referencing the `restriction_policy_resource_ids` output instead.
+- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 4.13.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [datadog_synthetics_private_location.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_private_location) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_private_locations"></a> [private\_locations](#input\_private\_locations) | Map of Synthetics private location configurations keyed by logical name. The api\_key field is sensitive — pass it via a sensitive variable or use Terraform state encryption. | <pre>map(object({<br/>    name        = string<br/>    description = optional(string, "")<br/>    tags        = optional(list(string), [])<br/>    api_key     = optional(string, null)<br/>    metadata = optional(object({<br/>      restricted_roles = optional(set(string), null)<br/>    }), null)<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_configs"></a> [configs](#output\_configs) | Map of private location installation JSON configuration blobs keyed by logical name. These are sensitive and contain the credentials required to install the private location worker. |
+| <a name="output_ids"></a> [ids](#output\_ids) | Map of private location IDs keyed by logical name. |
+| <a name="output_restriction_policy_resource_ids"></a> [restriction\_policy\_resource\_ids](#output\_restriction\_policy\_resource\_ids) | Map of resource IDs keyed by logical name, for use when setting restrictions with a datadog\_restriction\_policy resource. |
+<!-- END_TF_DOCS -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/

--- a/modules/datadog/synthetics/private_location/README.md
+++ b/modules/datadog/synthetics/private_location/README.md
@@ -116,7 +116,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 - **Sensitive `configs` output**: The `configs` output contains installation JSON blobs that include credentials. This output is marked `sensitive = true`. Ensure your Terraform state is encrypted when using this module.
 - **`api_key` field**: The optional `api_key` field allows specifying an existing Datadog API key for generating the private location configuration. If omitted, Datadog generates an API key automatically. Because this field can contain a sensitive API key, pass it from a `sensitive` variable and ensure state encryption is enabled.
 - **`restricted_roles` deprecated**: The `metadata.restricted_roles` field is deprecated by the Datadog API. Use a `datadog_restriction_policy` resource referencing the `restriction_policy_resource_ids` output instead.
-- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
+- **required_version >= 1.3.0**: The two-argument `optional(type, default)` syntax used in `variables.tf` requires Terraform >= 1.3.0 or OpenTofu >= 1.6.0 (since OpenTofu 1.6.x >= 1.3.0). This matches the version floor used by the other Datadog modules in this library (`rum`, `monitors`, `cloud_cost`).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -127,7 +127,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/private_location/README.md
+++ b/modules/datadog/synthetics/private_location/README.md
@@ -116,7 +116,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 - **Sensitive `configs` output**: The `configs` output contains installation JSON blobs that include credentials. This output is marked `sensitive = true`. Ensure your Terraform state is encrypted when using this module.
 - **`api_key` field**: The optional `api_key` field allows specifying an existing Datadog API key for generating the private location configuration. If omitted, Datadog generates an API key automatically. Because this field can contain a sensitive API key, pass it from a `sensitive` variable and ensure state encryption is enabled.
 - **`restricted_roles` deprecated**: The `metadata.restricted_roles` field is deprecated by the Datadog API. Use a `datadog_restriction_policy` resource referencing the `restriction_policy_resource_ids` output instead.
-- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -127,7 +127,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/private_location/main.tf
+++ b/modules/datadog/synthetics/private_location/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.0.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/private_location/main.tf
+++ b/modules/datadog/synthetics/private_location/main.tf
@@ -1,0 +1,35 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.1.5"
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+###########################
+# Locals
+###########################
+
+###########################
+# Module Configuration
+###########################
+resource "datadog_synthetics_private_location" "this" {
+  for_each = var.private_locations
+
+  name        = each.value.name
+  description = each.value.description
+  tags        = each.value.tags
+  api_key     = each.value.api_key
+
+  dynamic "metadata" {
+    for_each = each.value.metadata != null ? [each.value.metadata] : []
+    content {
+      restricted_roles = metadata.value.restricted_roles
+    }
+  }
+}

--- a/modules/datadog/synthetics/private_location/main.tf
+++ b/modules/datadog/synthetics/private_location/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/private_location/outputs.tf
+++ b/modules/datadog/synthetics/private_location/outputs.tf
@@ -1,0 +1,18 @@
+###########################
+# Resource Outputs
+###########################
+output "ids" {
+  description = "Map of private location IDs keyed by logical name."
+  value       = { for k, v in datadog_synthetics_private_location.this : k => v.id }
+}
+
+output "configs" {
+  description = "Map of private location installation JSON configuration blobs keyed by logical name. These are sensitive and contain the credentials required to install the private location worker."
+  value       = { for k, v in datadog_synthetics_private_location.this : k => v.config }
+  sensitive   = true
+}
+
+output "restriction_policy_resource_ids" {
+  description = "Map of resource IDs keyed by logical name, for use when setting restrictions with a datadog_restriction_policy resource."
+  value       = { for k, v in datadog_synthetics_private_location.this : k => v.restriction_policy_resource_id }
+}

--- a/modules/datadog/synthetics/private_location/variables.tf
+++ b/modules/datadog/synthetics/private_location/variables.tf
@@ -1,0 +1,16 @@
+###########################
+# Resource Variables
+###########################
+variable "private_locations" {
+  description = "Map of Synthetics private location configurations keyed by logical name. The api_key field is sensitive — pass it via a sensitive variable or use Terraform state encryption."
+  type = map(object({
+    name        = string
+    description = optional(string, "")
+    tags        = optional(list(string), [])
+    api_key     = optional(string, null)
+    metadata = optional(object({
+      restricted_roles = optional(set(string), null)
+    }), null)
+  }))
+  default = {}
+}

--- a/modules/datadog/synthetics/test/README.md
+++ b/modules/datadog/synthetics/test/README.md
@@ -248,7 +248,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 - **`monitor_id` output**: Each Synthetics test automatically creates a Datadog monitor. The `monitor_ids` output exposes these IDs so you can reference them (e.g., to create composite monitors).
 - **Global variable deprecation**: Direct use of `{{ GLOBAL_VAR }}` in test URLs is deprecated as of provider v3.1.0. Use `config_variable` blocks with `type = "global"` and reference the variable by its local name instead.
 - **`device_ids`**: Only applicable to browser tests. Valid values include `laptop_large`, `tablet`, `mobile_small`, `chrome.laptop_large`, `firefox.laptop_large`, etc.
-- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -259,7 +259,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/test/README.md
+++ b/modules/datadog/synthetics/test/README.md
@@ -1,0 +1,328 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Datadog Synthetics Test</h3>
+  <p align="center">
+    Manages Datadog Synthetics tests (API, browser, and multistep) using a scalable map/for_each pattern.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#description">Description</a></li>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#notes--design-decisions">Notes / Design Decisions</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+## Description
+
+Manages `datadog_synthetics_test` resources. This module supports the full range of Datadog Synthetics test types:
+
+- **API tests** (`type = "api"`) with subtypes: `http`, `ssl`, `tcp`, `dns`, `icmp`, `udp`, `websocket`, `grpc`
+- **Multistep API tests** (`type = "api"`, `subtype = "multi"`) — multiple ordered API steps per test
+- **Browser tests** (`type = "browser"`) — recorded browser interaction tests
+
+All nested configuration blocks (request definitions, assertions, options, retry settings, monitor options, browser steps, API steps, and config variables) are supported via dynamic blocks.
+
+## Prerequisites
+
+- A Datadog account with Synthetics enabled.
+- A Datadog provider configured with an API key and Application key that has the `synthetics_write` permission.
+- For **private location tests**: a `datadog_synthetics_private_location` resource must exist and its ID must be passed in `locations`.
+- For **global variable references** in `config_variable` blocks (`type = "global"`): the referenced `datadog_synthetics_global_variable` must exist.
+
+## Usage
+
+### API HTTP Test
+
+```hcl
+module "synthetics_tests" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/test"
+
+  tests = {
+    api_uptime = {
+      name      = "Uptime check — example.org"
+      type      = "api"
+      subtype   = "http"
+      status    = "live"
+      message   = "Notify @pagerduty"
+      locations = ["aws:us-east-1", "aws:eu-west-1"]
+      tags      = ["env:production", "team:platform"]
+
+      request_definition = {
+        method = "GET"
+        url    = "https://www.example.org"
+      }
+
+      request_headers = {
+        Content-Type = "application/json"
+      }
+
+      assertions = [
+        {
+          type     = "statusCode"
+          operator = "is"
+          target   = "200"
+        },
+        {
+          type     = "responseTime"
+          operator = "lessThan"
+          target   = "2000"
+        }
+      ]
+
+      options_list = {
+        tick_every = 900
+
+        retry = {
+          count    = 2
+          interval = 300
+        }
+
+        monitor_options = {
+          renotify_interval = 120
+        }
+      }
+    }
+  }
+}
+```
+
+### API SSL Test
+
+```hcl
+module "synthetics_ssl_tests" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/test"
+
+  tests = {
+    ssl_check = {
+      name      = "SSL Certificate Check — example.org"
+      type      = "api"
+      subtype   = "ssl"
+      status    = "live"
+      locations = ["aws:us-east-1"]
+      tags      = ["env:production"]
+
+      request_definition = {
+        host = "example.org"
+        port = "443"
+      }
+
+      assertions = [
+        {
+          type     = "certificate"
+          operator = "isInMoreThan"
+          target   = "30"
+        }
+      ]
+
+      options_list = {
+        tick_every         = 900
+        accept_self_signed = false
+      }
+    }
+  }
+}
+```
+
+### Multistep API Test
+
+```hcl
+module "synthetics_multistep" {
+  source = "github.com/zachreborn/terraform-modules//modules/datadog/synthetics/test"
+
+  tests = {
+    login_flow = {
+      name      = "Login API flow"
+      type      = "api"
+      subtype   = "multi"
+      status    = "live"
+      locations = ["aws:us-east-1"]
+      tags      = ["env:staging", "team:auth"]
+
+      options_list = {
+        tick_every = 3600
+      }
+
+      api_step = [
+        {
+          name    = "POST login"
+          subtype = "http"
+
+          request_definition = {
+            method = "POST"
+            url    = "https://api.example.org/login"
+          }
+
+          assertions = [
+            {
+              type     = "statusCode"
+              operator = "is"
+              target   = "200"
+            }
+          ]
+
+          extracted_values = [
+            {
+              name  = "AUTH_TOKEN"
+              type  = "http_body"
+              parser = {
+                type  = "json_path"
+                value = "$.token"
+              }
+            }
+          ]
+        },
+        {
+          name    = "GET profile"
+          subtype = "http"
+
+          request_definition = {
+            method = "GET"
+            url    = "https://api.example.org/profile"
+          }
+
+          request_headers = {
+            Authorization = "Bearer {{ AUTH_TOKEN }}"
+          }
+
+          assertions = [
+            {
+              type     = "statusCode"
+              operator = "is"
+              target   = "200"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Notes / Design Decisions
+
+- **`assertions` vs `assertion`**: The variable uses `assertions` (plural list) to hold multiple assertion objects per test. Each entry in the list is rendered as a separate `assertion {}` block in the resource. This avoids naming conflicts with Terraform HCL keywords.
+- **`api_step` list ordering**: The provider respects the order of `api_step` blocks. The list order in `api_step` determines step execution order. Use a list (not a map) to preserve ordering.
+- **`browser_step.params.step_variable`**: The provider uses a nested `variable {}` block inside `params`. To avoid conflicts with the Terraform `variable` keyword, this module's input attribute is named `step_variable`, which maps to the `variable {}` block in the resource.
+- **`browser_step.params.element_user_locator.locator_value`**: The provider uses a nested `value {}` block inside `element_user_locator` with `type` and `value` attributes. To avoid confusion with the `value` meta-attribute, this module's input attribute is named `locator_value`.
+- **Sensitive request credentials**: The `request_basicauth.password`, `request_basicauth.client_secret`, and `request_client_certificate` fields may contain secrets. These are stored in Terraform state. Enable state encryption when using credential-bearing tests.
+- **`monitor_id` output**: Each Synthetics test automatically creates a Datadog monitor. The `monitor_ids` output exposes these IDs so you can reference them (e.g., to create composite monitors).
+- **Global variable deprecation**: Direct use of `{{ GLOBAL_VAR }}` in test URLs is deprecated as of provider v3.1.0. Use `config_variable` blocks with `type = "global"` and reference the variable by its local name instead.
+- **`device_ids`**: Only applicable to browser tests. Valid values include `laptop_large`, `tablet`, `mobile_small`, `chrome.laptop_large`, `firefox.laptop_large`, etc.
+- **required_version >= 1.1.5**: The Datadog Terraform provider requires Terraform (or OpenTofu) >= 1.1.5. This module enforces that constraint via `required_version`.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 4.13.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [datadog_synthetics_test.this](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_tests"></a> [tests](#input\_tests) | Map of Synthetics test configurations keyed by logical name. May contain sensitive data (basic auth credentials, client certificates) — enable Terraform state encryption when using this module. | <pre>map(object({<br/>    name       = string<br/>    type       = string<br/>    subtype    = optional(string, null)<br/>    status     = optional(string, "live")<br/>    message    = optional(string, "")<br/>    locations  = list(string)<br/>    tags       = optional(list(string), [])<br/>    set_cookie = optional(string, null)<br/>    device_ids = optional(list(string), null)<br/><br/>    ###########################<br/>    # Request Configuration<br/>    ###########################<br/>    request_definition = optional(object({<br/>      method                  = optional(string, null)<br/>      url                     = optional(string, null)<br/>      host                    = optional(string, null)<br/>      port                    = optional(string, null)<br/>      body                    = optional(string, null)<br/>      body_type               = optional(string, null)<br/>      timeout                 = optional(number, null)<br/>      no_saving_response_body = optional(bool, null)<br/>      number_of_packets       = optional(number, null)<br/>      should_track_hops       = optional(bool, null)<br/>      persist_cookies         = optional(bool, null)<br/>      dns_server              = optional(string, null)<br/>      dns_server_port         = optional(number, null)<br/>      message                 = optional(string, null)<br/>      servername              = optional(string, null)<br/>      call_type               = optional(string, null)<br/>      service                 = optional(string, null)<br/>      plain_proto_file        = optional(string, null)<br/>      mcp_protocol_version    = optional(string, null)<br/>    }), null)<br/><br/>    request_headers  = optional(map(string), null)<br/>    request_query    = optional(map(string), null)<br/>    request_metadata = optional(map(string), null)<br/><br/>    request_basicauth = optional(object({<br/>      type                     = optional(string, null)<br/>      username                 = optional(string, null)<br/>      password                 = optional(string, null)<br/>      access_token_url         = optional(string, null)<br/>      token_api_authentication = optional(string, null)<br/>      client_id                = optional(string, null)<br/>      client_secret            = optional(string, null)<br/>      resource                 = optional(string, null)<br/>      scope                    = optional(string, null)<br/>      audience                 = optional(string, null)<br/>      workstation              = optional(string, null)<br/>      domain                   = optional(string, null)<br/>    }), null)<br/><br/>    request_client_certificate = optional(object({<br/>      cert = optional(object({<br/>        content  = string<br/>        filename = optional(string, null)<br/>      }), null)<br/>      key = optional(object({<br/>        content  = string<br/>        filename = optional(string, null)<br/>      }), null)<br/>    }), null)<br/><br/>    request_proxy = optional(object({<br/>      url     = string<br/>      headers = optional(map(string), null)<br/>    }), null)<br/><br/>    ###########################<br/>    # Assertions<br/>    ###########################<br/>    assertions = optional(list(object({<br/>      type     = string<br/>      operator = optional(string, null)<br/>      target   = optional(string, null)<br/>      property = optional(string, null)<br/>      target_mcp_capabilities = optional(object({<br/>        capabilities = list(string)<br/>      }), null)<br/>    })), [])<br/><br/>    ###########################<br/>    # Options<br/>    ###########################<br/>    options_list = optional(object({<br/>      tick_every                        = optional(number, null)<br/>      accept_self_signed                = optional(bool, null)<br/>      allow_insecure                    = optional(bool, null)<br/>      blocked_request_patterns          = optional(list(string), null)<br/>      check_certificate_revocation      = optional(bool, null)<br/>      disable_aia_intermediate_fetching = optional(bool, null)<br/>      disable_cors                      = optional(bool, null)<br/>      disable_csp                       = optional(bool, null)<br/>      follow_redirects                  = optional(bool, null)<br/>      http_version                      = optional(string, null)<br/>      ignore_server_certificate_error   = optional(bool, null)<br/>      initial_navigation_timeout        = optional(number, null)<br/>      min_failure_duration              = optional(number, null)<br/>      min_location_failed               = optional(number, null)<br/>      monitor_name                      = optional(string, null)<br/>      monitor_priority                  = optional(number, null)<br/>      no_screenshot                     = optional(bool, null)<br/>      restricted_roles                  = optional(list(string), null)<br/><br/>      retry = optional(object({<br/>        count    = optional(number, null)<br/>        interval = optional(number, null)<br/>      }), null)<br/><br/>      monitor_options = optional(object({<br/>        escalation_message       = optional(string, null)<br/>        notification_preset_name = optional(string, null)<br/>        renotify_interval        = optional(number, null)<br/>        renotify_occurrences     = optional(number, null)<br/>      }), null)<br/><br/>      scheduling = optional(object({<br/>        timezone = string<br/>        timeframes = list(object({<br/>          day  = number<br/>          from = string<br/>          to   = string<br/>        }))<br/>      }), null)<br/><br/>      rum_settings = optional(object({<br/>        is_enabled      = bool<br/>        application_id  = optional(string, null)<br/>        client_token_id = optional(number, null)<br/>      }), null)<br/><br/>      ci = optional(object({<br/>        execution_rule = string<br/>      }), null)<br/>    }), null)<br/><br/>    ###########################<br/>    # API Steps (subtype=multi)<br/>    ###########################<br/>    api_step = optional(list(object({<br/>      name              = string<br/>      subtype           = string<br/>      is_critical       = optional(bool, null)<br/>      allow_failure     = optional(bool, null)<br/>      exit_if_succeed   = optional(bool, null)<br/>      subtest_public_id = optional(string, null)<br/><br/>      request_definition = optional(object({<br/>        method                  = optional(string, null)<br/>        url                     = optional(string, null)<br/>        host                    = optional(string, null)<br/>        port                    = optional(string, null)<br/>        body                    = optional(string, null)<br/>        body_type               = optional(string, null)<br/>        timeout                 = optional(number, null)<br/>        call_type               = optional(string, null)<br/>        service                 = optional(string, null)<br/>        message                 = optional(string, null)<br/>        plain_proto_file        = optional(string, null)<br/>        mcp_protocol_version    = optional(string, null)<br/>        no_saving_response_body = optional(bool, null)<br/>      }), null)<br/><br/>      request_headers  = optional(map(string), null)<br/>      request_query    = optional(map(string), null)<br/>      request_metadata = optional(map(string), null)<br/><br/>      request_basicauth = optional(object({<br/>        type                     = optional(string, null)<br/>        username                 = optional(string, null)<br/>        password                 = optional(string, null)<br/>        access_token_url         = optional(string, null)<br/>        token_api_authentication = optional(string, null)<br/>        client_id                = optional(string, null)<br/>        client_secret            = optional(string, null)<br/>        resource                 = optional(string, null)<br/>        scope                    = optional(string, null)<br/>        audience                 = optional(string, null)<br/>        workstation              = optional(string, null)<br/>        domain                   = optional(string, null)<br/>      }), null)<br/><br/>      request_client_certificate = optional(object({<br/>        cert = optional(object({<br/>          content  = string<br/>          filename = optional(string, null)<br/>        }), null)<br/>        key = optional(object({<br/>          content  = string<br/>          filename = optional(string, null)<br/>        }), null)<br/>      }), null)<br/><br/>      request_proxy = optional(object({<br/>        url     = string<br/>        headers = optional(map(string), null)<br/>      }), null)<br/><br/>      assertions = optional(list(object({<br/>        type     = string<br/>        operator = optional(string, null)<br/>        target   = optional(string, null)<br/>        property = optional(string, null)<br/>        target_mcp_capabilities = optional(object({<br/>          capabilities = list(string)<br/>        }), null)<br/>      })), [])<br/><br/>      extracted_values = optional(list(object({<br/>        name   = string<br/>        type   = string<br/>        field  = optional(string, null)<br/>        secure = optional(bool, null)<br/>        parser = optional(object({<br/>          type  = string<br/>          value = optional(string, null)<br/>        }), null)<br/>      })), [])<br/>    })), [])<br/><br/>    ###########################<br/>    # Browser Steps (type=browser)<br/>    ###########################<br/>    browser_step = optional(list(object({<br/>      name                 = string<br/>      type                 = string<br/>      allow_failure        = optional(bool, null)<br/>      always_execute       = optional(bool, null)<br/>      exit_if_succeed      = optional(bool, null)<br/>      force_element_update = optional(bool, null)<br/>      is_critical          = optional(bool, null)<br/>      local_key            = optional(string, null)<br/>      no_screenshot        = optional(bool, null)<br/>      public_id            = optional(string, null)<br/>      timeout              = optional(number, null)<br/><br/>      params = object({<br/>        append_to_content     = optional(string, null)<br/>        attribute             = optional(string, null)<br/>        check                 = optional(string, null)<br/>        click_type            = optional(string, null)<br/>        click_with_javascript = optional(bool, null)<br/>        code                  = optional(string, null)<br/>        delay                 = optional(number, null)<br/>        element               = optional(string, null)<br/>        email                 = optional(string, null)<br/>        file                  = optional(string, null)<br/>        files                 = optional(string, null)<br/>        modifiers             = optional(list(string), null)<br/>        playing_tab_id        = optional(string, null)<br/>        request               = optional(string, null)<br/>        requests              = optional(string, null)<br/>        subtest_public_id     = optional(string, null)<br/>        value                 = optional(string, null)<br/>        with_click            = optional(bool, null)<br/>        x                     = optional(number, null)<br/>        y                     = optional(number, null)<br/><br/>        element_user_locator = optional(object({<br/>          fail_test_on_cannot_locate = optional(bool, null)<br/>          locator_value = object({<br/>            type  = string<br/>            value = string<br/>          })<br/>        }), null)<br/><br/>        pattern = optional(object({<br/>          type  = string<br/>          value = string<br/>        }), null)<br/><br/>        step_variable = optional(object({<br/>          name    = string<br/>          example = optional(string, null)<br/>          secure  = optional(bool, null)<br/>        }), null)<br/>      })<br/>    })), [])<br/><br/>    ###########################<br/>    # Browser Variables (type=browser)<br/>    ###########################<br/>    browser_variable = optional(list(object({<br/>      name    = string<br/>      type    = string<br/>      example = optional(string, null)<br/>      id      = optional(string, null)<br/>      pattern = optional(string, null)<br/>    })), [])<br/><br/>    ###########################<br/>    # Config Variables<br/>    ###########################<br/>    config_variable = optional(list(object({<br/>      name    = string<br/>      type    = string<br/>      id      = optional(string, null)<br/>      pattern = optional(string, null)<br/>      example = optional(string, null)<br/>    })), [])<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_ids"></a> [ids](#output\_ids) | Map of Synthetics test IDs keyed by logical name. |
+| <a name="output_monitor_ids"></a> [monitor\_ids](#output\_monitor\_ids) | Map of Datadog monitor IDs associated with each Synthetics test, keyed by logical name. |
+<!-- END_TF_DOCS -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Acknowledgments
+
+- [Zachary Hill](https://zacharyhill.co)
+- [Jake Jones](https://github.com/jakeasarus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/

--- a/modules/datadog/synthetics/test/README.md
+++ b/modules/datadog/synthetics/test/README.md
@@ -248,7 +248,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 - **`monitor_id` output**: Each Synthetics test automatically creates a Datadog monitor. The `monitor_ids` output exposes these IDs so you can reference them (e.g., to create composite monitors).
 - **Global variable deprecation**: Direct use of `{{ GLOBAL_VAR }}` in test URLs is deprecated as of provider v3.1.0. Use `config_variable` blocks with `type = "global"` and reference the variable by its local name instead.
 - **`device_ids`**: Only applicable to browser tests. Valid values include `laptop_large`, `tablet`, `mobile_small`, `chrome.laptop_large`, `firefox.laptop_large`, etc.
-- **required_version >= 1.0.0**: Follows the repo-wide convention. All modules require OpenTofu >= 1.6.0 or Terraform >= 1.0.0 — the `>= 1.0.0` constraint satisfies both, since OpenTofu 1.6.x >= 1.0.0.
+- **required_version >= 1.3.0**: The two-argument `optional(type, default)` syntax used in `variables.tf` requires Terraform >= 1.3.0 or OpenTofu >= 1.6.0 (since OpenTofu 1.6.x >= 1.3.0). This matches the version floor used by the other Datadog modules in this library (`rum`, `monitors`, `cloud_cost`).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -259,7 +259,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 4.0.0 |
 
 ## Providers

--- a/modules/datadog/synthetics/test/main.tf
+++ b/modules/datadog/synthetics/test/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.0.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/test/main.tf
+++ b/modules/datadog/synthetics/test/main.tf
@@ -1,0 +1,431 @@
+###########################
+# Provider Configuration
+###########################
+terraform {
+  required_version = ">= 1.1.5"
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+###########################
+# Locals
+###########################
+
+###########################
+# Module Configuration
+###########################
+resource "datadog_synthetics_test" "this" {
+  for_each = var.tests
+
+  name       = each.value.name
+  type       = each.value.type
+  subtype    = each.value.subtype
+  status     = each.value.status
+  message    = each.value.message
+  locations  = each.value.locations
+  tags       = each.value.tags
+  set_cookie = each.value.set_cookie
+  device_ids = each.value.device_ids
+
+  ###########################
+  # Request Definition
+  ###########################
+  dynamic "request_definition" {
+    for_each = each.value.request_definition != null ? [each.value.request_definition] : []
+    content {
+      method                  = request_definition.value.method
+      url                     = request_definition.value.url
+      host                    = request_definition.value.host
+      port                    = request_definition.value.port
+      body                    = request_definition.value.body
+      body_type               = request_definition.value.body_type
+      timeout                 = request_definition.value.timeout
+      no_saving_response_body = request_definition.value.no_saving_response_body
+      number_of_packets       = request_definition.value.number_of_packets
+      should_track_hops       = request_definition.value.should_track_hops
+      persist_cookies         = request_definition.value.persist_cookies
+      dns_server              = request_definition.value.dns_server
+      dns_server_port         = request_definition.value.dns_server_port
+      message                 = request_definition.value.message
+      servername              = request_definition.value.servername
+      call_type               = request_definition.value.call_type
+      service                 = request_definition.value.service
+      plain_proto_file        = request_definition.value.plain_proto_file
+      mcp_protocol_version    = request_definition.value.mcp_protocol_version
+    }
+  }
+
+  request_headers  = each.value.request_headers
+  request_query    = each.value.request_query
+  request_metadata = each.value.request_metadata
+
+  ###########################
+  # Request Auth
+  ###########################
+  dynamic "request_basicauth" {
+    for_each = each.value.request_basicauth != null ? [each.value.request_basicauth] : []
+    content {
+      type                     = request_basicauth.value.type
+      username                 = request_basicauth.value.username
+      password                 = request_basicauth.value.password
+      access_token_url         = request_basicauth.value.access_token_url
+      token_api_authentication = request_basicauth.value.token_api_authentication
+      client_id                = request_basicauth.value.client_id
+      client_secret            = request_basicauth.value.client_secret
+      resource                 = request_basicauth.value.resource
+      scope                    = request_basicauth.value.scope
+      audience                 = request_basicauth.value.audience
+      workstation              = request_basicauth.value.workstation
+      domain                   = request_basicauth.value.domain
+    }
+  }
+
+  dynamic "request_client_certificate" {
+    for_each = each.value.request_client_certificate != null ? [each.value.request_client_certificate] : []
+    content {
+      dynamic "cert" {
+        for_each = request_client_certificate.value.cert != null ? [request_client_certificate.value.cert] : []
+        content {
+          content  = cert.value.content
+          filename = cert.value.filename
+        }
+      }
+      dynamic "key" {
+        for_each = request_client_certificate.value.key != null ? [request_client_certificate.value.key] : []
+        content {
+          content  = key.value.content
+          filename = key.value.filename
+        }
+      }
+    }
+  }
+
+  dynamic "request_proxy" {
+    for_each = each.value.request_proxy != null ? [each.value.request_proxy] : []
+    content {
+      url     = request_proxy.value.url
+      headers = request_proxy.value.headers
+    }
+  }
+
+  ###########################
+  # Assertions
+  ###########################
+  dynamic "assertion" {
+    for_each = each.value.assertions
+    content {
+      type     = assertion.value.type
+      operator = assertion.value.operator
+      target   = assertion.value.target
+      property = assertion.value.property
+
+      dynamic "target_mcp_capabilities" {
+        for_each = assertion.value.target_mcp_capabilities != null ? [assertion.value.target_mcp_capabilities] : []
+        content {
+          capabilities = target_mcp_capabilities.value.capabilities
+        }
+      }
+    }
+  }
+
+  ###########################
+  # Options
+  ###########################
+  dynamic "options_list" {
+    for_each = each.value.options_list != null ? [each.value.options_list] : []
+    content {
+      tick_every                        = options_list.value.tick_every
+      accept_self_signed                = options_list.value.accept_self_signed
+      allow_insecure                    = options_list.value.allow_insecure
+      blocked_request_patterns          = options_list.value.blocked_request_patterns
+      check_certificate_revocation      = options_list.value.check_certificate_revocation
+      disable_aia_intermediate_fetching = options_list.value.disable_aia_intermediate_fetching
+      disable_cors                      = options_list.value.disable_cors
+      disable_csp                       = options_list.value.disable_csp
+      follow_redirects                  = options_list.value.follow_redirects
+      http_version                      = options_list.value.http_version
+      ignore_server_certificate_error   = options_list.value.ignore_server_certificate_error
+      initial_navigation_timeout        = options_list.value.initial_navigation_timeout
+      min_failure_duration              = options_list.value.min_failure_duration
+      min_location_failed               = options_list.value.min_location_failed
+      monitor_name                      = options_list.value.monitor_name
+      monitor_priority                  = options_list.value.monitor_priority
+      no_screenshot                     = options_list.value.no_screenshot
+      restricted_roles                  = options_list.value.restricted_roles
+
+      dynamic "retry" {
+        for_each = options_list.value.retry != null ? [options_list.value.retry] : []
+        content {
+          count    = retry.value.count
+          interval = retry.value.interval
+        }
+      }
+
+      dynamic "monitor_options" {
+        for_each = options_list.value.monitor_options != null ? [options_list.value.monitor_options] : []
+        content {
+          escalation_message       = monitor_options.value.escalation_message
+          notification_preset_name = monitor_options.value.notification_preset_name
+          renotify_interval        = monitor_options.value.renotify_interval
+          renotify_occurrences     = monitor_options.value.renotify_occurrences
+        }
+      }
+
+      dynamic "scheduling" {
+        for_each = options_list.value.scheduling != null ? [options_list.value.scheduling] : []
+        content {
+          timezone = scheduling.value.timezone
+          dynamic "timeframes" {
+            for_each = scheduling.value.timeframes
+            content {
+              day  = timeframes.value.day
+              from = timeframes.value.from
+              to   = timeframes.value.to
+            }
+          }
+        }
+      }
+
+      dynamic "rum_settings" {
+        for_each = options_list.value.rum_settings != null ? [options_list.value.rum_settings] : []
+        content {
+          is_enabled      = rum_settings.value.is_enabled
+          application_id  = rum_settings.value.application_id
+          client_token_id = rum_settings.value.client_token_id
+        }
+      }
+
+      dynamic "ci" {
+        for_each = options_list.value.ci != null ? [options_list.value.ci] : []
+        content {
+          execution_rule = ci.value.execution_rule
+        }
+      }
+    }
+  }
+
+  ###########################
+  # API Steps (subtype=multi)
+  ###########################
+  dynamic "api_step" {
+    for_each = each.value.api_step
+    content {
+      name              = api_step.value.name
+      subtype           = api_step.value.subtype
+      is_critical       = api_step.value.is_critical
+      allow_failure     = api_step.value.allow_failure
+      exit_if_succeed   = api_step.value.exit_if_succeed
+      subtest_public_id = api_step.value.subtest_public_id
+
+      dynamic "request_definition" {
+        for_each = api_step.value.request_definition != null ? [api_step.value.request_definition] : []
+        content {
+          method                  = request_definition.value.method
+          url                     = request_definition.value.url
+          host                    = request_definition.value.host
+          port                    = request_definition.value.port
+          body                    = request_definition.value.body
+          body_type               = request_definition.value.body_type
+          timeout                 = request_definition.value.timeout
+          call_type               = request_definition.value.call_type
+          service                 = request_definition.value.service
+          message                 = request_definition.value.message
+          plain_proto_file        = request_definition.value.plain_proto_file
+          mcp_protocol_version    = request_definition.value.mcp_protocol_version
+          no_saving_response_body = request_definition.value.no_saving_response_body
+        }
+      }
+
+      request_headers  = api_step.value.request_headers
+      request_query    = api_step.value.request_query
+      request_metadata = api_step.value.request_metadata
+
+      dynamic "request_basicauth" {
+        for_each = api_step.value.request_basicauth != null ? [api_step.value.request_basicauth] : []
+        content {
+          type                     = request_basicauth.value.type
+          username                 = request_basicauth.value.username
+          password                 = request_basicauth.value.password
+          access_token_url         = request_basicauth.value.access_token_url
+          token_api_authentication = request_basicauth.value.token_api_authentication
+          client_id                = request_basicauth.value.client_id
+          client_secret            = request_basicauth.value.client_secret
+          resource                 = request_basicauth.value.resource
+          scope                    = request_basicauth.value.scope
+          audience                 = request_basicauth.value.audience
+          workstation              = request_basicauth.value.workstation
+          domain                   = request_basicauth.value.domain
+        }
+      }
+
+      dynamic "request_client_certificate" {
+        for_each = api_step.value.request_client_certificate != null ? [api_step.value.request_client_certificate] : []
+        content {
+          dynamic "cert" {
+            for_each = request_client_certificate.value.cert != null ? [request_client_certificate.value.cert] : []
+            content {
+              content  = cert.value.content
+              filename = cert.value.filename
+            }
+          }
+          dynamic "key" {
+            for_each = request_client_certificate.value.key != null ? [request_client_certificate.value.key] : []
+            content {
+              content  = key.value.content
+              filename = key.value.filename
+            }
+          }
+        }
+      }
+
+      dynamic "request_proxy" {
+        for_each = api_step.value.request_proxy != null ? [api_step.value.request_proxy] : []
+        content {
+          url     = request_proxy.value.url
+          headers = request_proxy.value.headers
+        }
+      }
+
+      dynamic "assertion" {
+        for_each = api_step.value.assertions
+        content {
+          type     = assertion.value.type
+          operator = assertion.value.operator
+          target   = assertion.value.target
+          property = assertion.value.property
+
+          dynamic "target_mcp_capabilities" {
+            for_each = assertion.value.target_mcp_capabilities != null ? [assertion.value.target_mcp_capabilities] : []
+            content {
+              capabilities = target_mcp_capabilities.value.capabilities
+            }
+          }
+        }
+      }
+
+      dynamic "extracted_value" {
+        for_each = api_step.value.extracted_values
+        content {
+          name   = extracted_value.value.name
+          type   = extracted_value.value.type
+          field  = extracted_value.value.field
+          secure = extracted_value.value.secure
+
+          dynamic "parser" {
+            for_each = extracted_value.value.parser != null ? [extracted_value.value.parser] : []
+            content {
+              type  = parser.value.type
+              value = parser.value.value
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ###########################
+  # Browser Steps (type=browser)
+  ###########################
+  dynamic "browser_step" {
+    for_each = each.value.browser_step
+    content {
+      name                 = browser_step.value.name
+      type                 = browser_step.value.type
+      allow_failure        = browser_step.value.allow_failure
+      always_execute       = browser_step.value.always_execute
+      exit_if_succeed      = browser_step.value.exit_if_succeed
+      force_element_update = browser_step.value.force_element_update
+      is_critical          = browser_step.value.is_critical
+      local_key            = browser_step.value.local_key
+      no_screenshot        = browser_step.value.no_screenshot
+      public_id            = browser_step.value.public_id
+      timeout              = browser_step.value.timeout
+
+      params {
+        append_to_content     = browser_step.value.params.append_to_content
+        attribute             = browser_step.value.params.attribute
+        check                 = browser_step.value.params.check
+        click_type            = browser_step.value.params.click_type
+        click_with_javascript = browser_step.value.params.click_with_javascript
+        code                  = browser_step.value.params.code
+        delay                 = browser_step.value.params.delay
+        element               = browser_step.value.params.element
+        email                 = browser_step.value.params.email
+        file                  = browser_step.value.params.file
+        files                 = browser_step.value.params.files
+        modifiers             = browser_step.value.params.modifiers
+        playing_tab_id        = browser_step.value.params.playing_tab_id
+        request               = browser_step.value.params.request
+        requests              = browser_step.value.params.requests
+        subtest_public_id     = browser_step.value.params.subtest_public_id
+        value                 = browser_step.value.params.value
+        with_click            = browser_step.value.params.with_click
+        x                     = browser_step.value.params.x
+        y                     = browser_step.value.params.y
+
+        dynamic "element_user_locator" {
+          for_each = browser_step.value.params.element_user_locator != null ? [browser_step.value.params.element_user_locator] : []
+          iterator = eul
+          content {
+            fail_test_on_cannot_locate = eul.value.fail_test_on_cannot_locate
+            value {
+              type  = eul.value.locator_value.type
+              value = eul.value.locator_value.value
+            }
+          }
+        }
+
+        dynamic "pattern" {
+          for_each = browser_step.value.params.pattern != null ? [browser_step.value.params.pattern] : []
+          iterator = ptn
+          content {
+            type  = ptn.value.type
+            value = ptn.value.value
+          }
+        }
+
+        dynamic "variable" {
+          for_each = browser_step.value.params.step_variable != null ? [browser_step.value.params.step_variable] : []
+          iterator = step_var
+          content {
+            name    = step_var.value.name
+            example = step_var.value.example
+            secure  = step_var.value.secure
+          }
+        }
+      }
+    }
+  }
+
+  ###########################
+  # Browser Variables (type=browser)
+  ###########################
+  dynamic "browser_variable" {
+    for_each = each.value.browser_variable
+    content {
+      name    = browser_variable.value.name
+      type    = browser_variable.value.type
+      example = browser_variable.value.example
+      id      = browser_variable.value.id
+      pattern = browser_variable.value.pattern
+    }
+  }
+
+  ###########################
+  # Config Variables
+  ###########################
+  dynamic "config_variable" {
+    for_each = each.value.config_variable
+    content {
+      name    = config_variable.value.name
+      type    = config_variable.value.type
+      id      = config_variable.value.id
+      pattern = config_variable.value.pattern
+      example = config_variable.value.example
+    }
+  }
+}

--- a/modules/datadog/synthetics/test/main.tf
+++ b/modules/datadog/synthetics/test/main.tf
@@ -2,7 +2,7 @@
 # Provider Configuration
 ###########################
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
   required_providers {
     datadog = {
       source  = "DataDog/datadog"

--- a/modules/datadog/synthetics/test/outputs.tf
+++ b/modules/datadog/synthetics/test/outputs.tf
@@ -1,0 +1,12 @@
+###########################
+# Resource Outputs
+###########################
+output "ids" {
+  description = "Map of Synthetics test IDs keyed by logical name."
+  value       = { for k, v in datadog_synthetics_test.this : k => v.id }
+}
+
+output "monitor_ids" {
+  description = "Map of Datadog monitor IDs associated with each Synthetics test, keyed by logical name."
+  value       = { for k, v in datadog_synthetics_test.this : k => v.monitor_id }
+}

--- a/modules/datadog/synthetics/test/variables.tf
+++ b/modules/datadog/synthetics/test/variables.tf
@@ -1,0 +1,333 @@
+###########################
+# Resource Variables
+###########################
+variable "tests" {
+  description = "Map of Synthetics test configurations keyed by logical name. May contain sensitive data (basic auth credentials, client certificates) — enable Terraform state encryption when using this module."
+  type = map(object({
+    name       = string
+    type       = string
+    subtype    = optional(string, null)
+    status     = optional(string, "live")
+    message    = optional(string, "")
+    locations  = list(string)
+    tags       = optional(list(string), [])
+    set_cookie = optional(string, null)
+    device_ids = optional(list(string), null)
+
+    ###########################
+    # Request Configuration
+    ###########################
+    request_definition = optional(object({
+      method                  = optional(string, null)
+      url                     = optional(string, null)
+      host                    = optional(string, null)
+      port                    = optional(string, null)
+      body                    = optional(string, null)
+      body_type               = optional(string, null)
+      timeout                 = optional(number, null)
+      no_saving_response_body = optional(bool, null)
+      number_of_packets       = optional(number, null)
+      should_track_hops       = optional(bool, null)
+      persist_cookies         = optional(bool, null)
+      dns_server              = optional(string, null)
+      dns_server_port         = optional(number, null)
+      message                 = optional(string, null)
+      servername              = optional(string, null)
+      call_type               = optional(string, null)
+      service                 = optional(string, null)
+      plain_proto_file        = optional(string, null)
+      mcp_protocol_version    = optional(string, null)
+    }), null)
+
+    request_headers  = optional(map(string), null)
+    request_query    = optional(map(string), null)
+    request_metadata = optional(map(string), null)
+
+    request_basicauth = optional(object({
+      type                     = optional(string, null)
+      username                 = optional(string, null)
+      password                 = optional(string, null)
+      access_token_url         = optional(string, null)
+      token_api_authentication = optional(string, null)
+      client_id                = optional(string, null)
+      client_secret            = optional(string, null)
+      resource                 = optional(string, null)
+      scope                    = optional(string, null)
+      audience                 = optional(string, null)
+      workstation              = optional(string, null)
+      domain                   = optional(string, null)
+    }), null)
+
+    request_client_certificate = optional(object({
+      cert = optional(object({
+        content  = string
+        filename = optional(string, null)
+      }), null)
+      key = optional(object({
+        content  = string
+        filename = optional(string, null)
+      }), null)
+    }), null)
+
+    request_proxy = optional(object({
+      url     = string
+      headers = optional(map(string), null)
+    }), null)
+
+    ###########################
+    # Assertions
+    ###########################
+    assertions = optional(list(object({
+      type     = string
+      operator = optional(string, null)
+      target   = optional(string, null)
+      property = optional(string, null)
+      target_mcp_capabilities = optional(object({
+        capabilities = list(string)
+      }), null)
+    })), [])
+
+    ###########################
+    # Options
+    ###########################
+    options_list = optional(object({
+      tick_every                        = optional(number, null)
+      accept_self_signed                = optional(bool, null)
+      allow_insecure                    = optional(bool, null)
+      blocked_request_patterns          = optional(list(string), null)
+      check_certificate_revocation      = optional(bool, null)
+      disable_aia_intermediate_fetching = optional(bool, null)
+      disable_cors                      = optional(bool, null)
+      disable_csp                       = optional(bool, null)
+      follow_redirects                  = optional(bool, null)
+      http_version                      = optional(string, null)
+      ignore_server_certificate_error   = optional(bool, null)
+      initial_navigation_timeout        = optional(number, null)
+      min_failure_duration              = optional(number, null)
+      min_location_failed               = optional(number, null)
+      monitor_name                      = optional(string, null)
+      monitor_priority                  = optional(number, null)
+      no_screenshot                     = optional(bool, null)
+      restricted_roles                  = optional(list(string), null)
+
+      retry = optional(object({
+        count    = optional(number, null)
+        interval = optional(number, null)
+      }), null)
+
+      monitor_options = optional(object({
+        escalation_message       = optional(string, null)
+        notification_preset_name = optional(string, null)
+        renotify_interval        = optional(number, null)
+        renotify_occurrences     = optional(number, null)
+      }), null)
+
+      scheduling = optional(object({
+        timezone = string
+        timeframes = list(object({
+          day  = number
+          from = string
+          to   = string
+        }))
+      }), null)
+
+      rum_settings = optional(object({
+        is_enabled      = bool
+        application_id  = optional(string, null)
+        client_token_id = optional(number, null)
+      }), null)
+
+      ci = optional(object({
+        execution_rule = string
+      }), null)
+    }), null)
+
+    ###########################
+    # API Steps (subtype=multi)
+    ###########################
+    api_step = optional(list(object({
+      name              = string
+      subtype           = string
+      is_critical       = optional(bool, null)
+      allow_failure     = optional(bool, null)
+      exit_if_succeed   = optional(bool, null)
+      subtest_public_id = optional(string, null)
+
+      request_definition = optional(object({
+        method                  = optional(string, null)
+        url                     = optional(string, null)
+        host                    = optional(string, null)
+        port                    = optional(string, null)
+        body                    = optional(string, null)
+        body_type               = optional(string, null)
+        timeout                 = optional(number, null)
+        call_type               = optional(string, null)
+        service                 = optional(string, null)
+        message                 = optional(string, null)
+        plain_proto_file        = optional(string, null)
+        mcp_protocol_version    = optional(string, null)
+        no_saving_response_body = optional(bool, null)
+      }), null)
+
+      request_headers  = optional(map(string), null)
+      request_query    = optional(map(string), null)
+      request_metadata = optional(map(string), null)
+
+      request_basicauth = optional(object({
+        type                     = optional(string, null)
+        username                 = optional(string, null)
+        password                 = optional(string, null)
+        access_token_url         = optional(string, null)
+        token_api_authentication = optional(string, null)
+        client_id                = optional(string, null)
+        client_secret            = optional(string, null)
+        resource                 = optional(string, null)
+        scope                    = optional(string, null)
+        audience                 = optional(string, null)
+        workstation              = optional(string, null)
+        domain                   = optional(string, null)
+      }), null)
+
+      request_client_certificate = optional(object({
+        cert = optional(object({
+          content  = string
+          filename = optional(string, null)
+        }), null)
+        key = optional(object({
+          content  = string
+          filename = optional(string, null)
+        }), null)
+      }), null)
+
+      request_proxy = optional(object({
+        url     = string
+        headers = optional(map(string), null)
+      }), null)
+
+      assertions = optional(list(object({
+        type     = string
+        operator = optional(string, null)
+        target   = optional(string, null)
+        property = optional(string, null)
+        target_mcp_capabilities = optional(object({
+          capabilities = list(string)
+        }), null)
+      })), [])
+
+      extracted_values = optional(list(object({
+        name   = string
+        type   = string
+        field  = optional(string, null)
+        secure = optional(bool, null)
+        parser = optional(object({
+          type  = string
+          value = optional(string, null)
+        }), null)
+      })), [])
+    })), [])
+
+    ###########################
+    # Browser Steps (type=browser)
+    ###########################
+    browser_step = optional(list(object({
+      name                 = string
+      type                 = string
+      allow_failure        = optional(bool, null)
+      always_execute       = optional(bool, null)
+      exit_if_succeed      = optional(bool, null)
+      force_element_update = optional(bool, null)
+      is_critical          = optional(bool, null)
+      local_key            = optional(string, null)
+      no_screenshot        = optional(bool, null)
+      public_id            = optional(string, null)
+      timeout              = optional(number, null)
+
+      params = object({
+        append_to_content     = optional(string, null)
+        attribute             = optional(string, null)
+        check                 = optional(string, null)
+        click_type            = optional(string, null)
+        click_with_javascript = optional(bool, null)
+        code                  = optional(string, null)
+        delay                 = optional(number, null)
+        element               = optional(string, null)
+        email                 = optional(string, null)
+        file                  = optional(string, null)
+        files                 = optional(string, null)
+        modifiers             = optional(list(string), null)
+        playing_tab_id        = optional(string, null)
+        request               = optional(string, null)
+        requests              = optional(string, null)
+        subtest_public_id     = optional(string, null)
+        value                 = optional(string, null)
+        with_click            = optional(bool, null)
+        x                     = optional(number, null)
+        y                     = optional(number, null)
+
+        element_user_locator = optional(object({
+          fail_test_on_cannot_locate = optional(bool, null)
+          locator_value = object({
+            type  = string
+            value = string
+          })
+        }), null)
+
+        pattern = optional(object({
+          type  = string
+          value = string
+        }), null)
+
+        step_variable = optional(object({
+          name    = string
+          example = optional(string, null)
+          secure  = optional(bool, null)
+        }), null)
+      })
+    })), [])
+
+    ###########################
+    # Browser Variables (type=browser)
+    ###########################
+    browser_variable = optional(list(object({
+      name    = string
+      type    = string
+      example = optional(string, null)
+      id      = optional(string, null)
+      pattern = optional(string, null)
+    })), [])
+
+    ###########################
+    # Config Variables
+    ###########################
+    config_variable = optional(list(object({
+      name    = string
+      type    = string
+      id      = optional(string, null)
+      pattern = optional(string, null)
+      example = optional(string, null)
+    })), [])
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.tests : contains(["api", "browser"], v.type)
+    ])
+    error_message = "type must be one of: api, browser."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.tests :
+      v.subtype == null || contains(["http", "ssl", "tcp", "dns", "icmp", "udp", "websocket", "grpc", "multi"], v.subtype)
+    ])
+    error_message = "subtype must be one of: http, ssl, tcp, dns, icmp, udp, websocket, grpc, multi."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.tests : contains(["live", "paused"], v.status)
+    ])
+    error_message = "status must be one of: live, paused."
+  }
+}


### PR DESCRIPTION
## Summary

Adds 4 new modules under \`modules/datadog/synthetics/\` as part of the Datadog module library series.

### Modules Added

| Module | Resource | Description |
|---|---|---|
| \`synthetics/test\` | \`datadog_synthetics_test\` | Full API, browser, and multistep Synthetics test support |
| \`synthetics/global_variable\` | \`datadog_synthetics_global_variable\` | Global variables with TOTP, FIDO2, and parse_test_options |
| \`synthetics/private_location\` | \`datadog_synthetics_private_location\` | Private locations with sensitive config output |
| \`synthetics/concurrency_cap\` | \`datadog_synthetics_concurrency_cap\` | Org-wide singleton concurrency cap |

### Validation

All 4 modules validated with provider v4.13.0:
- \`tofu fmt -check -recursive\` ✓
- \`tofu init -backend=false\` ✓
- \`tofu validate\` ✓
- \`terraform-docs\` ✓

### Design Notes

- All modules follow the map/for_each scalability pattern (except \`concurrency_cap\` which is an org-wide singleton)
- \`synthetics/test\` covers all test types (api/browser/multi) via dynamic blocks for all nested schema blocks (request_definition, assertions, options_list, api_step, browser_step, config_variable, browser_variable)
- \`synthetics/private_location\` marks the \`configs\` output sensitive (contains installation credentials)
- Provider \`required_version >= 1.1.5\` enforced per Datadog provider requirements
- Schema verified against datadog/datadog v4.13.0

---
Generated by Oz agent: https://oz.warp.dev/runs/019f01a8-1a10-7133-b31f-8ace751f20e5
Conversation: https://app.warp.dev/conversation/4eeff57a-da42-4122-849f-decfa8337a20

Co-Authored-By: Oz <oz-agent@warp.dev>