### PR TITLE
feat(security-hub): support AWS Security Hub 2026 changes (CSPM + unified v2)

### DIFF
--- a/modules/aws/organizations/organization/README.md
+++ b/modules/aws/organizations/organization/README.md
@@ -110,6 +110,22 @@ To opt out entirely (no new resources, clean plan), set
 set `attach_identity_center_scp = false`. To attach the SCP to specific OUs or
 accounts instead of the organization root, set `identity_center_scp_target_ids`.
 
+### Centralized Security Services
+
+The default `aws_service_access_principals` enables AWS Organizations trusted
+access for the centralized security services this module library integrates
+with: Security Hub (both Security Hub CSPM and the unified Security Hub),
+GuardDuty, Config, IAM Access Analyzer, and Inspector. Keeping these in the
+organization module makes it the single source of truth for trusted access, so
+the delegated-administrator modules (`security_hub/organization`,
+`guardduty/organization`, `config/organization`, etc.) do not enable a principal
+out-of-band and cause perpetual drift on the next apply of this module.
+
+**Caveat:** once a service has a registered delegated administrator, AWS will not
+let you remove its principal from this list until the delegated administrator is
+deregistered. Remove the delegated-administrator resource first, then drop the
+principal.
+
 _For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -120,20 +136,20 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.78.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.78.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_centralized_backup"></a> [centralized\_backup](#module\_centralized\_backup) | ../policy | n/a |
 | <a name="module_centralized_root"></a> [centralized\_root](#module\_centralized\_root) | ../../iam/organizations_features | n/a |
 | <a name="module_identity_center_scp"></a> [identity\_center\_scp](#module\_identity\_center\_scp) | ../policy | n/a |
@@ -141,16 +157,16 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_organization) | resource |
 | [aws_organizations_policy_attachment.identity_center_scp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_attach_identity_center_scp"></a> [attach\_identity\_center\_scp](#input\_attach\_identity\_center\_scp) | (Optional) If true, attaches the Identity Center deny SCP to the targets in identity\_center\_scp\_target\_ids (defaulting to the organization root). When false, the policy is created but not attached. Defaults to true. | `bool` | `true` | no |
-| <a name="input_aws_service_access_principals"></a> [aws\_service\_access\_principals](#input\_aws\_service\_access\_principals) | (Optional) List of AWS service principal names for which you want to enable integration with your organization. This is typically in the form of a URL, such as service-abbreviation.amazonaws.com. Organization must have feature\_set set to ALL. For additional information, see the AWS Organizations User Guide. | `list(string)` | <pre>[<br/>  "account.amazonaws.com",<br/>  "aws-artifact-account-sync.amazonaws.com",<br/>  "backup.amazonaws.com",<br/>  "cloudtrail.amazonaws.com",<br/>  "health.amazonaws.com",<br/>  "sso.amazonaws.com"<br/>]</pre> | no |
+| <a name="input_aws_service_access_principals"></a> [aws\_service\_access\_principals](#input\_aws\_service\_access\_principals) | (Optional) List of AWS service principal names for which you want to enable trusted access (integration) with your organization. This is typically in the form of a URL, such as service-abbreviation.amazonaws.com. Organization must have feature\_set set to ALL. The default list enables the centralized security services this module library integrates with (Security Hub, GuardDuty, Config, IAM Access Analyzer, and Inspector) so that their delegated-administrator modules do not create trusted-access drift. Note: once a service has a registered delegated administrator, removing its principal from this list will fail until the delegated administrator is deregistered. For additional information, see the AWS Organizations User Guide. | `list(string)` | <pre>[<br/>  "access-analyzer.amazonaws.com",<br/>  "account.amazonaws.com",<br/>  "aws-artifact-account-sync.amazonaws.com",<br/>  "backup.amazonaws.com",<br/>  "cloudtrail.amazonaws.com",<br/>  "config.amazonaws.com",<br/>  "guardduty.amazonaws.com",<br/>  "health.amazonaws.com",<br/>  "inspector2.amazonaws.com",<br/>  "securityhub.amazonaws.com",<br/>  "sso.amazonaws.com"<br/>]</pre> | no |
 | <a name="input_enable_identity_center_scp"></a> [enable\_identity\_center\_scp](#input\_enable\_identity\_center\_scp) | (Optional) If true, creates a Service Control Policy (SCP) which denies sso:CreateInstance organization-wide so member accounts cannot create account-level IAM Identity Center instances. Defaults to true. Requires SERVICE\_CONTROL\_POLICY in enabled\_policy\_types. | `bool` | `true` | no |
 | <a name="input_enable_organization_backup"></a> [enable\_organization\_backup](#input\_enable\_organization\_backup) | (Optional) If true, enables the organization backup policy. Defaults to false. | `bool` | `false` | no |
 | <a name="input_enabled_features"></a> [enabled\_features](#input\_enabled\_features) | A list of IAM organization features which will be enabled. Valid values are RootCredentialsManagement and RootSessions. | `list(string)` | <pre>[<br/>  "RootCredentialsManagement",<br/>  "RootSessions"<br/>]</pre> | no |
@@ -164,7 +180,7 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_accounts"></a> [accounts](#output\_accounts) | List of organization accounts.All elements have these attributes: arn, email, id, name, status. |
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the organization |
 | <a name="output_id"></a> [id](#output\_id) | ID of the organization |

--- a/modules/aws/organizations/organization/variables.tf
+++ b/modules/aws/organizations/organization/variables.tf
@@ -3,14 +3,19 @@
 ############################################################
 
 variable "aws_service_access_principals" {
-  description = "(Optional) List of AWS service principal names for which you want to enable integration with your organization. This is typically in the form of a URL, such as service-abbreviation.amazonaws.com. Organization must have feature_set set to ALL. For additional information, see the AWS Organizations User Guide."
+  description = "(Optional) List of AWS service principal names for which you want to enable trusted access (integration) with your organization. This is typically in the form of a URL, such as service-abbreviation.amazonaws.com. Organization must have feature_set set to ALL. The default list enables the centralized security services this module library integrates with (Security Hub, GuardDuty, Config, IAM Access Analyzer, and Inspector) so that their delegated-administrator modules do not create trusted-access drift. Note: once a service has a registered delegated administrator, removing its principal from this list will fail until the delegated administrator is deregistered. For additional information, see the AWS Organizations User Guide."
   type        = list(string)
   default = [
+    "access-analyzer.amazonaws.com",
     "account.amazonaws.com",
     "aws-artifact-account-sync.amazonaws.com",
     "backup.amazonaws.com",
     "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+    "guardduty.amazonaws.com",
     "health.amazonaws.com",
+    "inspector2.amazonaws.com",
+    "securityhub.amazonaws.com",
     "sso.amazonaws.com",
   ]
 }

--- a/modules/aws/security_hub/organization/README.md
+++ b/modules/aws/security_hub/organization/README.md
@@ -26,9 +26,9 @@
     <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
   </a>
 
-<h3 align="center">Security Hub Organization</h3>
+<h3 align="center">Security Hub CSPM Organization</h3>
   <p align="center">
-    This module creates the resources required for Security Hub usage in an Organization and delegation to the account chosen.
+    This module enables and delegates AWS Security Hub CSPM (Cloud Security Posture Management) across an AWS Organization.
     <br />
     <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
     <br />
@@ -60,11 +60,26 @@
 
 <!-- USAGE EXAMPLES -->
 
+## About: Security Hub CSPM vs. the unified AWS Security Hub
+
+In 2026 AWS renamed the classic Security Hub service to **Security Hub CSPM**
+(Cloud Security Posture Management) and reassigned the name **AWS Security Hub**
+to a new unified service (OCSF schema, cross-service correlation, risk
+analytics). The two services coexist and CSPM is **not** deprecated.
+
+- **This module** manages Security Hub CSPM: the delegated administrator, the
+  account-level enablement, cross-Region finding aggregation, and (optionally)
+  central configuration policies.
+- The new unified service ("V2") is managed by the sibling module at
+  [`../v2`](../v2). Delegating CSPM to a non-management account (as this module
+  does) automatically designates that account as the unified Security Hub
+  delegated administrator too, so apply this module first.
+
 ## Usage
 
 ### Simple Example
 
-This example enables security hub, delegates an admin account from the organization management, and enables fll region aggregation of information.
+This example enables Security Hub CSPM, delegates an admin account from the organization management account, and enables all-region aggregation of findings.
 
 ```
 module "security_hub" {
@@ -94,6 +109,40 @@ module "security_hub" {
 }
 ```
 
+### Central Configuration
+
+This example uses CENTRAL configuration and a configuration policy applied to the
+organization root. With CENTRAL configuration, `auto_enable` and
+`auto_enable_standards` are forced to `false`/`NONE` (the module handles this
+automatically) because enablement is governed by the policy instead.
+
+```
+module "security_hub" {
+  source    = "github.com/zachreborn/terraform-modules//modules/aws/security_hub/organization"
+  providers = {
+    aws.organization_management_account = aws.organization_management_account
+    aws.organization_security_account   = aws.organization_security_account
+  }
+  admin_account_id   = module.account_security.id
+  configuration_type = "CENTRAL"
+
+  configuration_policies = {
+    "org-baseline" = {
+      description           = "Baseline Security Hub CSPM policy for the whole organization."
+      service_enabled       = true
+      enabled_standard_arns = [
+        "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
+        "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0",
+      ]
+      # Provide either disabled_control_identifiers or enabled_control_identifiers.
+      disabled_control_identifiers = []
+      # Associate the policy with the organization root (or specific OU/account IDs).
+      target_ids = [module.organization.roots[0].id]
+    }
+  }
+}
+```
+
 _For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -104,16 +153,16 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws.organization_management_account"></a> [aws.organization\_management\_account](#provider\_aws.organization\_management\_account) | >= 4.0.0 |
-| <a name="provider_aws.organization_security_account"></a> [aws.organization\_security\_account](#provider\_aws.organization\_security\_account) | >= 4.0.0 |
+| ---- | ------- |
+| <a name="provider_aws.organization_management_account"></a> [aws.organization\_management\_account](#provider\_aws.organization\_management\_account) | 6.53.0 |
+| <a name="provider_aws.organization_security_account"></a> [aws.organization\_security\_account](#provider\_aws.organization\_security\_account) | 6.53.0 |
 
 ## Modules
 
@@ -122,8 +171,10 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_securityhub_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
+| [aws_securityhub_configuration_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_configuration_policy) | resource |
+| [aws_securityhub_configuration_policy_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_configuration_policy_association) | resource |
 | [aws_securityhub_finding_aggregator.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_finding_aggregator) | resource |
 | [aws_securityhub_organization_admin_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_admin_account) | resource |
 | [aws_securityhub_organization_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_configuration) | resource |
@@ -131,17 +182,25 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_admin_account_id"></a> [admin\_account\_id](#input\_admin\_account\_id) | (Required) The 12-digit identifier of the AWS account designated as the Security Hub administrator account. | `string` | n/a | yes |
-| <a name="input_auto_enable"></a> [auto\_enable](#input\_auto\_enable) | (Required) Whether to automatically enable Security Hub for new accounts in the organization. Defaults to true. | `bool` | `true` | no |
-| <a name="input_auto_enable_standards"></a> [auto\_enable\_standards](#input\_auto\_enable\_standards) | (Optional) Whether to automatically enable Security Hub default standards for new member accounts in the organization. By default, this parameter is equal to DEFAULT, and new member accounts are automatically enabled with default Security Hub standards. To opt out of enabling default standards for new member accounts, set this parameter equal to NONE. | `string` | `"DEFAULT"` | no |
-| <a name="input_enable_default_standards"></a> [enable\_default\_standards](#input\_enable\_default\_standards) | (Optional) Whether to enable the security standards that Security Hub has designated as automatically enabled including: AWS Foundational Security Best Practices v1.0.0 and CIS AWS Foundations Benchmark v1.2.0. Defaults to true. | `bool` | `true` | no |
-| <a name="input_linking_mode"></a> [linking\_mode](#input\_linking\_mode) | (Optional) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are ALL\_REGIONS, ALL\_REGIONS\_EXCEPT\_SPECIFIED or SPECIFIED\_REGIONS. When ALL\_REGIONS or ALL\_REGIONS\_EXCEPT\_SPECIFIED are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them. | `string` | `"ALL_REGIONS"` | no |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_admin_account_id"></a> [admin\_account\_id](#input\_admin\_account\_id) | (Required) The 12-digit identifier of the AWS account designated as the Security Hub CSPM delegated administrator account. Per AWS, delegating CSPM to a non-management account also designates it as the delegated administrator for the unified AWS Security Hub. | `string` | n/a | yes |
+| <a name="input_auto_enable"></a> [auto\_enable](#input\_auto\_enable) | (Optional) Whether to automatically enable Security Hub CSPM for new accounts in the organization. Only applies to LOCAL configuration; when configuration\_type is CENTRAL this is forced to false. Defaults to true. | `bool` | `true` | no |
+| <a name="input_auto_enable_standards"></a> [auto\_enable\_standards](#input\_auto\_enable\_standards) | (Optional) Whether to automatically enable Security Hub CSPM default standards for new member accounts in the organization. Valid values are DEFAULT and NONE. Only applies to LOCAL configuration; when configuration\_type is CENTRAL this is forced to NONE. Defaults to DEFAULT. | `string` | `"DEFAULT"` | no |
+| <a name="input_configuration_policies"></a> [configuration\_policies](#input\_configuration\_policies) | (Optional) Map of Security Hub CSPM central configuration policies keyed by policy name. Only used when configuration\_type is CENTRAL. Per policy: service\_enabled toggles Security Hub CSPM on/off for associated targets; enabled\_standard\_arns lists the standard ARNs to enable; provide either enabled\_control\_identifiers or disabled\_control\_identifiers (mutually exclusive - a non-empty enabled\_control\_identifiers takes precedence); target\_ids is the list of organization root, OU, or account IDs to associate with the policy. Defaults to an empty map (no policies). | <pre>map(object({<br/>    description                  = optional(string)<br/>    service_enabled              = optional(bool, true)<br/>    enabled_standard_arns        = optional(list(string), [])<br/>    enabled_control_identifiers  = optional(list(string), [])<br/>    disabled_control_identifiers = optional(list(string), [])<br/>    target_ids                   = optional(list(string), [])<br/>  }))</pre> | `{}` | no |
+| <a name="input_configuration_type"></a> [configuration\_type](#input\_configuration\_type) | (Optional) Whether the organization uses LOCAL or CENTRAL configuration. LOCAL (default) preserves the historical behavior where each account/Region is configured independently and auto\_enable applies. CENTRAL enables configuration policies (see configuration\_policies), requires a finding aggregator, and forces auto\_enable to false and auto\_enable\_standards to NONE. Valid values: LOCAL, CENTRAL. | `string` | `"LOCAL"` | no |
+| <a name="input_enable_default_standards"></a> [enable\_default\_standards](#input\_enable\_default\_standards) | (Optional) Whether to enable the security standards that Security Hub CSPM has designated as automatically enabled including: AWS Foundational Security Best Practices v1.0.0 and CIS AWS Foundations Benchmark v1.2.0. Defaults to true. | `bool` | `true` | no |
+| <a name="input_linking_mode"></a> [linking\_mode](#input\_linking\_mode) | (Optional) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are ALL\_REGIONS, ALL\_REGIONS\_EXCEPT\_SPECIFIED or SPECIFIED\_REGIONS. When ALL\_REGIONS or ALL\_REGIONS\_EXCEPT\_SPECIFIED are used, Security Hub CSPM will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them. | `string` | `"ALL_REGIONS"` | no |
 | <a name="input_specified_regions"></a> [specified\_regions](#input\_specified\_regions) | (Optional) List of regions to include or exclude (required if linking\_mode is set to ALL\_REGIONS\_EXCEPT\_SPECIFIED or SPECIFIED\_REGIONS) | `list(string)` | `null` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_account_arn"></a> [account\_arn](#output\_account\_arn) | ARN of the Security Hub CSPM account resource in the delegated security account. |
+| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | The AWS account ID where Security Hub CSPM is enabled (the delegated security account). |
+| <a name="output_admin_account_id"></a> [admin\_account\_id](#output\_admin\_account\_id) | The 12-digit AWS account ID designated as the Security Hub CSPM delegated administrator. |
+| <a name="output_configuration_policy_ids"></a> [configuration\_policy\_ids](#output\_configuration\_policy\_ids) | Map of configuration policy name to policy ID for policies created when configuration\_type is CENTRAL. Empty for LOCAL configuration. |
+| <a name="output_finding_aggregator_arn"></a> [finding\_aggregator\_arn](#output\_finding\_aggregator\_arn) | ARN of the Security Hub CSPM finding aggregator. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/security_hub/organization/main.tf
+++ b/modules/aws/security_hub/organization/main.tf
@@ -1,41 +1,137 @@
+# This module manages AWS Security Hub CSPM (Cloud Security Posture Management),
+# the classic Security Hub service that produces ASFF findings and runs the
+# standards checks (AWS Foundational Security Best Practices, CIS, PCI DSS,
+# NIST 800-53). In 2026 AWS renamed the classic service to "Security Hub CSPM"
+# and reassigned the name "AWS Security Hub" to a new unified service (OCSF,
+# cross-service correlation). Both coexist and CSPM is not deprecated. The new
+# unified service is managed by the sibling module at ../v2.
 terraform {
   required_version = ">= 1.0.0"
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 4.0.0"
+      version               = ">= 6.0.0"
       configuration_aliases = [aws.organization_management_account, aws.organization_security_account]
     }
   }
 }
 
-# Security Hub configuration on the Security Account
+###########################################################
+# Locals
+###########################################################
+locals {
+  # Central configuration requires auto_enable = false and
+  # auto_enable_standards = "NONE" (those behaviors are governed by
+  # configuration policies instead). Coerce them here so callers cannot produce
+  # an invalid combination when configuration_type is CENTRAL.
+  is_central            = var.configuration_type == "CENTRAL"
+  auto_enable           = local.is_central ? false : var.auto_enable
+  auto_enable_standards = local.is_central ? "NONE" : var.auto_enable_standards
+
+  # Flatten configuration_policies into policy/target pairs for association.
+  configuration_policy_associations = local.is_central ? {
+    for assoc in flatten([
+      for name, cfg in var.configuration_policies : [
+        for target_id in cfg.target_ids : {
+          policy    = name
+          target_id = target_id
+        }
+      ]
+    ]) : "${assoc.policy}-${assoc.target_id}" => assoc
+  } : {}
+}
+
+###########################################################
+# Security Hub CSPM Account
+###########################################################
+# Enables Security Hub CSPM in the delegated security account.
 resource "aws_securityhub_account" "this" {
   provider                 = aws.organization_security_account
   enable_default_standards = var.enable_default_standards
 }
 
-# Security Hub Admin Deligation
+###########################################################
+# Security Hub CSPM Delegated Administrator
+###########################################################
+# Delegates Security Hub CSPM administration from the organization management
+# account to the security account. Per AWS, delegating CSPM to a non-management
+# account also makes that account the delegated administrator for the new
+# unified AWS Security Hub, so no separate V2 delegation resource is required.
 resource "aws_securityhub_organization_admin_account" "this" {
   depends_on       = [aws_securityhub_account.this]
   provider         = aws.organization_management_account
   admin_account_id = var.admin_account_id
 }
 
-# Security Hub Organization Configuration on the Security Account
-resource "aws_securityhub_organization_configuration" "this" {
-  provider = aws.organization_security_account
-  depends_on = [
-    aws_securityhub_organization_admin_account.this
-  ]
-  auto_enable           = var.auto_enable
-  auto_enable_standards = var.auto_enable_standards
-}
-
-# Security Hub Finding Aggregator on the Security Account
+###########################################################
+# Security Hub CSPM Finding Aggregator
+###########################################################
+# Created before the organization configuration because CSPM central
+# configuration requires an existing finding aggregator. This ordering is also
+# valid for LOCAL configuration.
 resource "aws_securityhub_finding_aggregator" "this" {
   provider          = aws.organization_security_account
-  depends_on        = [aws_securityhub_organization_configuration.this]
+  depends_on        = [aws_securityhub_organization_admin_account.this]
   linking_mode      = var.linking_mode
   specified_regions = var.specified_regions
+}
+
+###########################################################
+# Security Hub CSPM Organization Configuration
+###########################################################
+resource "aws_securityhub_organization_configuration" "this" {
+  provider   = aws.organization_security_account
+  depends_on = [aws_securityhub_finding_aggregator.this]
+
+  auto_enable           = local.auto_enable
+  auto_enable_standards = local.auto_enable_standards
+
+  # Only emit the block for CENTRAL configuration. Omitting it for LOCAL keeps
+  # the historical default behavior and avoids a diff for existing callers.
+  dynamic "organization_configuration" {
+    for_each = local.is_central ? [1] : []
+    content {
+      configuration_type = "CENTRAL"
+    }
+  }
+}
+
+###########################################################
+# Security Hub CSPM Configuration Policies (CENTRAL only)
+###########################################################
+resource "aws_securityhub_configuration_policy" "this" {
+  for_each = local.is_central ? var.configuration_policies : {}
+  provider = aws.organization_security_account
+
+  name        = each.key
+  description = each.value.description
+
+  configuration_policy {
+    service_enabled       = each.value.service_enabled
+    enabled_standard_arns = each.value.service_enabled ? each.value.enabled_standard_arns : []
+
+    dynamic "security_controls_configuration" {
+      for_each = each.value.service_enabled ? [1] : []
+      content {
+        # enabled and disabled control identifiers are mutually exclusive in the
+        # AWS API. If enabled_control_identifiers is provided it takes
+        # precedence; otherwise the disabled list is used (empty means all
+        # controls enabled).
+        enabled_control_identifiers  = length(each.value.enabled_control_identifiers) > 0 ? each.value.enabled_control_identifiers : null
+        disabled_control_identifiers = length(each.value.enabled_control_identifiers) > 0 ? null : each.value.disabled_control_identifiers
+      }
+    }
+  }
+
+  depends_on = [aws_securityhub_organization_configuration.this]
+}
+
+resource "aws_securityhub_configuration_policy_association" "this" {
+  for_each = local.configuration_policy_associations
+  provider = aws.organization_security_account
+
+  policy_id = aws_securityhub_configuration_policy.this[each.value.policy].id
+  target_id = each.value.target_id
+
+  depends_on = [aws_securityhub_configuration_policy.this]
 }

--- a/modules/aws/security_hub/organization/outputs.tf
+++ b/modules/aws/security_hub/organization/outputs.tf
@@ -1,0 +1,40 @@
+############################################################
+# AWS Security Hub CSPM Account Outputs
+############################################################
+
+output "account_id" {
+  description = "The AWS account ID where Security Hub CSPM is enabled (the delegated security account)."
+  value       = aws_securityhub_account.this.id
+}
+
+output "account_arn" {
+  description = "ARN of the Security Hub CSPM account resource in the delegated security account."
+  value       = aws_securityhub_account.this.arn
+}
+
+############################################################
+# AWS Security Hub CSPM Delegated Administrator Outputs
+############################################################
+
+output "admin_account_id" {
+  description = "The 12-digit AWS account ID designated as the Security Hub CSPM delegated administrator."
+  value       = aws_securityhub_organization_admin_account.this.admin_account_id
+}
+
+############################################################
+# AWS Security Hub CSPM Finding Aggregator Outputs
+############################################################
+
+output "finding_aggregator_arn" {
+  description = "ARN of the Security Hub CSPM finding aggregator."
+  value       = aws_securityhub_finding_aggregator.this.arn
+}
+
+############################################################
+# AWS Security Hub CSPM Configuration Policy Outputs
+############################################################
+
+output "configuration_policy_ids" {
+  description = "Map of configuration policy name to policy ID for policies created when configuration_type is CENTRAL. Empty for LOCAL configuration."
+  value       = { for name, policy in aws_securityhub_configuration_policy.this : name => policy.id }
+}

--- a/modules/aws/security_hub/organization/variables.tf
+++ b/modules/aws/security_hub/organization/variables.tf
@@ -1,10 +1,10 @@
 ############################################################
-# AWS Security Hub Account Variables
+# AWS Security Hub CSPM Account Variables
 ############################################################
 
 variable "enable_default_standards" {
   type        = bool
-  description = "(Optional) Whether to enable the security standards that Security Hub has designated as automatically enabled including: AWS Foundational Security Best Practices v1.0.0 and CIS AWS Foundations Benchmark v1.2.0. Defaults to true."
+  description = "(Optional) Whether to enable the security standards that Security Hub CSPM has designated as automatically enabled including: AWS Foundational Security Best Practices v1.0.0 and CIS AWS Foundations Benchmark v1.2.0. Defaults to true."
   default     = true
   validation {
     condition     = can(regex("^(true|false)$", var.enable_default_standards))
@@ -13,12 +13,12 @@ variable "enable_default_standards" {
 }
 
 ############################################################
-# AWS Security Hub Organization Admin Variables
+# AWS Security Hub CSPM Delegated Administrator Variables
 ############################################################
 
 variable "admin_account_id" {
   type        = string
-  description = "(Required) The 12-digit identifier of the AWS account designated as the Security Hub administrator account."
+  description = "(Required) The 12-digit identifier of the AWS account designated as the Security Hub CSPM delegated administrator account. Per AWS, delegating CSPM to a non-management account also designates it as the delegated administrator for the unified AWS Security Hub."
   validation {
     condition     = can(regex("^\\d{12}$", var.admin_account_id))
     error_message = "The value must be a 12-digit identifier."
@@ -26,12 +26,12 @@ variable "admin_account_id" {
 }
 
 ############################################################
-# AWS Security Hub Organization Admin Variables
+# AWS Security Hub CSPM Organization Configuration Variables
 ############################################################
 
 variable "auto_enable" {
   type        = bool
-  description = "(Required) Whether to automatically enable Security Hub for new accounts in the organization. Defaults to true."
+  description = "(Optional) Whether to automatically enable Security Hub CSPM for new accounts in the organization. Only applies to LOCAL configuration; when configuration_type is CENTRAL this is forced to false. Defaults to true."
   default     = true
   validation {
     condition     = can(regex("^(true|false)$", var.auto_enable))
@@ -41,7 +41,7 @@ variable "auto_enable" {
 
 variable "auto_enable_standards" {
   type        = string
-  description = "(Optional) Whether to automatically enable Security Hub default standards for new member accounts in the organization. By default, this parameter is equal to DEFAULT, and new member accounts are automatically enabled with default Security Hub standards. To opt out of enabling default standards for new member accounts, set this parameter equal to NONE."
+  description = "(Optional) Whether to automatically enable Security Hub CSPM default standards for new member accounts in the organization. Valid values are DEFAULT and NONE. Only applies to LOCAL configuration; when configuration_type is CENTRAL this is forced to NONE. Defaults to DEFAULT."
   default     = "DEFAULT"
   validation {
     condition     = can(regex("^(DEFAULT|NONE)$", var.auto_enable_standards))
@@ -49,13 +49,36 @@ variable "auto_enable_standards" {
   }
 }
 
+variable "configuration_type" {
+  type        = string
+  description = "(Optional) Whether the organization uses LOCAL or CENTRAL configuration. LOCAL (default) preserves the historical behavior where each account/Region is configured independently and auto_enable applies. CENTRAL enables configuration policies (see configuration_policies), requires a finding aggregator, and forces auto_enable to false and auto_enable_standards to NONE. Valid values: LOCAL, CENTRAL."
+  default     = "LOCAL"
+  validation {
+    condition     = contains(["LOCAL", "CENTRAL"], var.configuration_type)
+    error_message = "The value must be LOCAL or CENTRAL."
+  }
+}
+
+variable "configuration_policies" {
+  type = map(object({
+    description                  = optional(string)
+    service_enabled              = optional(bool, true)
+    enabled_standard_arns        = optional(list(string), [])
+    enabled_control_identifiers  = optional(list(string), [])
+    disabled_control_identifiers = optional(list(string), [])
+    target_ids                   = optional(list(string), [])
+  }))
+  description = "(Optional) Map of Security Hub CSPM central configuration policies keyed by policy name. Only used when configuration_type is CENTRAL. Per policy: service_enabled toggles Security Hub CSPM on/off for associated targets; enabled_standard_arns lists the standard ARNs to enable; provide either enabled_control_identifiers or disabled_control_identifiers (mutually exclusive - a non-empty enabled_control_identifiers takes precedence); target_ids is the list of organization root, OU, or account IDs to associate with the policy. Defaults to an empty map (no policies)."
+  default     = {}
+}
+
 ############################################################
-# AWS Security Hub Finding Aggregator Variables
+# AWS Security Hub CSPM Finding Aggregator Variables
 ############################################################
 
 variable "linking_mode" {
   type        = string
-  description = "(Optional) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are ALL_REGIONS, ALL_REGIONS_EXCEPT_SPECIFIED or SPECIFIED_REGIONS. When ALL_REGIONS or ALL_REGIONS_EXCEPT_SPECIFIED are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them."
+  description = "(Optional) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are ALL_REGIONS, ALL_REGIONS_EXCEPT_SPECIFIED or SPECIFIED_REGIONS. When ALL_REGIONS or ALL_REGIONS_EXCEPT_SPECIFIED are used, Security Hub CSPM will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them."
   default     = "ALL_REGIONS"
   validation {
     condition     = can(regex("^(ALL_REGIONS|ALL_REGIONS_EXCEPT_SPECIFIED|SPECIFIED_REGIONS)$", var.linking_mode))

--- a/modules/aws/security_hub/v2/README.md
+++ b/modules/aws/security_hub/v2/README.md
@@ -1,0 +1,269 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+<!-- PROJECT SHIELDS -->
+<!--
+*** I'm using markdown "reference style" links for readability.
+*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
+*** See the bottom of this document for the declaration of the reference variables
+*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
+*** https://www.markdownguide.org/basic-syntax/#reference-style-links
+-->
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Security Hub V2 (Unified)</h3>
+  <p align="center">
+    This module enables the unified AWS Security Hub ("V2") in the delegated security account, including cross-Region finding aggregation and OCSF automation rules.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#Resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+<!-- USAGE EXAMPLES -->
+
+## About: the unified AWS Security Hub vs. Security Hub CSPM
+
+In 2026 AWS reassigned the name **AWS Security Hub** to a new unified security
+operations service (OCSF schema, cross-service correlation, risk analytics,
+exposure summaries) and renamed the classic posture manager to **Security Hub
+CSPM**. This module manages the new unified service. The classic CSPM service is
+managed by the sibling module at [`../organization`](../organization).
+
+## Prerequisites
+
+- **Delegate CSPM first.** Apply the [`../organization`](../organization) (Security
+  Hub CSPM) module before this one. Per AWS, designating a non-management account
+  as the Security Hub CSPM delegated administrator automatically makes that same
+  account the delegated administrator for the unified Security Hub. There is no
+  separate Terraform resource to delegate the unified service.
+- **Organization trusted access.** `securityhub.amazonaws.com` must have trusted
+  access enabled in the organization (the `organizations/organization` module
+  enables this by default).
+
+## Notes / Design Decisions
+
+- **Scope is the delegated security account.** All V2 resources
+  (`aws_securityhub_account_v2`, `aws_securityhub_aggregator_v2`,
+  `aws_securityhub_automation_rule_v2`) are created in the delegated security
+  (administrator) account, so this module takes a single
+  `aws.organization_security_account` provider alias.
+- **Org-wide member enablement is not yet available in Terraform.** The AWS
+  provider does not expose a V2 equivalent of
+  `aws_securityhub_organization_admin_account` or
+  `aws_securityhub_organization_configuration`. Auto-enabling the unified service
+  across member accounts is currently a console/API action (Security Hub
+  configuration policies / deployments). Perform that step outside Terraform
+  until the provider adds support.
+- **Cost.** Enabling the unified service turns on the per-resource **Essentials
+  plan** (30-day free trial, then billed). Usage-based add-ons (Threat analytics
+  from GuardDuty, Lambda code scanning from Inspector) are billed separately.
+  Set an AWS Budgets alarm before enabling anything paid, and scope Regions
+  with intent via `region_linking_mode` / `linked_regions`.
+- **Automation rules require an aggregator.** Automation rules must be created in
+  the aggregation (home) Region and require an existing aggregator, so
+  `automation_rules` requires `enable_finding_aggregation = true`.
+
+## Usage
+
+### Simple Example
+
+Enables the unified Security Hub with all-Region aggregation in the delegated
+security account.
+
+```
+module "security_hub_v2" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/security_hub/v2"
+  providers = {
+    aws.organization_security_account = aws.organization_security_account
+  }
+}
+```
+
+### Specified Regions
+
+```
+module "security_hub_v2" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/security_hub/v2"
+  providers = {
+    aws.organization_security_account = aws.organization_security_account
+  }
+  region_linking_mode = "SPECIFIED_REGIONS"
+  linked_regions      = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+}
+```
+
+### With an Automation Rule
+
+Suppresses low-severity GuardDuty findings.
+
+```
+module "security_hub_v2" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/security_hub/v2"
+  providers = {
+    aws.organization_security_account = aws.organization_security_account
+  }
+
+  automation_rules = {
+    "suppress-guardduty-low" = {
+      description = "Suppress low severity GuardDuty findings"
+      rule_order  = 100
+      ocsf_finding_criteria_json = jsonencode({
+        CompositeFilters = [
+          {
+            StringFilters = [
+              {
+                FieldName = "metadata.product.name"
+                Filter = {
+                  Comparison = "EQUALS"
+                  Value      = "GuardDuty"
+                }
+              }
+            ]
+          }
+        ]
+        CompositeOperator = "AND"
+      })
+      finding_fields_update = {
+        severity_id = 99
+        status_id   = 3
+        comment     = "Low severity GuardDuty finding suppressed"
+      }
+    }
+  }
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.46.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws.organization_security_account"></a> [aws.organization\_security\_account](#provider\_aws.organization\_security\_account) | >= 6.46.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_securityhub_account_v2.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account_v2) | resource |
+| [aws_securityhub_aggregator_v2.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_aggregator_v2) | resource |
+| [aws_securityhub_automation_rule_v2.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_automation_rule_v2) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_automation_rules"></a> [automation\_rules](#input\_automation\_rules) | (Optional) Map of Security Hub V2 automation rules keyed by rule name. Requires enable\_finding\_aggregation = true. Per rule: rule\_order sets priority (lower is higher priority); rule\_status is ENABLED or DISABLED; ocsf\_finding\_criteria\_json is the JSON-encoded OCSF finding criteria; action\_type is FINDING\_FIELDS\_UPDATE or EXTERNAL\_INTEGRATION; supply finding\_fields\_update for FINDING\_FIELDS\_UPDATE actions, or external\_integration\_connector\_arn for EXTERNAL\_INTEGRATION actions. Defaults to an empty map (no rules). | <pre>map(object({<br/>    description                = string<br/>    rule_order                 = number<br/>    rule_status                = optional(string, "ENABLED")<br/>    ocsf_finding_criteria_json = string<br/>    action_type                = optional(string, "FINDING_FIELDS_UPDATE")<br/>    finding_fields_update = optional(object({<br/>      comment     = optional(string)<br/>      severity_id = optional(number)<br/>      status_id   = optional(number)<br/>    }))<br/>    external_integration_connector_arn = optional(string)<br/>  }))</pre> | `{}` | no |
+| <a name="input_enable_finding_aggregation"></a> [enable\_finding\_aggregation](#input\_enable\_finding\_aggregation) | (Optional) Whether to create a Security Hub V2 cross-Region finding aggregator. Must be true to use automation\_rules. Defaults to true. | `bool` | `true` | no |
+| <a name="input_linked_regions"></a> [linked\_regions](#input\_linked\_regions) | (Optional) List of Regions linked to the aggregation Region. Required when region\_linking\_mode is SPECIFIED\_REGIONS or ALL\_REGIONS\_EXCEPT\_SPECIFIED; otherwise leave null. Defaults to null. | `list(string)` | `null` | no |
+| <a name="input_region_linking_mode"></a> [region\_linking\_mode](#input\_region\_linking\_mode) | (Optional) Determines how Regions are linked to the aggregator. Valid values: ALL\_REGIONS, ALL\_REGIONS\_EXCEPT\_SPECIFIED, SPECIFIED\_REGIONS. Only used when enable\_finding\_aggregation is true. Defaults to ALL\_REGIONS. | `string` | `"ALL_REGIONS"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to the Security Hub V2 resources created by this module (account, aggregator, and automation rules). | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_account_arn"></a> [account\_arn](#output\_account\_arn) | ARN of the unified Security Hub (V2) resource created in the security account. |
+| <a name="output_aggregation_region"></a> [aggregation\_region](#output\_aggregation\_region) | The AWS Region where Security Hub V2 findings are aggregated, or null when enable\_finding\_aggregation is false. |
+| <a name="output_aggregator_arn"></a> [aggregator\_arn](#output\_aggregator\_arn) | ARN of the Security Hub V2 aggregator, or null when enable\_finding\_aggregation is false. |
+| <a name="output_automation_rule_arns"></a> [automation\_rule\_arns](#output\_automation\_rule\_arns) | Map of automation rule name to rule ARN for rules created by this module. Empty when no automation\_rules are supplied. |
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://github.com/zachreborn)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/aws/security_hub/v2/main.tf
+++ b/modules/aws/security_hub/v2/main.tf
@@ -1,0 +1,106 @@
+# This module manages the unified AWS Security Hub service ("V2"), the 2026
+# release that uses the OCSF schema and correlates signals across GuardDuty,
+# Inspector, Macie, and Security Hub CSPM into prioritized exposures. It is
+# distinct from Security Hub CSPM (managed by the sibling module at
+# ../organization) and the two services coexist.
+#
+# IMPORTANT: The AWS provider does not yet expose an org-level resource for the
+# unified service (there is no V2 equivalent of
+# aws_securityhub_organization_admin_account or
+# aws_securityhub_organization_configuration). This module therefore enables the
+# unified service and its aggregator/automation rules in the delegated security
+# (administrator) account. Delegated-administrator designation is inherited from
+# the Security Hub CSPM delegated administrator (see ../organization), and
+# org-wide member auto-enablement is performed via console/API configuration
+# policies that are not yet available in Terraform.
+###########################################################
+# Provider Configuration
+###########################################################
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 6.46.0"
+      configuration_aliases = [aws.organization_security_account]
+    }
+  }
+}
+
+###########################################################
+# Security Hub V2 Account
+###########################################################
+# Enables the unified Security Hub (V2) in the delegated security account. This
+# turns on the per-resource Essentials plan (30-day free trial, then billed).
+resource "aws_securityhub_account_v2" "this" {
+  provider = aws.organization_security_account
+
+  tags = var.tags
+}
+
+###########################################################
+# Security Hub V2 Finding Aggregator
+###########################################################
+# Cross-Region aggregation for the unified service. Required before any
+# automation rules can be created.
+resource "aws_securityhub_aggregator_v2" "this" {
+  count    = var.enable_finding_aggregation ? 1 : 0
+  provider = aws.organization_security_account
+
+  region_linking_mode = var.region_linking_mode
+  linked_regions      = var.linked_regions
+
+  tags = var.tags
+
+  depends_on = [aws_securityhub_account_v2.this]
+}
+
+###########################################################
+# Security Hub V2 Automation Rules
+###########################################################
+# OCSF automation rules. Must be created in the aggregation (home) Region and
+# require an existing aggregator.
+resource "aws_securityhub_automation_rule_v2" "this" {
+  for_each = var.automation_rules
+  provider = aws.organization_security_account
+
+  rule_name   = each.key
+  description = each.value.description
+  rule_order  = each.value.rule_order
+  rule_status = each.value.rule_status
+
+  criteria {
+    ocsf_finding_criteria_json = each.value.ocsf_finding_criteria_json
+  }
+
+  action {
+    type = each.value.action_type
+
+    dynamic "finding_fields_update" {
+      for_each = each.value.finding_fields_update != null ? [each.value.finding_fields_update] : []
+      content {
+        comment     = finding_fields_update.value.comment
+        severity_id = finding_fields_update.value.severity_id
+        status_id   = finding_fields_update.value.status_id
+      }
+    }
+
+    dynamic "external_integration_configuration" {
+      for_each = each.value.external_integration_connector_arn != null ? [each.value.external_integration_connector_arn] : []
+      content {
+        connector_arn = external_integration_configuration.value
+      }
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [aws_securityhub_aggregator_v2.this]
+
+  lifecycle {
+    precondition {
+      condition     = var.enable_finding_aggregation
+      error_message = "automation_rules require enable_finding_aggregation = true, because a Security Hub V2 aggregator must exist in the aggregation (home) Region before automation rules can be created."
+    }
+  }
+}

--- a/modules/aws/security_hub/v2/outputs.tf
+++ b/modules/aws/security_hub/v2/outputs.tf
@@ -1,0 +1,31 @@
+###########################################################
+# Security Hub V2 Account Outputs
+###########################################################
+
+output "account_arn" {
+  description = "ARN of the unified Security Hub (V2) resource created in the security account."
+  value       = aws_securityhub_account_v2.this.arn
+}
+
+###########################################################
+# Security Hub V2 Finding Aggregator Outputs
+###########################################################
+
+output "aggregator_arn" {
+  description = "ARN of the Security Hub V2 aggregator, or null when enable_finding_aggregation is false."
+  value       = try(aws_securityhub_aggregator_v2.this[0].arn, null)
+}
+
+output "aggregation_region" {
+  description = "The AWS Region where Security Hub V2 findings are aggregated, or null when enable_finding_aggregation is false."
+  value       = try(aws_securityhub_aggregator_v2.this[0].aggregation_region, null)
+}
+
+###########################################################
+# Security Hub V2 Automation Rule Outputs
+###########################################################
+
+output "automation_rule_arns" {
+  description = "Map of automation rule name to rule ARN for rules created by this module. Empty when no automation_rules are supplied."
+  value       = { for name, rule in aws_securityhub_automation_rule_v2.this : name => rule.rule_arn }
+}

--- a/modules/aws/security_hub/v2/variables.tf
+++ b/modules/aws/security_hub/v2/variables.tf
@@ -1,0 +1,57 @@
+###########################################################
+# Security Hub V2 Finding Aggregator Variables
+###########################################################
+
+variable "enable_finding_aggregation" {
+  type        = bool
+  description = "(Optional) Whether to create a Security Hub V2 cross-Region finding aggregator. Must be true to use automation_rules. Defaults to true."
+  default     = true
+}
+
+variable "region_linking_mode" {
+  type        = string
+  description = "(Optional) Determines how Regions are linked to the aggregator. Valid values: ALL_REGIONS, ALL_REGIONS_EXCEPT_SPECIFIED, SPECIFIED_REGIONS. Only used when enable_finding_aggregation is true. Defaults to ALL_REGIONS."
+  default     = "ALL_REGIONS"
+  validation {
+    condition     = contains(["ALL_REGIONS", "ALL_REGIONS_EXCEPT_SPECIFIED", "SPECIFIED_REGIONS"], var.region_linking_mode)
+    error_message = "The value must be ALL_REGIONS, ALL_REGIONS_EXCEPT_SPECIFIED, or SPECIFIED_REGIONS."
+  }
+}
+
+variable "linked_regions" {
+  type        = list(string)
+  description = "(Optional) List of Regions linked to the aggregation Region. Required when region_linking_mode is SPECIFIED_REGIONS or ALL_REGIONS_EXCEPT_SPECIFIED; otherwise leave null. Defaults to null."
+  default     = null
+}
+
+###########################################################
+# Security Hub V2 Automation Rule Variables
+###########################################################
+
+variable "automation_rules" {
+  type = map(object({
+    description                = string
+    rule_order                 = number
+    rule_status                = optional(string, "ENABLED")
+    ocsf_finding_criteria_json = string
+    action_type                = optional(string, "FINDING_FIELDS_UPDATE")
+    finding_fields_update = optional(object({
+      comment     = optional(string)
+      severity_id = optional(number)
+      status_id   = optional(number)
+    }))
+    external_integration_connector_arn = optional(string)
+  }))
+  description = "(Optional) Map of Security Hub V2 automation rules keyed by rule name. Requires enable_finding_aggregation = true. Per rule: rule_order sets priority (lower is higher priority); rule_status is ENABLED or DISABLED; ocsf_finding_criteria_json is the JSON-encoded OCSF finding criteria; action_type is FINDING_FIELDS_UPDATE or EXTERNAL_INTEGRATION; supply finding_fields_update for FINDING_FIELDS_UPDATE actions, or external_integration_connector_arn for EXTERNAL_INTEGRATION actions. Defaults to an empty map (no rules)."
+  default     = {}
+}
+
+###########################################################
+# General Variables
+###########################################################
+
+variable "tags" {
+  type        = map(string)
+  description = "(Optional) A map of tags to assign to the Security Hub V2 resources created by this module (account, aggregator, and automation rules)."
+  default     = {}
+}


### PR DESCRIPTION
# Description
AWS split Security Hub into two coexisting services in 2026: the classic posture manager (now **Security Hub CSPM**) and a new unified **AWS Security Hub** (OCSF, cross-service correlation). This PR updates the organization module and Security Hub modules to reflect that split.

- **fix(organizations):** add \`securityhub.amazonaws.com\`, \`guardduty.amazonaws.com\`, \`config.amazonaws.com\`, \`access-analyzer.amazonaws.com\`, and \`inspector2.amazonaws.com\` to the default \`aws_service_access_principals\`. The delegated-administrator modules for these services auto-enable trusted access; without them in this module's managed list, the next apply would revert that access and cause drift.
- **feat(security-hub):** modernize \`modules/aws/security_hub/organization\` (unchanged path/resource addresses) — bump \`aws\` provider to \`>= 6.0.0\`, relabel it as Security Hub CSPM, add a previously-missing \`outputs.tf\`, and add optional CENTRAL configuration support (\`configuration_type\`, map-driven \`configuration_policies\`). Defaults preserve existing LOCAL behavior.
- **feat(security-hub):** add \`modules/aws/security_hub/v2\`, a new module for the unified Security Hub service (\`aws_securityhub_account_v2\`, \`aws_securityhub_aggregator_v2\`, map-driven \`aws_securityhub_automation_rule_v2\`). The AWS provider does not yet expose an org-level V2 resource, so org-wide member enablement remains a console/API action — this is documented in the module README along with Essentials-plan cost guidance.

Each module was validated with \`tofu init -backend=false\` + \`tofu validate\`, formatted with \`tofu fmt -recursive\`, and had its \`terraform-docs\` block regenerated.

## Issue or Ticket
N/A — implements the approved plan below (no tracking issue).

## Type of change
- [x] \`feat\` — a new user-facing feature (SemVer MINOR)
- [ ] \`fix\` — a bug fix (SemVer PATCH)
- [ ] \`docs\` — documentation only
- [ ] \`style\` — formatting/whitespace; no logic change
- [ ] \`refactor\` — code change that neither fixes a bug nor adds a feature
- [ ] \`perf\` — performance improvement
- [ ] \`test\` — adding or correcting tests
- [ ] \`build\` — build system or dependency changes
- [ ] \`ci\` — CI configuration (GitHub Actions, etc.)
- [ ] \`chore\` — maintenance task that does not fit elsewhere
- [ ] \`revert\` — reverts a previous commit

Note: this PR is squash-merged under the \`feat\` PR title, so it releases as a MINOR bump. The \`fix\` commit (organization trusted-access principals) is included in the same PR for review convenience; split it into a separate PR first if a standalone PATCH release is preferred.

## Breaking Changes
- [ ] Yes — this is a breaking change
- [x] No

Module directory paths and existing resource addresses are unchanged; new inputs/outputs are additive with backward-compatible defaults.

## TODOs
- [x] PR title follows Conventional Commits (\`<type>(scope): description\`).
- [x] Validate your code matches the style of the project (\`tofu fmt -recursive\`).
- [x] Update the docs (regenerate the \`terraform-docs\` block where applicable).
- [x] Validate all tests run successfully, including pre-commit checks (\`tofu validate\` per module; no automated test suite in this repo).
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.

---
Generated by an Oz agent conversation: https://app.warp.dev/conversation/723381b1-6848-480a-9afb-6374440bb4bb
Plan: https://app.warp.dev/drive/notebook/3bSMjp4JpsEaQszCThKr7S

Co-Authored-By: Oz <oz-agent@warp.dev>