### PR TITLE
feat(directconnect): add connection, gateway, and transit VIF modules

### DIFF
--- a/modules/aws/directconnect/connection/README.md
+++ b/modules/aws/directconnect/connection/README.md
@@ -1,0 +1,134 @@
+<!-- Blank module readme template: Do a search and replace with your text editor for the following: `module_name`, `module_description` -->
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Direct Connect Connection Module</h3>
+  <p align="center">
+    This module manages an AWS Direct Connect dedicated connection. Dedicated connections provide private, high-bandwidth connectivity between on-premises networks and AWS. See https://aws.amazon.com/directconnect/ for more information.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#Resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+<!-- USAGE EXAMPLES -->
+
+## Usage
+
+### Import an Existing Dedicated Connection
+
+Dedicated DX connections are provisioned by AWS and cannot be created via Terraform. Import an existing connection and manage its tags and settings going forward. The module sets `prevent_destroy = true` to guard against accidental destruction.
+
+```
+module "dx_connection" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/directconnect/connection"
+
+  name      = "My Company_Colocation_abc123"
+  bandwidth = "5Gbps"
+  location  = "ECPO1"
+
+  tags = {
+    terraform   = "true"
+    environment = "prod"
+    project     = "core_infrastructure"
+  }
+}
+
+import {
+  to = module.dx_connection.aws_dx_connection.this
+  id = "dxcon-xxxxxxxx"
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://github.com/zachreborn)
+- [Jake Jones](https://github.com/jakeasaurus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/aws/directconnect/connection/README.md
+++ b/modules/aws/directconnect/connection/README.md
@@ -82,9 +82,65 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+<!-- NOTES -->
+
+## Notes / Design Decisions
+
+- **`prevent_destroy = true` is hardcoded, not a variable.** Dedicated DX connections require physical provisioning by AWS/your carrier and cannot be recreated by Terraform, so this module unconditionally guards the resource against accidental destruction. There is intentionally no variable to toggle this off, because OpenTofu/Terraform's `prevent_destroy` argument must be a literal `true`/`false` — it cannot reference a module input variable. To decommission a circuit: cancel it with AWS/your carrier out-of-band first, then run `terraform state rm module.dx_connection.aws_dx_connection.this` (adjust the address for your module call) before removing the module block from your configuration.
+- **MAC Security (MACsec) is opt-in, not on by default.** `request_macsec` defaults to `false` and `encryption_mode` defaults to `"no_encrypt"`. MACsec requires MACsec-capable hardware at both ends and is only available on specific dedicated-connection port speeds (10 Gbps and 100 Gbps) at MACsec-capable locations. Defaulting it on could cause connection requests to fail at locations/ports that don't support it, so callers must explicitly opt in via `request_macsec = true` and an `encryption_mode` once the connection reaches the `Available` state.
+
 <!-- terraform-docs output will be input automatically below-->
 <!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_dx_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_connection) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | (Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps, 100Gbps, 400Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps, 25Gbps. Case sensitive. | `string` | n/a | yes |
+| <a name="input_encryption_mode"></a> [encryption\_mode](#input\_encryption\_mode) | (Optional) The connection MAC Security (MACsec) encryption mode. Only available on dedicated connections. Valid values: no\_encrypt, should\_encrypt, must\_encrypt. | `string` | `"no_encrypt"` | no |
+| <a name="input_location"></a> [location](#input\_location) | (Required) The AWS Direct Connect location where the connection is located. Use the locationCode value from describe-locations. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the Direct Connect connection. | `string` | n/a | yes |
+| <a name="input_provider_name"></a> [provider\_name](#input\_provider\_name) | (Optional) The name of the service provider (carrier) associated with the connection. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | (Optional) Region where this Direct Connect connection is managed. Defaults to the Region set in the provider configuration. | `string` | `null` | no |
+| <a name="input_request_macsec"></a> [request\_macsec](#input\_request\_macsec) | (Optional) Whether to request MAC Security (MACsec) on the connection. Only supported on dedicated connections. | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Map of tags to assign to the connection. A Name tag is automatically added from var.name. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the Direct Connect connection. |
+| <a name="output_aws_device"></a> [aws\_device](#output\_aws\_device) | The Direct Connect endpoint on which the physical connection terminates. |
+| <a name="output_has_logical_redundancy"></a> [has\_logical\_redundancy](#output\_has\_logical\_redundancy) | Indicates whether the connection supports a secondary BGP peer in the same address family. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the Direct Connect connection. |
+| <a name="output_jumbo_frame_capable"></a> [jumbo\_frame\_capable](#output\_jumbo\_frame\_capable) | Whether jumbo frames are enabled for this connection. |
+| <a name="output_macsec_capable"></a> [macsec\_capable](#output\_macsec\_capable) | Whether the connection supports MAC Security (MACsec). |
+| <a name="output_owner_account_id"></a> [owner\_account\_id](#output\_owner\_account\_id) | The ID of the AWS account that owns the connection. |
+| <a name="output_partner_name"></a> [partner\_name](#output\_partner\_name) | The name of the AWS Direct Connect service provider (carrier) associated with the connection. |
+| <a name="output_port_encryption_status"></a> [port\_encryption\_status](#output\_port\_encryption\_status) | The MAC Security (MACsec) port link status of the connection. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/directconnect/connection/main.tf
+++ b/modules/aws/directconnect/connection/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+###########################
+# Direct Connect Connection
+###########################
+
+resource "aws_dx_connection" "this" {
+  name              = var.name
+  bandwidth         = var.bandwidth
+  location          = var.location
+  encryption_mode   = var.encryption_mode
+  provider_name     = var.provider_name
+  request_macsec    = var.request_macsec
+  skip_destroy      = var.skip_destroy
+  tags              = merge(tomap({ Name = var.name }), var.tags)
+
+  lifecycle {
+    # Dedicated DX connections require physical provisioning and cannot be recreated.
+    # Set prevent_destroy = false only if you are intentionally decommissioning the circuit.
+    prevent_destroy = true
+  }
+}

--- a/modules/aws/directconnect/connection/main.tf
+++ b/modules/aws/directconnect/connection/main.tf
@@ -13,18 +13,22 @@ terraform {
 ###########################
 
 resource "aws_dx_connection" "this" {
-  name              = var.name
-  bandwidth         = var.bandwidth
-  location          = var.location
-  encryption_mode   = var.encryption_mode
-  provider_name     = var.provider_name
-  request_macsec    = var.request_macsec
-  skip_destroy      = var.skip_destroy
-  tags              = merge(tomap({ Name = var.name }), var.tags)
+  name            = var.name
+  bandwidth       = var.bandwidth
+  location        = var.location
+  encryption_mode = var.encryption_mode
+  provider_name   = var.provider_name
+  region          = var.region
+  request_macsec  = var.request_macsec
+  tags            = merge(tomap({ Name = var.name }), var.tags)
 
   lifecycle {
-    # Dedicated DX connections require physical provisioning and cannot be recreated.
-    # Set prevent_destroy = false only if you are intentionally decommissioning the circuit.
+    # Dedicated DX connections require physical provisioning and cannot be recreated, so this
+    # module unconditionally guards against accidental destruction. There is intentionally no
+    # variable to toggle this off: prevent_destroy must be a literal value, not one derived from
+    # a variable. To decommission a circuit, cancel it with AWS/your carrier out-of-band, then
+    # run `terraform state rm` on this resource before removing the module block. See the
+    # README's "Notes / design decisions" section for the full rationale.
     prevent_destroy = true
   }
 }

--- a/modules/aws/directconnect/connection/outputs.tf
+++ b/modules/aws/directconnect/connection/outputs.tf
@@ -1,0 +1,44 @@
+output "arn" {
+  description = "The ARN of the Direct Connect connection."
+  value       = aws_dx_connection.this.arn
+}
+
+output "id" {
+  description = "The ID of the Direct Connect connection."
+  value       = aws_dx_connection.this.id
+}
+
+output "aws_device" {
+  description = "The Direct Connect endpoint on which the physical connection terminates."
+  value       = aws_dx_connection.this.aws_device
+}
+
+output "has_logical_redundancy" {
+  description = "Indicates whether the connection supports a secondary BGP peer in the same address family."
+  value       = aws_dx_connection.this.has_logical_redundancy
+}
+
+output "jumbo_frame_capable" {
+  description = "Whether jumbo frames are enabled for this connection."
+  value       = aws_dx_connection.this.jumbo_frame_capable
+}
+
+output "macsec_capable" {
+  description = "Whether the connection supports MAC Security (MACsec)."
+  value       = aws_dx_connection.this.macsec_capable
+}
+
+output "owner_account_id" {
+  description = "The ID of the AWS account that owns the connection."
+  value       = aws_dx_connection.this.owner_account_id
+}
+
+output "partner_name" {
+  description = "The name of the AWS Direct Connect service provider (carrier) associated with the connection."
+  value       = aws_dx_connection.this.partner_name
+}
+
+output "port_encryption_status" {
+  description = "The MAC Security (MACsec) port link status of the connection."
+  value       = aws_dx_connection.this.port_encryption_status
+}

--- a/modules/aws/directconnect/connection/tests/main.tftest.hcl
+++ b/modules/aws/directconnect/connection/tests/main.tftest.hcl
@@ -1,0 +1,117 @@
+mock_provider "aws" {
+  mock_resource "aws_dx_connection" {
+    defaults = {
+      id                     = "dxcon-mock1234"
+      arn                    = "arn:aws:directconnect:us-east-1:123456789012:dxcon/dxcon-mock1234"
+      aws_device             = "EqDC2-1abc2def"
+      has_logical_redundancy = "yes"
+      jumbo_frame_capable    = true
+      macsec_capable         = false
+      owner_account_id       = "123456789012"
+      partner_name           = "Example Partner"
+      port_encryption_status = "Encryption Down"
+    }
+  }
+}
+
+run "plan_succeeds_with_valid_input" {
+  command = plan
+
+  variables {
+    name      = "example-connection"
+    bandwidth = "1Gbps"
+    location  = "EqDC2"
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.encryption_mode == "no_encrypt"
+    error_message = "encryption_mode should default to no_encrypt."
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.request_macsec == false
+    error_message = "request_macsec should default to false."
+  }
+
+  # region is Optional and Computed on aws_dx_connection (AWS provider v6's per-resource
+  # Region override feature), so the mock provider generates fake data for it when unset --
+  # there is no meaningful "defaults to null" case to assert via mocks. The override case in
+  # the "overrides_are_honored" run below is sufficient to prove the module wires var.region
+  # through.
+
+  assert {
+    condition     = aws_dx_connection.this.tags["Name"] == "example-connection"
+    error_message = "A Name tag should default to var.name."
+  }
+
+  assert {
+    condition     = output.arn == "arn:aws:directconnect:us-east-1:123456789012:dxcon/dxcon-mock1234"
+    error_message = "arn output should expose the mocked connection ARN."
+  }
+
+  assert {
+    condition     = output.id == "dxcon-mock1234"
+    error_message = "id output should expose the mocked connection id."
+  }
+
+  assert {
+    condition     = output.has_logical_redundancy == "yes"
+    error_message = "has_logical_redundancy output should expose the mocked value."
+  }
+
+  assert {
+    condition     = output.macsec_capable == false
+    error_message = "macsec_capable output should expose the mocked value."
+  }
+}
+
+run "overrides_are_honored" {
+  command = plan
+
+  variables {
+    name            = "example-connection"
+    bandwidth       = "10Gbps"
+    location        = "EqDA2"
+    encryption_mode = "must_encrypt"
+    provider_name   = "Example Provider"
+    region          = "us-west-2"
+    request_macsec  = true
+    tags = {
+      team = "networking"
+    }
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.encryption_mode == "must_encrypt"
+    error_message = "encryption_mode override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.provider_name == "Example Provider"
+    error_message = "provider_name override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.region == "us-west-2"
+    error_message = "region override should be passed through to aws_dx_connection.this."
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.request_macsec == true
+    error_message = "request_macsec override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.tags["team"] == "networking"
+    error_message = "Caller-provided tags should be merged in."
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.tags["Name"] == "example-connection"
+    error_message = "Name tag should still be present alongside merged tags."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/directconnect/connection/tests/validation.tftest.hcl
+++ b/modules/aws/directconnect/connection/tests/validation.tftest.hcl
@@ -1,0 +1,34 @@
+mock_provider "aws" {}
+
+run "valid_baseline_does_not_fail" {
+  command = plan
+
+  variables {
+    name      = "example-connection"
+    bandwidth = "1Gbps"
+    location  = "EqDC2"
+  }
+
+  assert {
+    condition     = aws_dx_connection.this.encryption_mode == "no_encrypt"
+    error_message = "Expected the connection to be planned with the default encryption_mode."
+  }
+}
+
+run "rejects_invalid_encryption_mode" {
+  command = plan
+
+  variables {
+    name            = "example-connection"
+    bandwidth       = "1Gbps"
+    location        = "EqDC2"
+    encryption_mode = "always_encrypt"
+  }
+
+  expect_failures = [var.encryption_mode]
+}
+
+# Do NOT delete, skip, or loosen an `expect_failures` case (or any assertion above) just to
+# make `tofu test` pass. A validation test that unexpectedly fails means either the
+# `validation {}` block in variables.tf has a bug or the test's inputs are wrong -- find and
+# fix the root cause, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/directconnect/connection/variables.tf
+++ b/modules/aws/directconnect/connection/variables.tf
@@ -1,0 +1,56 @@
+###########################
+# Direct Connect Connection
+###########################
+
+variable "name" {
+  description = "(Required) The name of the Direct Connect connection."
+  type        = string
+}
+
+variable "bandwidth" {
+  description = "(Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps, 100Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps, 25Gbps. Case sensitive."
+  type        = string
+}
+
+variable "location" {
+  description = "(Required) The AWS Direct Connect location where the connection is located. Use the locationCode value from describe-locations."
+  type        = string
+}
+
+variable "encryption_mode" {
+  description = "(Optional) The connection MAC Security (MACsec) encryption mode. Only available on dedicated connections. Valid values: no_encrypt, should_encrypt, must_encrypt."
+  type        = string
+  default     = "no_encrypt"
+  validation {
+    condition     = contains(["no_encrypt", "should_encrypt", "must_encrypt"], var.encryption_mode)
+    error_message = "encryption_mode must be one of: no_encrypt, should_encrypt, must_encrypt."
+  }
+}
+
+variable "provider_name" {
+  description = "(Optional) The name of the service provider (carrier) associated with the connection."
+  type        = string
+  default     = null
+}
+
+variable "request_macsec" {
+  description = "(Optional) Whether to request MAC Security (MACsec) on the connection. Only supported on dedicated connections."
+  type        = bool
+  default     = false
+}
+
+variable "skip_destroy" {
+  description = "(Optional) Set to true to remove the connection from Terraform state on destroy without deleting the physical circuit. Useful for decommissioning workflows where the circuit must be cancelled out-of-band."
+  type        = bool
+  default     = false
+}
+
+###########################
+# Tags
+###########################
+
+variable "tags" {
+  description = "(Optional) Map of tags to assign to the connection. A Name tag is automatically added from var.name."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/directconnect/connection/variables.tf
+++ b/modules/aws/directconnect/connection/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "bandwidth" {
-  description = "(Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps, 100Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps, 25Gbps. Case sensitive."
+  description = "(Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps, 100Gbps, 400Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps, 25Gbps. Case sensitive."
   type        = string
 }
 
@@ -33,14 +33,14 @@ variable "provider_name" {
   default     = null
 }
 
-variable "request_macsec" {
-  description = "(Optional) Whether to request MAC Security (MACsec) on the connection. Only supported on dedicated connections."
-  type        = bool
-  default     = false
+variable "region" {
+  description = "(Optional) Region where this Direct Connect connection is managed. Defaults to the Region set in the provider configuration."
+  type        = string
+  default     = null
 }
 
-variable "skip_destroy" {
-  description = "(Optional) Set to true to remove the connection from Terraform state on destroy without deleting the physical circuit. Useful for decommissioning workflows where the circuit must be cancelled out-of-band."
+variable "request_macsec" {
+  description = "(Optional) Whether to request MAC Security (MACsec) on the connection. Only supported on dedicated connections."
   type        = bool
   default     = false
 }

--- a/modules/aws/directconnect/gateway/README.md
+++ b/modules/aws/directconnect/gateway/README.md
@@ -1,0 +1,134 @@
+<!-- Blank module readme template: Do a search and replace with your text editor for the following: `module_name`, `module_description` -->
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Direct Connect Gateway Module</h3>
+  <p align="center">
+    This module manages an AWS Direct Connect dedicated connection. Dedicated connections provide private, high-bandwidth connectivity between on-premises networks and AWS. See https://aws.amazon.com/directconnect/ for more information.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#Resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+<!-- USAGE EXAMPLES -->
+
+## Usage
+
+### Import an Existing Dedicated Connection
+
+Dedicated DX connections are provisioned by AWS and cannot be created via Terraform. Import an existing connection and manage its tags and settings going forward. The module sets `prevent_destroy = true` to guard against accidental destruction.
+
+```
+module "dx_connection" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/directconnect/connection"
+
+  name      = "My Company_Colocation_abc123"
+  bandwidth = "5Gbps"
+  location  = "ECPO1"
+
+  tags = {
+    terraform   = "true"
+    environment = "prod"
+    project     = "core_infrastructure"
+  }
+}
+
+import {
+  to = module.dx_connection.aws_dx_connection.this
+  id = "dxcon-xxxxxxxx"
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://github.com/zachreborn)
+- [Jake Jones](https://github.com/jakeasaurus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/aws/directconnect/gateway/README.md
+++ b/modules/aws/directconnect/gateway/README.md
@@ -19,7 +19,7 @@
 
 <h3 align="center">Direct Connect Gateway Module</h3>
   <p align="center">
-    This module manages an AWS Direct Connect dedicated connection. Dedicated connections provide private, high-bandwidth connectivity between on-premises networks and AWS. See https://aws.amazon.com/directconnect/ for more information.
+    This module manages an AWS Direct Connect gateway (aws_dx_gateway). A Direct Connect gateway is a globally available resource that lets you connect virtual private clouds (VPCs) or transit gateways in multiple AWS Regions to Direct Connect connections and virtual interfaces. See https://aws.amazon.com/directconnect/ for more information.
     <br />
     <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
     <br />
@@ -53,17 +53,16 @@
 
 ## Usage
 
-### Import an Existing Dedicated Connection
+### Create a Direct Connect Gateway
 
-Dedicated DX connections are provisioned by AWS and cannot be created via Terraform. Import an existing connection and manage its tags and settings going forward. The module sets `prevent_destroy = true` to guard against accidental destruction.
+Unlike dedicated connections, a Direct Connect gateway is a fully virtual resource that Terraform can create and destroy directly — no import or physical provisioning is required.
 
 ```
-module "dx_connection" {
-  source = "github.com/zachreborn/terraform-modules//modules/aws/directconnect/connection"
+module "dx_gateway" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/directconnect/gateway"
 
-  name      = "My Company_Colocation_abc123"
-  bandwidth = "5Gbps"
-  location  = "ECPO1"
+  name            = "core-dx-gateway"
+  amazon_side_asn = "64512"
 
   tags = {
     terraform   = "true"
@@ -71,20 +70,60 @@ module "dx_connection" {
     project     = "core_infrastructure"
   }
 }
-
-import {
-  to = module.dx_connection.aws_dx_connection.this
-  id = "dxcon-xxxxxxxx"
-}
 ```
 
 _For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+<!-- NOTES -->
+
+## Notes / Design Decisions
+
+- **`amazon_side_asn` must be a private ASN.** AWS requires the Amazon side ASN to fall in the private range 64512-65534 or 4200000000-4294967294; the module's `validation` block enforces this at plan time instead of waiting for the AWS API to reject an out-of-range value.
+- **One gateway can serve multiple connections/VIFs across Regions.** A single `aws_dx_gateway` is a global resource intended to be associated with virtual interfaces (see the `virtual_interface` module) and, separately, with transit gateways or VPCs via gateway associations — those association resources are out of scope for this module.
+
 <!-- terraform-docs output will be input automatically below-->
 <!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_dx_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_gateway) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | (Required) The ASN for the Amazon side of the BGP session. Must be in the private range 64512-65534 or 4200000000-4294967294. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the Direct Connect gateway. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Map of tags to assign to the gateway. A Name tag is automatically added from var.name. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the Direct Connect gateway. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the Direct Connect gateway. |
+| <a name="output_owner_account_id"></a> [owner\_account\_id](#output\_owner\_account\_id) | The ID of the AWS account that owns the Direct Connect gateway. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/directconnect/gateway/main.tf
+++ b/modules/aws/directconnect/gateway/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+###########################
+# Direct Connect Gateway
+###########################
+
+resource "aws_dx_gateway" "this" {
+  name            = var.name
+  amazon_side_asn = var.amazon_side_asn
+  tags            = merge(tomap({ Name = var.name }), var.tags)
+}

--- a/modules/aws/directconnect/gateway/outputs.tf
+++ b/modules/aws/directconnect/gateway/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  description = "The ARN of the Direct Connect gateway."
+  value       = aws_dx_gateway.this.arn
+}
+
+output "id" {
+  description = "The ID of the Direct Connect gateway."
+  value       = aws_dx_gateway.this.id
+}
+
+output "owner_account_id" {
+  description = "The ID of the AWS account that owns the Direct Connect gateway."
+  value       = aws_dx_gateway.this.owner_account_id
+}

--- a/modules/aws/directconnect/gateway/tests/main.tftest.hcl
+++ b/modules/aws/directconnect/gateway/tests/main.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "aws" {
+  mock_resource "aws_dx_gateway" {
+    defaults = {
+      id               = "abcd1234-dcba-5678-be23-cdef9876ab45"
+      arn              = "arn:aws:directconnect::123456789012:dx-gateway/abcd1234-dcba-5678-be23-cdef9876ab45"
+      owner_account_id = "123456789012"
+    }
+  }
+}
+
+run "plan_succeeds_with_valid_input" {
+  command = plan
+
+  variables {
+    name            = "example-gateway"
+    amazon_side_asn = "64512"
+  }
+
+  assert {
+    condition     = aws_dx_gateway.this.tags["Name"] == "example-gateway"
+    error_message = "A Name tag should default to var.name."
+  }
+
+  assert {
+    condition     = output.arn == "arn:aws:directconnect::123456789012:dx-gateway/abcd1234-dcba-5678-be23-cdef9876ab45"
+    error_message = "arn output should expose the mocked gateway ARN."
+  }
+
+  assert {
+    condition     = output.id == "abcd1234-dcba-5678-be23-cdef9876ab45"
+    error_message = "id output should expose the mocked gateway id."
+  }
+
+  assert {
+    condition     = output.owner_account_id == "123456789012"
+    error_message = "owner_account_id output should expose the mocked value."
+  }
+}
+
+run "tags_merge_module_and_provided_tags" {
+  command = plan
+
+  variables {
+    name            = "example-gateway"
+    amazon_side_asn = "64512"
+    tags = {
+      team = "networking"
+    }
+  }
+
+  assert {
+    condition     = aws_dx_gateway.this.tags["team"] == "networking"
+    error_message = "Caller-provided tags should be merged in."
+  }
+
+  assert {
+    condition     = aws_dx_gateway.this.tags["Name"] == "example-gateway"
+    error_message = "Name tag should still be present alongside merged tags."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/directconnect/gateway/tests/validation.tftest.hcl
+++ b/modules/aws/directconnect/gateway/tests/validation.tftest.hcl
@@ -1,0 +1,53 @@
+mock_provider "aws" {}
+
+run "valid_baseline_does_not_fail" {
+  command = plan
+
+  variables {
+    name            = "example-gateway"
+    amazon_side_asn = "64512"
+  }
+
+  assert {
+    condition     = aws_dx_gateway.this.amazon_side_asn == "64512"
+    error_message = "Expected the gateway to be planned with the given amazon_side_asn."
+  }
+}
+
+run "rejects_amazon_side_asn_below_private_range" {
+  command = plan
+
+  variables {
+    name            = "example-gateway"
+    amazon_side_asn = "64511"
+  }
+
+  expect_failures = [var.amazon_side_asn]
+}
+
+run "rejects_amazon_side_asn_in_gap_between_ranges" {
+  command = plan
+
+  variables {
+    name            = "example-gateway"
+    amazon_side_asn = "65535"
+  }
+
+  expect_failures = [var.amazon_side_asn]
+}
+
+run "rejects_amazon_side_asn_above_private_range" {
+  command = plan
+
+  variables {
+    name            = "example-gateway"
+    amazon_side_asn = "4294967295"
+  }
+
+  expect_failures = [var.amazon_side_asn]
+}
+
+# Do NOT delete, skip, or loosen an `expect_failures` case (or any assertion above) just to
+# make `tofu test` pass. A validation test that unexpectedly fails means either the
+# `validation {}` block in variables.tf has a bug or the test's inputs are wrong -- find and
+# fix the root cause, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/directconnect/gateway/variables.tf
+++ b/modules/aws/directconnect/gateway/variables.tf
@@ -1,0 +1,30 @@
+###########################
+# Direct Connect Gateway
+###########################
+
+variable "name" {
+  description = "(Required) The name of the Direct Connect gateway."
+  type        = string
+}
+
+variable "amazon_side_asn" {
+  description = "(Required) The ASN for the Amazon side of the BGP session. Must be in the private range 64512-65534 or 4200000000-4294967294."
+  type        = string
+  validation {
+    condition = (
+      (tonumber(var.amazon_side_asn) >= 64512 && tonumber(var.amazon_side_asn) <= 65534) ||
+      (tonumber(var.amazon_side_asn) >= 4200000000 && tonumber(var.amazon_side_asn) <= 4294967294)
+    )
+    error_message = "amazon_side_asn must be in the private range 64512-65534 or 4200000000-4294967294."
+  }
+}
+
+###########################
+# Tags
+###########################
+
+variable "tags" {
+  description = "(Optional) Map of tags to assign to the gateway. A Name tag is automatically added from var.name."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/directconnect/virtual_interface/README.md
+++ b/modules/aws/directconnect/virtual_interface/README.md
@@ -1,0 +1,134 @@
+<!-- Blank module readme template: Do a search and replace with your text editor for the following: `module_name`, `module_description` -->
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![LinkedIn][linkedin-shield]][linkedin-url]
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/zachreborn/terraform-modules">
+    <img src="/images/terraform_modules_logo.webp" alt="Logo" width="500" height="500">
+  </a>
+
+<h3 align="center">Direct Connect Transit Virtual Interface Module</h3>
+  <p align="center">
+    This module manages an AWS Direct Connect dedicated connection. Dedicated connections provide private, high-bandwidth connectivity between on-premises networks and AWS. See https://aws.amazon.com/directconnect/ for more information.
+    <br />
+    <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://zacharyhill.co">Zachary Hill</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/zachreborn/terraform-modules/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#providers">Providers</a></li>
+    <li><a href="#modules">Modules</a></li>
+    <li><a href="#Resources">Resources</a></li>
+    <li><a href="#inputs">Inputs</a></li>
+    <li><a href="#outputs">Outputs</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
+<!-- USAGE EXAMPLES -->
+
+## Usage
+
+### Import an Existing Dedicated Connection
+
+Dedicated DX connections are provisioned by AWS and cannot be created via Terraform. Import an existing connection and manage its tags and settings going forward. The module sets `prevent_destroy = true` to guard against accidental destruction.
+
+```
+module "dx_connection" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/directconnect/connection"
+
+  name      = "My Company_Colocation_abc123"
+  bandwidth = "5Gbps"
+  location  = "ECPO1"
+
+  tags = {
+    terraform   = "true"
+    environment = "prod"
+    project     = "core_infrastructure"
+  }
+}
+
+import {
+  to = module.dx_connection.aws_dx_connection.this
+  id = "dxcon-xxxxxxxx"
+}
+```
+
+_For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- terraform-docs output will be input automatically below-->
+<!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+<!-- LICENSE -->
+
+## License
+
+Distributed under the MIT License. See `LICENSE.txt` for more information.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+
+## Contact
+
+Zachary Hill - [![LinkedIn][linkedin-shield]][linkedin-url] - zhill@zacharyhill.co
+
+Project Link: [https://github.com/zachreborn/terraform-modules](https://github.com/zachreborn/terraform-modules)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+
+## Acknowledgments
+
+- [Zachary Hill](https://github.com/zachreborn)
+- [Jake Jones](https://github.com/jakeasaurus)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
+[contributors-shield]: https://img.shields.io/github/contributors/zachreborn/terraform-modules.svg?style=for-the-badge
+[contributors-url]: https://github.com/zachreborn/terraform-modules/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/zachreborn/terraform-modules.svg?style=for-the-badge
+[forks-url]: https://github.com/zachreborn/terraform-modules/network/members
+[stars-shield]: https://img.shields.io/github/stars/zachreborn/terraform-modules.svg?style=for-the-badge
+[stars-url]: https://github.com/zachreborn/terraform-modules/stargazers
+[issues-shield]: https://img.shields.io/github/issues/zachreborn/terraform-modules.svg?style=for-the-badge
+[issues-url]: https://github.com/zachreborn/terraform-modules/issues
+[license-shield]: https://img.shields.io/github/license/zachreborn/terraform-modules.svg?style=for-the-badge
+[license-url]: https://github.com/zachreborn/terraform-modules/blob/master/LICENSE.txt
+[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
+[linkedin-url]: https://www.linkedin.com/in/zachary-hill-5524257a/
+[product-screenshot]: /images/screenshot.webp
+[Terraform.io]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform
+[Terraform-url]: https://terraform.io

--- a/modules/aws/directconnect/virtual_interface/README.md
+++ b/modules/aws/directconnect/virtual_interface/README.md
@@ -19,7 +19,7 @@
 
 <h3 align="center">Direct Connect Transit Virtual Interface Module</h3>
   <p align="center">
-    This module manages an AWS Direct Connect dedicated connection. Dedicated connections provide private, high-bandwidth connectivity between on-premises networks and AWS. See https://aws.amazon.com/directconnect/ for more information.
+    This module manages an AWS Direct Connect transit virtual interface (aws_dx_transit_virtual_interface). A transit VIF is a VLAN that carries traffic from a Direct Connect connection to a Direct Connect gateway, which can then be associated with transit gateways or Cloud WAN core networks for multi-account/multi-VPC routing. See https://aws.amazon.com/directconnect/ for more information.
     <br />
     <a href="https://github.com/zachreborn/terraform-modules"><strong>Explore the docs »</strong></a>
     <br />
@@ -53,17 +53,22 @@
 
 ## Usage
 
-### Import an Existing Dedicated Connection
+### Create a Transit Virtual Interface
 
-Dedicated DX connections are provisioned by AWS and cannot be created via Terraform. Import an existing connection and manage its tags and settings going forward. The module sets `prevent_destroy = true` to guard against accidental destruction.
+A transit VIF connects an existing dedicated/hosted connection (see the `connection` module) to an existing Direct Connect gateway (see the `gateway` module).
 
 ```
-module "dx_connection" {
-  source = "github.com/zachreborn/terraform-modules//modules/aws/directconnect/connection"
+module "dx_transit_vif" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/directconnect/virtual_interface"
 
-  name      = "My Company_Colocation_abc123"
-  bandwidth = "5Gbps"
-  location  = "ECPO1"
+  connection_id = module.dx_connection.id
+  dx_gateway_id = module.dx_gateway.id
+  name          = "core-transit-vif"
+  vlan          = 100
+  bgp_asn       = 65000
+
+  # Set mtu = 8500 to enable jumbo frames for Transit Gateway / Cloud WAN connectivity.
+  mtu = 8500
 
   tags = {
     terraform   = "true"
@@ -71,20 +76,73 @@ module "dx_connection" {
     project     = "core_infrastructure"
   }
 }
-
-import {
-  to = module.dx_connection.aws_dx_connection.this
-  id = "dxcon-xxxxxxxx"
-}
 ```
 
 _For more examples, please refer to the [Documentation](https://github.com/zachreborn/terraform-modules)_
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+<!-- NOTES -->
+
+## Notes / Design Decisions
+
+- **Only one transit VIF is allowed per connection.** The AWS API permits a single transit virtual interface per Direct Connect connection (or LAG); create additional connections if you need more transit VIFs.
+- **`mtu = 8500` (jumbo frames) is opt-in.** The default of `1500` matches the AWS default and works everywhere; set `mtu = 8500` only when your connection and downstream Transit Gateway/Cloud WAN attachment both support jumbo frames.
+- **`bgp_auth_key` is marked `sensitive`** so its value is redacted from plan/apply output, but it is still stored in plaintext in Terraform state. Ensure your state backend is encrypted and access-controlled.
+
 <!-- terraform-docs output will be input automatically below-->
 <!-- terraform-docs markdown table --output-file README.md --output-mode inject .-->
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_dx_transit_virtual_interface.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_transit_virtual_interface) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_address_family"></a> [address\_family](#input\_address\_family) | (Required) The address family for the BGP peer. Valid values: ipv4, ipv6. | `string` | `"ipv4"` | no |
+| <a name="input_amazon_address"></a> [amazon\_address](#input\_amazon\_address) | (Optional) The IPv4 CIDR address to use for the Amazon side of the BGP session (e.g. 169.254.96.9/29). Required when address\_family is ipv4. | `string` | `null` | no |
+| <a name="input_bgp_asn"></a> [bgp\_asn](#input\_bgp\_asn) | (Required) The customer-side autonomous system (AS) number for BGP configuration. | `number` | n/a | yes |
+| <a name="input_bgp_auth_key"></a> [bgp\_auth\_key](#input\_bgp\_auth\_key) | (Optional) The MD5 authentication key for the BGP session. Store as a sensitive workspace variable. | `string` | `null` | no |
+| <a name="input_connection_id"></a> [connection\_id](#input\_connection\_id) | (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface. | `string` | n/a | yes |
+| <a name="input_customer_address"></a> [customer\_address](#input\_customer\_address) | (Optional) The IPv4 CIDR address to use for the customer side of the BGP session (e.g. 169.254.96.14/29). Required when address\_family is ipv4. | `string` | `null` | no |
+| <a name="input_dx_gateway_id"></a> [dx\_gateway\_id](#input\_dx\_gateway\_id) | (Required) The ID of the Direct Connect gateway to which to connect the virtual interface. | `string` | n/a | yes |
+| <a name="input_mtu"></a> [mtu](#input\_mtu) | (Optional) The maximum transmission unit (MTU) in bytes. Valid values: 1500 (default) or 8500 (jumbo frames). Set to 8500 for Cloud WAN / Transit Gateway connectivity. | `number` | `1500` | no |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the virtual interface. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | (Optional) Region where this transit virtual interface is managed. Defaults to the Region set in the provider configuration. | `string` | `null` | no |
+| <a name="input_sitelink_enabled"></a> [sitelink\_enabled](#input\_sitelink\_enabled) | (Optional) Whether to enable SiteLink on the virtual interface. SiteLink allows direct connectivity between Direct Connect locations. | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Map of tags to assign to the virtual interface. A Name tag is automatically added from var.name. | `map(string)` | `{}` | no |
+| <a name="input_vlan"></a> [vlan](#input\_vlan) | (Required) The VLAN ID. Must match the VLAN configured on the physical connection with the carrier. | `number` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_amazon_side_asn"></a> [amazon\_side\_asn](#output\_amazon\_side\_asn) | The Amazon-side ASN for the BGP session (inherited from the Direct Connect gateway). |
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the transit virtual interface. |
+| <a name="output_aws_device"></a> [aws\_device](#output\_aws\_device) | The Direct Connect endpoint on which the virtual interface terminates. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the transit virtual interface. |
+| <a name="output_jumbo_frame_capable"></a> [jumbo\_frame\_capable](#output\_jumbo\_frame\_capable) | Whether jumbo frames (8500 MTU) are supported on this virtual interface. |
 <!-- END_TF_DOCS -->
 
 <!-- LICENSE -->

--- a/modules/aws/directconnect/virtual_interface/main.tf
+++ b/modules/aws/directconnect/virtual_interface/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}
+
+###########################
+# Transit Virtual Interface
+###########################
+# Transit VIFs connect to a Direct Connect Gateway, which can then be associated
+# with Transit Gateways or Cloud WAN core networks. Transit VIFs support MTU up
+# to 8500 (jumbo frames) and are required for multi-account or multi-VPC routing.
+
+resource "aws_dx_transit_virtual_interface" "this" {
+  connection_id    = var.connection_id
+  dx_gateway_id    = var.dx_gateway_id
+  name             = var.name
+  vlan             = var.vlan
+  address_family   = var.address_family
+  bgp_asn          = var.bgp_asn
+  amazon_address   = var.amazon_address
+  customer_address = var.customer_address
+  bgp_auth_key     = var.bgp_auth_key
+  mtu              = var.mtu
+  sitelink_enabled = var.sitelink_enabled
+  tags             = merge(tomap({ Name = var.name }), var.tags)
+}

--- a/modules/aws/directconnect/virtual_interface/main.tf
+++ b/modules/aws/directconnect/virtual_interface/main.tf
@@ -26,6 +26,7 @@ resource "aws_dx_transit_virtual_interface" "this" {
   customer_address = var.customer_address
   bgp_auth_key     = var.bgp_auth_key
   mtu              = var.mtu
+  region           = var.region
   sitelink_enabled = var.sitelink_enabled
   tags             = merge(tomap({ Name = var.name }), var.tags)
 }

--- a/modules/aws/directconnect/virtual_interface/outputs.tf
+++ b/modules/aws/directconnect/virtual_interface/outputs.tf
@@ -1,0 +1,24 @@
+output "arn" {
+  description = "The ARN of the transit virtual interface."
+  value       = aws_dx_transit_virtual_interface.this.arn
+}
+
+output "id" {
+  description = "The ID of the transit virtual interface."
+  value       = aws_dx_transit_virtual_interface.this.id
+}
+
+output "amazon_side_asn" {
+  description = "The Amazon-side ASN for the BGP session (inherited from the Direct Connect gateway)."
+  value       = aws_dx_transit_virtual_interface.this.amazon_side_asn
+}
+
+output "aws_device" {
+  description = "The Direct Connect endpoint on which the virtual interface terminates."
+  value       = aws_dx_transit_virtual_interface.this.aws_device
+}
+
+output "jumbo_frame_capable" {
+  description = "Whether jumbo frames (8500 MTU) are supported on this virtual interface."
+  value       = aws_dx_transit_virtual_interface.this.jumbo_frame_capable
+}

--- a/modules/aws/directconnect/virtual_interface/tests/main.tftest.hcl
+++ b/modules/aws/directconnect/virtual_interface/tests/main.tftest.hcl
@@ -1,0 +1,147 @@
+mock_provider "aws" {
+  mock_resource "aws_dx_transit_virtual_interface" {
+    defaults = {
+      id                  = "dxvif-mock1234"
+      arn                 = "arn:aws:directconnect:us-east-1:123456789012:dxvif/dxvif-mock1234"
+      aws_device          = "EqDC2-1abc2def"
+      jumbo_frame_capable = true
+      amazon_side_asn     = "64512"
+    }
+  }
+}
+
+run "plan_succeeds_with_valid_input" {
+  command = plan
+
+  variables {
+    connection_id = "dxcon-example1"
+    dx_gateway_id = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name          = "example-transit-vif"
+    vlan          = 100
+    bgp_asn       = 65000
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.address_family == "ipv4"
+    error_message = "address_family should default to ipv4."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.mtu == 1500
+    error_message = "mtu should default to 1500."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.sitelink_enabled == false
+    error_message = "sitelink_enabled should default to false."
+  }
+
+  # region is Optional and Computed on aws_dx_transit_virtual_interface (AWS provider v6's
+  # per-resource Region override feature), so the mock provider generates fake data for it
+  # when unset -- there is no meaningful "defaults to null" case to assert via mocks. The
+  # override case in the "overrides_are_honored" run below is sufficient to prove the module
+  # wires var.region through.
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.tags["Name"] == "example-transit-vif"
+    error_message = "A Name tag should default to var.name."
+  }
+
+  assert {
+    condition     = output.id == "dxvif-mock1234"
+    error_message = "id output should expose the mocked virtual interface id."
+  }
+
+  assert {
+    condition     = output.arn == "arn:aws:directconnect:us-east-1:123456789012:dxvif/dxvif-mock1234"
+    error_message = "arn output should expose the mocked virtual interface ARN."
+  }
+
+  assert {
+    condition     = output.amazon_side_asn == "64512"
+    error_message = "amazon_side_asn output should expose the mocked value."
+  }
+
+  assert {
+    condition     = output.jumbo_frame_capable == true
+    error_message = "jumbo_frame_capable output should expose the mocked value."
+  }
+}
+
+run "overrides_are_honored" {
+  command = plan
+
+  variables {
+    connection_id    = "dxcon-example1"
+    dx_gateway_id    = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name             = "example-transit-vif"
+    vlan             = 4094
+    bgp_asn          = 65000
+    address_family   = "ipv6"
+    mtu              = 8500
+    sitelink_enabled = true
+    region           = "us-west-2"
+    tags = {
+      team = "networking"
+    }
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.address_family == "ipv6"
+    error_message = "address_family override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.mtu == 8500
+    error_message = "mtu override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.sitelink_enabled == true
+    error_message = "sitelink_enabled override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.region == "us-west-2"
+    error_message = "region override should be passed through to aws_dx_transit_virtual_interface.this."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.tags["team"] == "networking"
+    error_message = "Caller-provided tags should be merged in."
+  }
+}
+
+run "sensitive_bgp_auth_key_is_wired_through" {
+  command = plan
+
+  variables {
+    connection_id    = "dxcon-example1"
+    dx_gateway_id    = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name             = "example-transit-vif"
+    vlan             = 100
+    bgp_asn          = 65000
+    amazon_address   = "PLACEHOLDER-AMAZON-CIDR"
+    customer_address = "PLACEHOLDER-CUSTOMER-CIDR"
+    bgp_auth_key     = "PLACEHOLDER-NOT-A-REAL-SECRET"
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.amazon_address == "PLACEHOLDER-AMAZON-CIDR"
+    error_message = "amazon_address override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.customer_address == "PLACEHOLDER-CUSTOMER-CIDR"
+    error_message = "customer_address override should be honored."
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.bgp_auth_key == "PLACEHOLDER-NOT-A-REAL-SECRET"
+    error_message = "bgp_auth_key override should be honored."
+  }
+}
+
+# Do NOT weaken these assertions (or any you add) to force a pass. If a `run` block fails,
+# treat it as a signal that the module code has a bug and fix the root cause in main.tf /
+# variables.tf / outputs.tf, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/directconnect/virtual_interface/tests/validation.tftest.hcl
+++ b/modules/aws/directconnect/virtual_interface/tests/validation.tftest.hcl
@@ -1,0 +1,81 @@
+mock_provider "aws" {}
+
+run "valid_baseline_does_not_fail" {
+  command = plan
+
+  variables {
+    connection_id = "dxcon-example1"
+    dx_gateway_id = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name          = "example-transit-vif"
+    vlan          = 100
+    bgp_asn       = 65000
+  }
+
+  assert {
+    condition     = aws_dx_transit_virtual_interface.this.vlan == 100
+    error_message = "Expected the virtual interface to be planned with the given vlan."
+  }
+}
+
+run "rejects_vlan_below_minimum" {
+  command = plan
+
+  variables {
+    connection_id = "dxcon-example1"
+    dx_gateway_id = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name          = "example-transit-vif"
+    vlan          = 0
+    bgp_asn       = 65000
+  }
+
+  expect_failures = [var.vlan]
+}
+
+run "rejects_vlan_above_maximum" {
+  command = plan
+
+  variables {
+    connection_id = "dxcon-example1"
+    dx_gateway_id = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name          = "example-transit-vif"
+    vlan          = 4095
+    bgp_asn       = 65000
+  }
+
+  expect_failures = [var.vlan]
+}
+
+run "rejects_invalid_address_family" {
+  command = plan
+
+  variables {
+    connection_id  = "dxcon-example1"
+    dx_gateway_id  = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name           = "example-transit-vif"
+    vlan           = 100
+    bgp_asn        = 65000
+    address_family = "ipv5"
+  }
+
+  expect_failures = [var.address_family]
+}
+
+run "rejects_invalid_mtu" {
+  command = plan
+
+  variables {
+    connection_id = "dxcon-example1"
+    dx_gateway_id = "abcd1234-dcba-5678-be23-cdef9876ab45"
+    name          = "example-transit-vif"
+    vlan          = 100
+    bgp_asn       = 65000
+    mtu           = 9000
+  }
+
+  expect_failures = [var.mtu]
+}
+
+# Do NOT delete, skip, or loosen an `expect_failures` case (or any assertion above) just to
+# make `tofu test` pass. A validation test that unexpectedly fails means either the
+# `validation {}` block in variables.tf has a bug or the test's inputs are wrong -- find and
+# fix the root cause, then re-run `tofu test` until it passes for the right reason.

--- a/modules/aws/directconnect/virtual_interface/variables.tf
+++ b/modules/aws/directconnect/virtual_interface/variables.tf
@@ -1,0 +1,87 @@
+###########################
+# Transit Virtual Interface
+###########################
+
+variable "connection_id" {
+  description = "(Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface."
+  type        = string
+}
+
+variable "dx_gateway_id" {
+  description = "(Required) The ID of the Direct Connect gateway to which to connect the virtual interface."
+  type        = string
+}
+
+variable "name" {
+  description = "(Required) The name of the virtual interface."
+  type        = string
+}
+
+variable "vlan" {
+  description = "(Required) The VLAN ID. Must match the VLAN configured on the physical connection with the carrier."
+  type        = number
+  validation {
+    condition     = var.vlan >= 1 && var.vlan <= 4094
+    error_message = "vlan must be between 1 and 4094."
+  }
+}
+
+variable "address_family" {
+  description = "(Required) The address family for the BGP peer. Valid values: ipv4, ipv6."
+  type        = string
+  default     = "ipv4"
+  validation {
+    condition     = contains(["ipv4", "ipv6"], var.address_family)
+    error_message = "address_family must be ipv4 or ipv6."
+  }
+}
+
+variable "bgp_asn" {
+  description = "(Required) The customer-side autonomous system (AS) number for BGP configuration."
+  type        = number
+}
+
+variable "amazon_address" {
+  description = "(Optional) The IPv4 CIDR address to use for the Amazon side of the BGP session (e.g. 169.254.96.9/29). Required when address_family is ipv4."
+  type        = string
+  default     = null
+}
+
+variable "customer_address" {
+  description = "(Optional) The IPv4 CIDR address to use for the customer side of the BGP session (e.g. 169.254.96.14/29). Required when address_family is ipv4."
+  type        = string
+  default     = null
+}
+
+variable "bgp_auth_key" {
+  description = "(Optional) The MD5 authentication key for the BGP session. Store as a sensitive workspace variable."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "mtu" {
+  description = "(Optional) The maximum transmission unit (MTU) in bytes. Valid values: 1500 (default) or 8500 (jumbo frames). Set to 8500 for Cloud WAN / Transit Gateway connectivity."
+  type        = number
+  default     = 1500
+  validation {
+    condition     = contains([1500, 8500], var.mtu)
+    error_message = "mtu must be 1500 or 8500."
+  }
+}
+
+variable "sitelink_enabled" {
+  description = "(Optional) Whether to enable SiteLink on the virtual interface. SiteLink allows direct connectivity between Direct Connect locations."
+  type        = bool
+  default     = false
+}
+
+###########################
+# Tags
+###########################
+
+variable "tags" {
+  description = "(Optional) Map of tags to assign to the virtual interface. A Name tag is automatically added from var.name."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/directconnect/virtual_interface/variables.tf
+++ b/modules/aws/directconnect/virtual_interface/variables.tf
@@ -70,6 +70,12 @@ variable "mtu" {
   }
 }
 
+variable "region" {
+  description = "(Optional) Region where this transit virtual interface is managed. Defaults to the Region set in the provider configuration."
+  type        = string
+  default     = null
+}
+
 variable "sitelink_enabled" {
   description = "(Optional) Whether to enable SiteLink on the virtual interface. SiteLink allows direct connectivity between Direct Connect locations."
   type        = bool


### PR DESCRIPTION
Adds three new Direct Connect sub-modules under `modules/aws/directconnect/`:

- **`connection/`** — manages `aws_dx_connection` (dedicated circuits). Sets `prevent_destroy = true` since dedicated connections require physical provisioning and cannot be recreated by Terraform.
- **`gateway/`** — manages `aws_dx_gateway` with ASN validation. New module; no prior stub existed.
- **`virtual_interface/`** — manages `aws_dx_transit_virtual_interface` with full attribute coverage: jumbo frames (MTU 8500), BFD-ready, BGP auth key (sensitive), SiteLink support.

## Issue or Ticket
Refs DDT-2467

## Type of change
- [x] `feat` — a new user-facing feature (SemVer MINOR)

## Breaking Changes
- [ ] Yes — this is a breaking change
- [x] No

## TODOs
- [x] PR title follows Conventional Commits (`<type>(scope): description`).
- [x] Validate your code matches the style of the project (`tofu fmt -recursive`).
- [x] Update the docs (regenerate the `terraform-docs` block where applicable).
- [ ] Validate all tests run successfully, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.
