### PR TITLE
test(route53): add native OpenTofu test coverage for routing record and registered domain modules

### DIFF
--- a/modules/aws/route53/failover_routing_record/tests/main.tftest.hcl
+++ b/modules/aws/route53/failover_routing_record/tests/main.tftest.hcl
@@ -1,0 +1,122 @@
+mock_provider "aws" {}
+
+run "plan_succeeds_with_valid_input" {
+  command = plan
+
+  variables {
+    zone_id                      = "Z1234567890ABC"
+    name                         = "app.example.com"
+    type                         = "CNAME"
+    records                      = ["primary-target.example.com"]
+    set_identifier               = "primary"
+    health_check_id              = "hc-1234567890"
+    failover_routing_policy_type = "PRIMARY"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.zone_id == "Z1234567890ABC"
+    error_message = "zone_id should pass through unchanged."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.name == "app.example.com"
+    error_message = "name should pass through unchanged."
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "primary-target.example.com")
+    error_message = "records should pass through unchanged when under the 255 character split threshold."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.set_identifier == "primary"
+    error_message = "set_identifier should pass through unchanged."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.health_check_id == "hc-1234567890"
+    error_message = "health_check_id should pass through unchanged."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.failover_routing_policy[0].type == "PRIMARY"
+    error_message = "failover_routing_policy.type should be PRIMARY."
+  }
+}
+
+run "failover_secondary_type_is_honored" {
+  command = plan
+
+  variables {
+    zone_id                      = "Z1234567890ABC"
+    name                         = "app.example.com"
+    type                         = "CNAME"
+    records                      = ["secondary-target.example.com"]
+    set_identifier               = "secondary"
+    failover_routing_policy_type = "SECONDARY"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.failover_routing_policy[0].type == "SECONDARY"
+    error_message = "failover_routing_policy.type should be SECONDARY when explicitly set."
+  }
+}
+
+run "ttl_defaults_to_300" {
+  command = plan
+
+  variables {
+    zone_id                      = "Z1234567890ABC"
+    name                         = "app.example.com"
+    type                         = "CNAME"
+    records                      = ["primary-target.example.com"]
+    set_identifier               = "primary"
+    failover_routing_policy_type = "PRIMARY"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 300
+    error_message = "ttl should default to 300 when unset."
+  }
+}
+
+run "ttl_override_is_honored" {
+  command = plan
+
+  variables {
+    zone_id                      = "Z1234567890ABC"
+    name                         = "app.example.com"
+    type                         = "CNAME"
+    ttl                          = 60
+    records                      = ["primary-target.example.com"]
+    set_identifier               = "primary"
+    failover_routing_policy_type = "PRIMARY"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 60
+    error_message = "Explicit ttl override should be honored."
+  }
+}
+
+run "record_longer_than_255_characters_is_split" {
+  command = plan
+
+  variables {
+    zone_id                      = "Z1234567890ABC"
+    name                         = "app.example.com"
+    type                         = "TXT"
+    records                      = [join("", [for i in range(300) : "a"])]
+    set_identifier               = "primary"
+    failover_routing_policy_type = "PRIMARY"
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "${join("", [for i in range(255) : "a"])}\"\"${join("", [for i in range(45) : "a"])}")
+    error_message = "A 300 character record should have an empty-string separator inserted after the 255th character."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/failover_routing_record/tests/validation.tftest.hcl
+++ b/modules/aws/route53/failover_routing_record/tests/validation.tftest.hcl
@@ -1,0 +1,39 @@
+mock_provider "aws" {}
+
+run "valid_baseline_does_not_fail" {
+  command = plan
+
+  variables {
+    zone_id                      = "Z1234567890ABC"
+    name                         = "app.example.com"
+    type                         = "A"
+    records                      = ["primary-target.example.com"]
+    set_identifier               = "primary"
+    failover_routing_policy_type = "PRIMARY"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.type == "A"
+    error_message = "A supported record type should plan successfully."
+  }
+}
+
+run "rejects_unsupported_type" {
+  command = plan
+
+  variables {
+    zone_id                      = "Z1234567890ABC"
+    name                         = "app.example.com"
+    type                         = "INVALID"
+    records                      = ["primary-target.example.com"]
+    set_identifier               = "primary"
+    failover_routing_policy_type = "PRIMARY"
+  }
+
+  expect_failures = [var.type]
+}
+
+# Do NOT delete, skip, or loosen an `expect_failures` case (or any assertion above) just to
+# make `tofu test` pass. A validation test that unexpectedly fails means either the
+# `validation {}` block in variables.tf has a bug or the test's inputs are wrong -- find and
+# fix the root cause, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/geolocation_routing_record/tests/main.tftest.hcl
+++ b/modules/aws/route53/geolocation_routing_record/tests/main.tftest.hcl
@@ -1,0 +1,131 @@
+mock_provider "aws" {}
+
+run "plan_succeeds_with_country_based_geolocation" {
+  command = plan
+
+  variables {
+    zone_id                              = "Z1234567890ABC"
+    name                                 = "app.example.com"
+    type                                 = "CNAME"
+    records                              = ["us-target.example.com"]
+    set_identifier                       = "us"
+    geolocation_routing_policy_country   = "US"
+    geolocation_routing_policy_continent = null
+  }
+
+  assert {
+    condition     = aws_route53_record.this.zone_id == "Z1234567890ABC"
+    error_message = "zone_id should pass through unchanged."
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "us-target.example.com")
+    error_message = "records should pass through unchanged when under the 255 character split threshold."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.geolocation_routing_policy[0].country == "US"
+    error_message = "geolocation_routing_policy.country should be honored."
+  }
+}
+
+run "plan_succeeds_with_continent_based_geolocation" {
+  command = plan
+
+  variables {
+    zone_id                              = "Z1234567890ABC"
+    name                                 = "app.example.com"
+    type                                 = "CNAME"
+    records                              = ["na-target.example.com"]
+    set_identifier                       = "na"
+    geolocation_routing_policy_continent = "NA"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.geolocation_routing_policy[0].continent == "NA"
+    error_message = "geolocation_routing_policy.continent should be honored."
+  }
+}
+
+run "plan_succeeds_with_country_and_subdivision" {
+  command = plan
+
+  variables {
+    zone_id                                = "Z1234567890ABC"
+    name                                   = "app.example.com"
+    type                                   = "CNAME"
+    records                                = ["wa-target.example.com"]
+    set_identifier                         = "us-wa"
+    geolocation_routing_policy_country     = "US"
+    geolocation_routing_policy_subdivision = "WA"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.geolocation_routing_policy[0].country == "US"
+    error_message = "geolocation_routing_policy.country should be honored alongside subdivision."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.geolocation_routing_policy[0].subdivision == "WA"
+    error_message = "geolocation_routing_policy.subdivision should be honored."
+  }
+}
+
+run "ttl_defaults_to_300" {
+  command = plan
+
+  variables {
+    zone_id                            = "Z1234567890ABC"
+    name                               = "app.example.com"
+    type                               = "CNAME"
+    records                            = ["default-target.example.com"]
+    set_identifier                     = "default"
+    geolocation_routing_policy_country = "*"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 300
+    error_message = "ttl should default to 300 when unset."
+  }
+}
+
+run "ttl_override_is_honored" {
+  command = plan
+
+  variables {
+    zone_id                            = "Z1234567890ABC"
+    name                               = "app.example.com"
+    type                               = "CNAME"
+    ttl                                = 60
+    records                            = ["default-target.example.com"]
+    set_identifier                     = "default"
+    geolocation_routing_policy_country = "*"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 60
+    error_message = "Explicit ttl override should be honored."
+  }
+}
+
+run "record_longer_than_255_characters_is_split" {
+  command = plan
+
+  variables {
+    zone_id                            = "Z1234567890ABC"
+    name                               = "app.example.com"
+    type                               = "TXT"
+    records                            = [join("", [for i in range(300) : "a"])]
+    set_identifier                     = "default"
+    geolocation_routing_policy_country = "*"
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "${join("", [for i in range(255) : "a"])}\"\"${join("", [for i in range(45) : "a"])}")
+    error_message = "A 300 character record should have an empty-string separator inserted after the 255th character."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/geolocation_routing_record/tests/validation.tftest.hcl
+++ b/modules/aws/route53/geolocation_routing_record/tests/validation.tftest.hcl
@@ -1,0 +1,39 @@
+mock_provider "aws" {}
+
+run "valid_baseline_does_not_fail" {
+  command = plan
+
+  variables {
+    zone_id                            = "Z1234567890ABC"
+    name                               = "app.example.com"
+    type                               = "A"
+    records                            = ["us-target.example.com"]
+    set_identifier                     = "us"
+    geolocation_routing_policy_country = "US"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.type == "A"
+    error_message = "A supported record type should plan successfully."
+  }
+}
+
+run "rejects_unsupported_type" {
+  command = plan
+
+  variables {
+    zone_id                            = "Z1234567890ABC"
+    name                               = "app.example.com"
+    type                               = "INVALID"
+    records                            = ["us-target.example.com"]
+    set_identifier                     = "us"
+    geolocation_routing_policy_country = "US"
+  }
+
+  expect_failures = [var.type]
+}
+
+# Do NOT delete, skip, or loosen an `expect_failures` case (or any assertion above) just to
+# make `tofu test` pass. A validation test that unexpectedly fails means either the
+# `validation {}` block in variables.tf has a bug or the test's inputs are wrong -- find and
+# fix the root cause, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/latency_routing_record/tests/main.tftest.hcl
+++ b/modules/aws/route53/latency_routing_record/tests/main.tftest.hcl
@@ -1,0 +1,106 @@
+mock_provider "aws" {}
+
+run "plan_succeeds_with_valid_input" {
+  command = plan
+
+  variables {
+    zone_id                       = "Z1234567890ABC"
+    name                          = "app.example.com"
+    type                          = "CNAME"
+    records                       = ["use1-target.example.com"]
+    set_identifier                = "use1"
+    latency_routing_policy_region = "us-east-1"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.zone_id == "Z1234567890ABC"
+    error_message = "zone_id should pass through unchanged."
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "use1-target.example.com")
+    error_message = "records should pass through unchanged when under the 255 character split threshold."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.latency_routing_policy[0].region == "us-east-1"
+    error_message = "latency_routing_policy.region should be honored."
+  }
+}
+
+run "different_region_is_honored" {
+  command = plan
+
+  variables {
+    zone_id                       = "Z1234567890ABC"
+    name                          = "app.example.com"
+    type                          = "CNAME"
+    records                       = ["euw1-target.example.com"]
+    set_identifier                = "euw1"
+    latency_routing_policy_region = "eu-west-1"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.latency_routing_policy[0].region == "eu-west-1"
+    error_message = "latency_routing_policy.region should reflect the configured region."
+  }
+}
+
+run "ttl_defaults_to_300" {
+  command = plan
+
+  variables {
+    zone_id                       = "Z1234567890ABC"
+    name                          = "app.example.com"
+    type                          = "CNAME"
+    records                       = ["use1-target.example.com"]
+    set_identifier                = "use1"
+    latency_routing_policy_region = "us-east-1"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 300
+    error_message = "ttl should default to 300 when unset."
+  }
+}
+
+run "ttl_override_is_honored" {
+  command = plan
+
+  variables {
+    zone_id                       = "Z1234567890ABC"
+    name                          = "app.example.com"
+    type                          = "CNAME"
+    ttl                           = 60
+    records                       = ["use1-target.example.com"]
+    set_identifier                = "use1"
+    latency_routing_policy_region = "us-east-1"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 60
+    error_message = "Explicit ttl override should be honored."
+  }
+}
+
+run "record_longer_than_255_characters_is_split" {
+  command = plan
+
+  variables {
+    zone_id                       = "Z1234567890ABC"
+    name                          = "app.example.com"
+    type                          = "TXT"
+    records                       = [join("", [for i in range(300) : "a"])]
+    set_identifier                = "use1"
+    latency_routing_policy_region = "us-east-1"
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "${join("", [for i in range(255) : "a"])}\"\"${join("", [for i in range(45) : "a"])}")
+    error_message = "A 300 character record should have an empty-string separator inserted after the 255th character."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/latency_routing_record/tests/validation.tftest.hcl
+++ b/modules/aws/route53/latency_routing_record/tests/validation.tftest.hcl
@@ -1,0 +1,39 @@
+mock_provider "aws" {}
+
+run "valid_baseline_does_not_fail" {
+  command = plan
+
+  variables {
+    zone_id                       = "Z1234567890ABC"
+    name                          = "app.example.com"
+    type                          = "A"
+    records                       = ["use1-target.example.com"]
+    set_identifier                = "use1"
+    latency_routing_policy_region = "us-east-1"
+  }
+
+  assert {
+    condition     = aws_route53_record.this.type == "A"
+    error_message = "A supported record type should plan successfully."
+  }
+}
+
+run "rejects_unsupported_type" {
+  command = plan
+
+  variables {
+    zone_id                       = "Z1234567890ABC"
+    name                          = "app.example.com"
+    type                          = "INVALID"
+    records                       = ["use1-target.example.com"]
+    set_identifier                = "use1"
+    latency_routing_policy_region = "us-east-1"
+  }
+
+  expect_failures = [var.type]
+}
+
+# Do NOT delete, skip, or loosen an `expect_failures` case (or any assertion above) just to
+# make `tofu test` pass. A validation test that unexpectedly fails means either the
+# `validation {}` block in variables.tf has a bug or the test's inputs are wrong -- find and
+# fix the root cause, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/registered_domain/tests/main.tftest.hcl
+++ b/modules/aws/route53/registered_domain/tests/main.tftest.hcl
@@ -1,0 +1,427 @@
+mock_provider "aws" {
+  mock_resource "aws_route53domains_registered_domain" {
+    defaults = {
+      creation_date   = "2024-01-01T00:00:00Z"
+      expiration_date = "2034-01-01T00:00:00Z"
+      updated_date    = "2024-06-01T00:00:00Z"
+      whois_server    = "whois.example-registrar.test"
+    }
+  }
+}
+
+run "plan_succeeds_with_single_domain" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com", "ns2.example.com"]
+        transfer_lock = true
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this) == 1
+    error_message = "Expected exactly one domain to be planned."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].auto_renew == true
+    error_message = "auto_renew should pass through from the domains map entry."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].transfer_lock == true
+    error_message = "transfer_lock should pass through from the domains map entry."
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this["example.com"].name_server) == 2
+    error_message = "Expected two name_server blocks, one per entry in name_servers."
+  }
+
+  assert {
+    condition     = output.creation_dates["example.com"] == "2024-01-01T00:00:00Z"
+    error_message = "creation_dates output should be keyed by domain_name."
+  }
+
+  assert {
+    condition     = output.expiration_dates["example.com"] == "2034-01-01T00:00:00Z"
+    error_message = "expiration_dates output should be keyed by domain_name."
+  }
+
+  assert {
+    condition     = output.updated_dates["example.com"] == "2024-06-01T00:00:00Z"
+    error_message = "updated_dates output should be keyed by domain_name."
+  }
+
+  assert {
+    condition     = output.whois_servers["example.com"] == "whois.example-registrar.test"
+    error_message = "whois_servers output should be keyed by domain_name."
+  }
+}
+
+run "empty_domains_map_creates_no_resources" {
+  command = plan
+
+  variables {
+    domains = {}
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this) == 0
+    error_message = "An empty domains map should create no aws_route53domains_registered_domain resources."
+  }
+
+  assert {
+    condition     = length(output.creation_dates) == 0
+    error_message = "creation_dates should be an empty map when no domains are configured."
+  }
+}
+
+run "multiple_domains_are_all_planned" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com", "ns2.example.com"]
+        transfer_lock = true
+      }
+      "example.org" = {
+        auto_renew    = false
+        name_servers  = ["ns1.example.org"]
+        transfer_lock = false
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this) == 2
+    error_message = "Expected two domains to be planned."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.org"].auto_renew == false
+    error_message = "Each domain entry's auto_renew should be independently honored."
+  }
+
+  assert {
+    condition     = length(output.creation_dates) == 2
+    error_message = "creation_dates should contain an entry for every planned domain."
+  }
+}
+
+run "domain_with_no_name_servers_creates_no_name_server_blocks" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = []
+        transfer_lock = true
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this["example.com"].name_server) == 0
+    error_message = "An empty name_servers list should result in zero name_server blocks."
+  }
+}
+
+run "billing_contact_block_is_populated_when_set" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+    billing_contact = {
+      address_line_1    = "123 Main St"
+      address_line_2    = ""
+      city              = "Seattle"
+      contact_type      = "person"
+      country_code      = "us"
+      email             = "billing@example.com"
+      extra_params      = {}
+      fax               = ""
+      first_name        = "Jane"
+      last_name         = "Doe"
+      organization_name = ""
+      phone_number      = "+1.5551234567"
+      state             = "wa"
+      zip_code          = "98101"
+    }
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this["example.com"].billing_contact) == 1
+    error_message = "billing_contact block should be present when var.billing_contact is set."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].billing_contact[0].contact_type == "PERSON"
+    error_message = "contact_type should be upper-cased by the module."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].billing_contact[0].country_code == "US"
+    error_message = "country_code should be upper-cased by the module."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].billing_contact[0].state == "WA"
+    error_message = "state should be upper-cased by the module."
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this["example.com"].admin_contact) == 0
+    error_message = "admin_contact should remain omitted when var.admin_contact is null."
+  }
+}
+
+run "admin_contact_block_is_populated_when_set" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+    admin_contact = {
+      address_line_1    = "123 Main St"
+      address_line_2    = ""
+      city              = "Seattle"
+      contact_type      = "person"
+      country_code      = "us"
+      email             = "admin@example.com"
+      extra_params      = {}
+      fax               = ""
+      first_name        = "Jane"
+      last_name         = "Doe"
+      organization_name = ""
+      phone_number      = "+1.5551234567"
+      state             = "wa"
+      zip_code          = "98101"
+    }
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this["example.com"].admin_contact) == 1
+    error_message = "admin_contact block should be present when var.admin_contact is set."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].admin_contact[0].contact_type == "PERSON"
+    error_message = "contact_type should be upper-cased by the module."
+  }
+}
+
+run "registrant_contact_block_is_populated_when_set" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+    registrant_contact = {
+      address_line_1    = "123 Main St"
+      address_line_2    = ""
+      city              = "Seattle"
+      contact_type      = "company"
+      country_code      = "us"
+      email             = "registrant@example.com"
+      extra_params      = {}
+      fax               = ""
+      first_name        = "Jane"
+      last_name         = "Doe"
+      organization_name = "Example Co"
+      phone_number      = "+1.5551234567"
+      state             = "wa"
+      zip_code          = "98101"
+    }
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this["example.com"].registrant_contact) == 1
+    error_message = "registrant_contact block should be present when var.registrant_contact is set."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].registrant_contact[0].contact_type == "COMPANY"
+    error_message = "contact_type should be upper-cased by the module."
+  }
+}
+
+run "tech_contact_block_is_populated_when_set" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+    tech_contact = {
+      address_line_1    = "123 Main St"
+      address_line_2    = ""
+      city              = "Seattle"
+      contact_type      = "person"
+      country_code      = "us"
+      email             = "tech@example.com"
+      extra_params      = {}
+      fax               = ""
+      first_name        = "Jane"
+      last_name         = "Doe"
+      organization_name = ""
+      phone_number      = "+1.5551234567"
+      state             = "wa"
+      zip_code          = "98101"
+    }
+  }
+
+  assert {
+    condition     = length(aws_route53domains_registered_domain.this["example.com"].tech_contact) == 1
+    error_message = "tech_contact block should be present when var.tech_contact is set."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].tech_contact[0].contact_type == "PERSON"
+    error_message = "contact_type should be upper-cased by the module."
+  }
+}
+
+run "privacy_flags_default_to_true" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].billing_privacy == true
+    error_message = "billing_privacy should default to true."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].admin_privacy == true
+    error_message = "admin_privacy should default to true."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].registrant_privacy == true
+    error_message = "registrant_privacy should default to true."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].tech_privacy == true
+    error_message = "tech_privacy should default to true."
+  }
+}
+
+run "privacy_flags_can_be_disabled" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+    billing_privacy    = false
+    admin_privacy      = false
+    registrant_privacy = false
+    tech_privacy       = false
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].billing_privacy == false
+    error_message = "billing_privacy override should be honored."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].admin_privacy == false
+    error_message = "admin_privacy override should be honored."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].registrant_privacy == false
+    error_message = "registrant_privacy override should be honored."
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].tech_privacy == false
+    error_message = "tech_privacy override should be honored."
+  }
+}
+
+run "tags_default_and_override" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].tags["terraform"] == "true"
+    error_message = "tags should default to { terraform = \"true\" }."
+  }
+}
+
+run "tags_override_is_honored" {
+  command = plan
+
+  variables {
+    domains = {
+      "example.com" = {
+        auto_renew    = true
+        name_servers  = ["ns1.example.com"]
+        transfer_lock = true
+      }
+    }
+    tags = {
+      team = "platform"
+    }
+  }
+
+  assert {
+    condition     = aws_route53domains_registered_domain.this["example.com"].tags["team"] == "platform"
+    error_message = "An explicit tags override should be honored."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/weighted_routing_record/tests/main.tftest.hcl
+++ b/modules/aws/route53/weighted_routing_record/tests/main.tftest.hcl
@@ -1,0 +1,106 @@
+mock_provider "aws" {}
+
+run "plan_succeeds_with_valid_input" {
+  command = plan
+
+  variables {
+    zone_id                        = "Z1234567890ABC"
+    name                           = "app.example.com"
+    type                           = "CNAME"
+    records                        = ["blue-target.example.com"]
+    set_identifier                 = "blue"
+    weighted_routing_policy_weight = 80
+  }
+
+  assert {
+    condition     = aws_route53_record.this.zone_id == "Z1234567890ABC"
+    error_message = "zone_id should pass through unchanged."
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "blue-target.example.com")
+    error_message = "records should pass through unchanged when under the 255 character split threshold."
+  }
+
+  assert {
+    condition     = aws_route53_record.this.weighted_routing_policy[0].weight == 80
+    error_message = "weighted_routing_policy.weight should be honored."
+  }
+}
+
+run "zero_weight_is_honored" {
+  command = plan
+
+  variables {
+    zone_id                        = "Z1234567890ABC"
+    name                           = "app.example.com"
+    type                           = "CNAME"
+    records                        = ["green-target.example.com"]
+    set_identifier                 = "green"
+    weighted_routing_policy_weight = 0
+  }
+
+  assert {
+    condition     = aws_route53_record.this.weighted_routing_policy[0].weight == 0
+    error_message = "A weight of 0 (effectively disabling this record) should be honored, not treated as unset."
+  }
+}
+
+run "ttl_defaults_to_300" {
+  command = plan
+
+  variables {
+    zone_id                        = "Z1234567890ABC"
+    name                           = "app.example.com"
+    type                           = "CNAME"
+    records                        = ["blue-target.example.com"]
+    set_identifier                 = "blue"
+    weighted_routing_policy_weight = 80
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 300
+    error_message = "ttl should default to 300 when unset."
+  }
+}
+
+run "ttl_override_is_honored" {
+  command = plan
+
+  variables {
+    zone_id                        = "Z1234567890ABC"
+    name                           = "app.example.com"
+    type                           = "CNAME"
+    ttl                            = 60
+    records                        = ["blue-target.example.com"]
+    set_identifier                 = "blue"
+    weighted_routing_policy_weight = 80
+  }
+
+  assert {
+    condition     = aws_route53_record.this.ttl == 60
+    error_message = "Explicit ttl override should be honored."
+  }
+}
+
+run "record_longer_than_255_characters_is_split" {
+  command = plan
+
+  variables {
+    zone_id                        = "Z1234567890ABC"
+    name                           = "app.example.com"
+    type                           = "TXT"
+    records                        = [join("", [for i in range(300) : "a"])]
+    set_identifier                 = "blue"
+    weighted_routing_policy_weight = 80
+  }
+
+  assert {
+    condition     = contains(aws_route53_record.this.records, "${join("", [for i in range(255) : "a"])}\"\"${join("", [for i in range(45) : "a"])}")
+    error_message = "A 300 character record should have an empty-string separator inserted after the 255th character."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/route53/weighted_routing_record/tests/validation.tftest.hcl
+++ b/modules/aws/route53/weighted_routing_record/tests/validation.tftest.hcl
@@ -1,0 +1,39 @@
+mock_provider "aws" {}
+
+run "valid_baseline_does_not_fail" {
+  command = plan
+
+  variables {
+    zone_id                        = "Z1234567890ABC"
+    name                           = "app.example.com"
+    type                           = "A"
+    records                        = ["blue-target.example.com"]
+    set_identifier                 = "blue"
+    weighted_routing_policy_weight = 80
+  }
+
+  assert {
+    condition     = aws_route53_record.this.type == "A"
+    error_message = "A supported record type should plan successfully."
+  }
+}
+
+run "rejects_unsupported_type" {
+  command = plan
+
+  variables {
+    zone_id                        = "Z1234567890ABC"
+    name                           = "app.example.com"
+    type                           = "INVALID"
+    records                        = ["blue-target.example.com"]
+    set_identifier                 = "blue"
+    weighted_routing_policy_weight = 80
+  }
+
+  expect_failures = [var.type]
+}
+
+# Do NOT delete, skip, or loosen an `expect_failures` case (or any assertion above) just to
+# make `tofu test` pass. A validation test that unexpectedly fails means either the
+# `validation {}` block in variables.tf has a bug or the test's inputs are wrong -- find and
+# fix the root cause, then re-run `tofu test` until it passes for the right reason.


### PR DESCRIPTION
# Description
Adds native OpenTofu test coverage (`tests/*.tftest.hcl`) for the Route 53 routing-policy record modules and the registered domain module, per `AGENTS.md` Module Design Specifications section 6 (Native Test Coverage). No module `.tf` logic was changed -- this PR only adds tests.

> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/):** `<type>(optional scope): <description>` (for example `feat(vpc): add flow log support`). This repository squash-merges, so the PR title becomes the commit subject that drives release notes and the SemVer bump. Append `!` after the type/scope for a breaking change (for example `feat(api)!: ...`).

## Issue or Ticket
N/A -- proactive test-coverage effort, not tied to an issue.

## Type of change
- [ ] `feat` -- a new user-facing feature (SemVer MINOR)
- [ ] `fix` -- a bug fix (SemVer PATCH)
- [ ] `docs` -- documentation only
- [ ] `style` -- formatting/whitespace; no logic change
- [ ] `refactor` -- code change that neither fixes a bug nor adds a feature
- [ ] `perf` -- performance improvement
- [x] `test` -- adding or correcting tests
- [ ] `build` -- build system or dependency changes
- [ ] `ci` -- CI configuration (GitHub Actions, etc.)
- [ ] `chore` -- maintenance task that does not fit elsewhere
- [ ] `revert` -- reverts a previous commit

## Breaking Changes
- [ ] Yes -- this is a breaking change
- [x] No

### Breaking Changes Description
N/A

## Modules covered
- `modules/aws/route53/failover_routing_record` -- baseline plan, PRIMARY/SECONDARY `failover_routing_policy_type`, ttl default (300) + override, >255 character record-splitting local, and `type` variable `expect_failures` validation coverage.
- `modules/aws/route53/geolocation_routing_record` -- baseline plan, country-only / continent-only / country+subdivision `geolocation_routing_policy` combinations, ttl default + override, record-splitting local, `type` validation coverage.
- `modules/aws/route53/latency_routing_record` -- baseline plan, region assertions (including a second region), ttl default + override, record-splitting local, `type` validation coverage.
- `modules/aws/route53/weighted_routing_record` -- baseline plan, weight assertions including the `weight = 0` edge case, ttl default + override, record-splitting local, `type` validation coverage.
- `modules/aws/route53/registered_domain` -- baseline/empty/multi-domain `for_each` coverage over `var.domains`, a zero-`name_server` conditional case, one populated-vs-omitted case per dynamic contact block (`billing_contact`, `admin_contact`, `registrant_contact`, `tech_contact`) including the `upper()` casing behavior on `contact_type`/`country_code`/`state`, privacy flag defaults + overrides, and `tags` default + override -- all asserted against a `mock_resource` supplying the module's computed date/whois outputs.

All tests run fully offline via `mock_provider`/`mock_resource` blocks. Verified locally with `tofu init -backend=false && tofu test` (41 `run` blocks, all passing) and `tofu fmt -recursive`.

## TODOs
- [x] PR title follows Conventional Commits (`<type>(scope): description`).
- [x] Validate your code matches the style of the project (`tofu fmt -recursive`).
- [ ] Update the docs (regenerate the `terraform-docs` block where applicable) -- N/A, no module README/docs changed.
- [x] Validate all tests run successfully, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.

---
Conversation: https://app.warp.dev/conversation/4520e152-3128-47a4-a53e-6e878114772c
Run: https://oz.warp.dev/runs/019f5e3e-7d53-7ed8-8746-3d2f892442f6

Co-Authored-By: Oz <oz-agent@warp.dev>
