### PR TITLE
chore: trigger release-please for v8.22.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Manual trigger — re-run when release-please fails to parse a commit
+  # (e.g. due to nested parentheses in a squash-merge commit body).
+  workflow_dispatch: {}
 
 # Least-privilege default; the job below elevates only what release-please
 # needs to open the Release PR and cut the tag/release.


### PR DESCRIPTION
## Summary

Two changes to fix the release-please parser failure from PR #341 and prevent it happening again.

### Commit 1 — release trigger (\`chore: trigger release-please for v8.22.0\`)

Empty commit with a \`Release-As: 8.22.0\` footer. When merged, release-please will open a Release PR targeting v8.22.0 (the correct MINOR bump from the \`feat(datadog):\` commit in #341) and the normal Release PR → maintainer merge → tag flow proceeds.

**Root cause of the failure:** The squash-merge of PR #341 wrote the PR description into the commit body. That description contained \`yamldecode(file(...))\` inside a markdown table. The Conventional Commits parser hit the nested \`(\` at line 12, column 18 of the commit body, logged \`unexpected token '(' at 12:18, valid tokens [)]\`, skipped the commit entirely, and found zero user-facing commits — so no Release PR was created.

### Commit 2 — structural fix (\`ci: add workflow_dispatch trigger to release-please workflow\`)

Adds a \`workflow_dispatch\` trigger to \`.github/workflows/release-please.yml\` so the workflow can be manually re-run from the Actions UI without needing a fix PR.

Note: the squash merge commit body setting has already been changed from \`PR_BODY\` → \`BLANK\` (via the GitHub API, effective immediately). Future squash merges will use the PR title as the subject and an empty body, making this class of parse failure structurally impossible. The \`workflow_dispatch\` is a belt-and-suspenders fallback.

### Version

\`8.21.0\` → \`8.22.0\` (MINOR — #341 added new Datadog Cloud Cost modules)

---

Co-Authored-By: Oz <oz-agent@warp.dev>