### PR TITLE
feat(issue-triage): detect duplicate and similar issues before advancing

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,6 +15,11 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  # Needed for the duplicate/similar-issue check in the issue-triage skill,
+  # which calls `gh pr list` to search open and merged PRs. GITHUB_TOKEN
+  # permissions are explicit here, so any scope not listed defaults to
+  # `none` — without this, that search would silently fail with a 403.
+  pull-requests: read
   # Needed to dispatch the spec-generation workflow as the next stage when
   # the agent applies `ready-for-spec`. Label events from GITHUB_TOKEN do
   # not cascade to other workflows, but workflow_dispatch events from

--- a/.warp/skills/issue-triage/SKILL.md
+++ b/.warp/skills/issue-triage/SKILL.md
@@ -61,8 +61,11 @@ do this first, before classification.
    The `--jq` filter is required, not optional: the issue being triaged is
    usually its own strongest search match, and without filtering it out it
    can get misread as an "open duplicate" of itself in step 5 below.
-   Re-run with just the module path if the first search is too broad or
-   returns nothing useful.
+   Re-run with just the module path if the first search returns nothing
+   useful — that broadens it. If it instead returns too many candidates to
+   review, narrow it with a quoted, distinctive phrase from the title;
+   dropping terms only produces a superset of matches, so it cannot fix an
+   overly broad search.
 3. Search pull requests the same way — a spec or implementation PR can exist
    for a request even before (or without) its issue carrying a pipeline
    label:
@@ -82,10 +85,14 @@ do this first, before classification.
    underlying request* — not merely the same module. A different bug or
    feature in a shared module is not a duplicate.
 Classify the strongest candidate found, if any:
-- **Active or completed effort** — a candidate issue/PR carries (or carried)
+- **Active or completed effort** — a candidate issue carries (or carried)
   any of `ready-for-spec`, `spec-in-progress`, `spec-ready-for-review`,
-  `spec-approved`, `implementation-in-progress`, `implemented`, or a merged
-  spec/implementation exists for the same request.
+  `spec-approved`, `implementation-in-progress`, `implemented`; or a
+  candidate PR — open or merged — is a spec/implementation PR for the same
+  request, recognizable by its branch prefix (`spec/issue-<N>-...`,
+  `feat/issue-<N>-...`, `fix/issue-<N>-...`) or title. An open, unmerged PR
+  is active work in progress — do not wait for it to merge before counting
+  it.
 - **Open duplicate** — an open issue with no pipeline label yet already
   describes the same request.
 - **Related, not duplicate** — same module/area but a distinct problem or

--- a/.warp/skills/issue-triage/SKILL.md
+++ b/.warp/skills/issue-triage/SKILL.md
@@ -2,14 +2,16 @@
 name: issue-triage
 description: >-
   Triage a GitHub issue in the zachreborn/terraform-modules Terraform/OpenTofu
-  module library: classify it as a bug or feature, validate it against the
+  module library: check it for duplicate or closely related issues already in
+  the pipeline, classify it as a bug or feature, validate it against the
   repository's minimum reporting standards, and move it through the
   issue-to-implementation pipeline by posting a single comment and applying the
-  correct label (needs-info or ready-for-spec) via the gh CLI. Use this skill
-  whenever you are asked to triage, validate, classify, or label an incoming
-  issue for this repo, or when an issue is opened or edited and needs its
-  pipeline state set. This skill is the canonical source for the triage agent;
-  the Issue Triage GitHub Actions workflow invokes it with per-run context.
+  correct label (possible-duplicate, needs-info, or ready-for-spec) via the gh
+  CLI. Use this skill whenever you are asked to triage, validate, classify, or
+  label an incoming issue for this repo, or when an issue is opened or edited
+  and needs its pipeline state set. This skill is the canonical source for the
+  triage agent; the Issue Triage GitHub Actions workflow invokes it with
+  per-run context.
 ---
 
 # Issue triage
@@ -38,6 +40,54 @@ If the body is not included in the prompt, fetch it first:
 gh issue view <issue_number> --repo <repository> \
   --json title,body,labels,comments
 ```
+
+## Duplicate and similar-issue check
+Before classifying the issue, check whether the same request is already being
+worked on elsewhere in the pipeline. This is the primary defense against
+spending spec-generation or implementation effort twice on the same problem —
+do this first, before classification.
+1. Extract 2-4 distinguishing signals from the issue: the affected/target
+   module path(s) (e.g. `modules/aws/ec2_instance`) plus a couple of
+   distinctive nouns/phrases from the title. Skip generic words like "bug",
+   "feature", "module", or "support".
+2. Search issues in any state for overlap, excluding the current issue
+   number:
+   ```sh
+   gh issue list --repo <repository> --state all \
+     --search "<signal-1> <signal-2>" \
+     --json number,title,state,labels,url --limit 20
+   ```
+   Re-run with just the module path if the first search is too broad or
+   returns nothing useful.
+3. Search pull requests the same way — a spec or implementation PR can exist
+   for a request even before (or without) its issue carrying a pipeline
+   label:
+   ```sh
+   gh pr list --repo <repository> --state all \
+     --search "<signal-1> <signal-2>" \
+     --json number,title,state,url,headRefName --limit 20
+   ```
+4. Grep the checked-out repo for a merged spec covering the same module —
+   this catches cases where design work already happened even if the
+   originating issue is closed:
+   ```sh
+   grep -ril "<module_path>" .github/specs/ 2>/dev/null
+   ```
+5. For every candidate surfaced above, read enough of it (title, body
+   snippet, or spec content) to judge whether it describes the *same
+   underlying request* — not merely the same module. A different bug or
+   feature in a shared module is not a duplicate.
+Classify the strongest candidate found, if any:
+- **Active or completed effort** — a candidate issue/PR carries (or carried)
+  any of `ready-for-spec`, `spec-in-progress`, `spec-ready-for-review`,
+  `spec-approved`, `implementation-in-progress`, `implemented`, or a merged
+  spec/implementation exists for the same request.
+- **Open duplicate** — an open issue with no pipeline label yet already
+  describes the same request.
+- **Related, not duplicate** — same module/area but a distinct problem or
+  request. Note it for context later; it does not change how this run
+  proceeds.
+- **None found** — proceed as normal.
 
 ## Classification
 
@@ -73,31 +123,60 @@ re-triage rounds.
 ## Actions you must take
 
 Use the `gh` CLI (it is already authenticated in your environment). Substitute
-the issue number and repository from the run context.
+the issue number and repository from the run context. The duplicate check
+takes priority: if it found an active/completed effort or an open duplicate,
+take only the first action below and stop — do not also evaluate
+classification or minimum standards this run.
 
-**If ANY required item is missing:**
+**If the duplicate check found an active/completed effort or an open
+duplicate:**
+
+- Post a single comment that:
+  - Links each duplicate candidate found (issue/PR/spec) by number and title,
+    with its current pipeline state (e.g. open, `spec-approved`, merged,
+    `implemented`).
+  - States in one sentence why it matches (same module + same underlying
+    request).
+  - Ends with exactly:
+
+    > If this is not a duplicate, please **edit the issue body** to explain the difference — editing the body re-triggers triage automatically. If it is a duplicate, please close this issue and reference the original.
+
+- Then apply the label:
+
+  ```sh
+  gh issue edit <issue_number> --repo <repository> --add-label possible-duplicate
+  ```
+
+**If ANY required item is missing** (and no duplicate was flagged above):
 
 - Post a single comment listing each missing item by name and briefly
-  explaining what is needed. End the comment with exactly:
+  explaining what is needed. If the duplicate check found related-but-not-
+  duplicate issues, add a short "Related issues" line linking them for
+  context — this does not block anything. End the comment with exactly:
 
   > Please **edit the issue body** (not a comment reply) to add the items above — editing the body re-triggers triage automatically.
 
-- Then apply the `needs-info` label:
+- Then apply the `needs-info` label and clear any stale duplicate flag from a
+  prior run:
 
   ```sh
   gh issue edit <issue_number> --repo <repository> --add-label needs-info
+  gh issue edit <issue_number> --repo <repository> --remove-label possible-duplicate || true
   ```
 
-**If ALL required items are present:**
+**If ALL required items are present** (and no duplicate was flagged above):
 
 - Post a single short comment containing:
   - Classification (bug/feature)
   - Affected module path(s)
   - Breaking-change risk (none/low/medium/high) with one sentence of rationale
-- Then advance the issue:
+  - If the duplicate check found related-but-not-duplicate issues, a short
+    "Related issues" line linking them for context
+- Then advance the issue and clear any stale duplicate flag from a prior run:
 
   ```sh
   gh issue edit <issue_number> --repo <repository> --remove-label needs-info || true
+  gh issue edit <issue_number> --repo <repository> --remove-label possible-duplicate || true
   gh issue edit <issue_number> --repo <repository> --add-label ready-for-spec
   ```
 
@@ -105,4 +184,5 @@ the issue number and repository from the run context.
 
 Your only side effects are issue comments and label changes via `gh`. Do not
 edit any files. Do not push commits. Do not open PRs. Do not invoke `terraform`
-or `tofu`. Post exactly one comment per run.
+or `tofu`. Do not close issues yourself — flagging `possible-duplicate` is a
+suggestion for a human to confirm. Post exactly one comment per run.

--- a/.warp/skills/issue-triage/SKILL.md
+++ b/.warp/skills/issue-triage/SKILL.md
@@ -55,8 +55,12 @@ do this first, before classification.
    ```sh
    gh issue list --repo <repository> --state all \
      --search "<signal-1> <signal-2>" \
-     --json number,title,state,labels,url --limit 20
+     --json number,title,state,labels,url --limit 20 \
+     --jq "map(select(.number != <issue_number>))"
    ```
+   The `--jq` filter is required, not optional: the issue being triaged is
+   usually its own strongest search match, and without filtering it out it
+   can get misread as an "open duplicate" of itself in step 5 below.
    Re-run with just the module path if the first search is too broad or
    returns nothing useful.
 3. Search pull requests the same way — a spec or implementation PR can exist
@@ -141,10 +145,13 @@ duplicate:**
 
     > If this is not a duplicate, please **edit the issue body** to explain the difference — editing the body re-triggers triage automatically. If it is a duplicate, please close this issue and reference the original.
 
-- Then apply the label:
+- Then apply the label and clear a stale `needs-info` from a prior run —
+  the duplicate check takes priority over that state, so only one of the
+  two should remain:
 
   ```sh
   gh issue edit <issue_number> --repo <repository> --add-label possible-duplicate
+  gh issue edit <issue_number> --repo <repository> --remove-label needs-info || true
   ```
 
 **If ANY required item is missing** (and no duplicate was flagged above):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ tags = merge(tomap({ Name = var.name }), var.tags)
 | `scan.yml` | Scheduled (12 hrs) or manual | Checkov security scan, uploads SARIF to GitHub |
 | `release-please.yml` | Push → main | Maintains the Release PR + `CHANGELOG.md` from Conventional Commits; merging the Release PR cuts the `vX.Y.Z` tag and publishes the GitHub Release (the single automated publisher) |
 | `release.yml` | Manual (`workflow_dispatch`) | Emergency/manual fallback only — publishes a GitHub Release for an **already-existing** `vX.Y.Z` tag; no longer triggers on tag pushes |
-| `issue-triage.yml` | Issue opened/edited/labeled | Oz agent checks for duplicate/similar issues, validates issue against minimum standards, comments + labels |
+| `issue-triage.yml` | Issue opened/edited | Oz agent checks for duplicate/similar issues, validates issue against minimum standards, comments + labels |
 | `spec-generation.yml` | Issue labeled `ready-for-spec` (or manual) | Oz agent opens a spec PR under `.github/specs/` |
 | `spec-approved.yml` | Spec PR merged | Flips originating issue to `spec-approved` |
 | `implementation.yml` | Issue labeled `spec-approved` (or manual) | Oz agent opens an implementation PR per the merged spec |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ tags = merge(tomap({ Name = var.name }), var.tags)
 | `scan.yml` | Scheduled (12 hrs) or manual | Checkov security scan, uploads SARIF to GitHub |
 | `release-please.yml` | Push → main | Maintains the Release PR + `CHANGELOG.md` from Conventional Commits; merging the Release PR cuts the `vX.Y.Z` tag and publishes the GitHub Release (the single automated publisher) |
 | `release.yml` | Manual (`workflow_dispatch`) | Emergency/manual fallback only — publishes a GitHub Release for an **already-existing** `vX.Y.Z` tag; no longer triggers on tag pushes |
-| `issue-triage.yml` | Issue opened/edited/labeled | Oz agent validates issue against minimum standards, comments + labels |
+| `issue-triage.yml` | Issue opened/edited/labeled | Oz agent checks for duplicate/similar issues, validates issue against minimum standards, comments + labels |
 | `spec-generation.yml` | Issue labeled `ready-for-spec` (or manual) | Oz agent opens a spec PR under `.github/specs/` |
 | `spec-approved.yml` | Spec PR merged | Flips originating issue to `spec-approved` |
 | `implementation.yml` | Issue labeled `spec-approved` (or manual) | Oz agent opens an implementation PR per the merged spec |
@@ -354,8 +354,11 @@ This repo runs an Oz-powered pipeline that turns issues into reviewed specs and 
 ```mermaid
 stateDiagram-v2
     [*] --> needs_info: triage finds missing info
+    [*] --> possible_duplicate: triage finds a likely duplicate
     [*] --> ready_for_spec: triage passes minimum standards
     needs_info --> ready_for_spec: author edits, re-triage passes
+    possible_duplicate --> ready_for_spec: author edits issue, re-triage clears flag
+    possible_duplicate --> [*]: closed as duplicate
     ready_for_spec --> spec_in_progress: Spec Generation runs
     spec_in_progress --> spec_ready_for_review: spec PR opened
     spec_in_progress --> ready_for_spec: failure (label restored)
@@ -368,6 +371,7 @@ stateDiagram-v2
 **Stages and the label that drives each transition**:
 
 1. Issue opened → triage agent runs (only for trusted authors; see below).
+   - Likely duplicate of an open, in-flight, or already-`implemented` issue/PR/spec → label `possible-duplicate` + comment linking the match; classification and minimum-standards checks are skipped for that run.
    - Missing required info → label `needs-info` + comment listing what's missing.
    - Complete → label `ready-for-spec` + classification comment.
 2. `ready-for-spec` → spec-generation agent runs; opens a PR under `.github/specs/issue-<N>-<slug>.md`; issue moves to `spec-in-progress` then `spec-ready-for-review`.
@@ -388,8 +392,9 @@ stateDiagram-v2
 
 - Apply the `skip-oz` label to any issue to disable all Oz workflows for it (label-triggered runs *and* `workflow_dispatch`).
 - Use `workflow_dispatch` on `spec-generation.yml` or `implementation.yml` to re-run a stage manually with an `issue_number` input. Manual dispatch still re-checks `skip-oz` and the trust gate at runtime.
+- A `possible-duplicate` flag is a triage suggestion, not a verdict: edit the issue body (even a small clarifying note) to re-trigger triage and re-evaluate it, or close the issue referencing the original if it is in fact a duplicate.
 
-**Required repo config** (one-time): set `WARP_API_KEY` (secret), optional `WARP_AGENT_PROFILE` (variable), and create the labels listed above plus `needs-info`, `skip-oz`, and `implemented` (color `#0E8A16`). The three Oz-agent workflows fail fast with a clear error if `WARP_API_KEY` is missing, so the PR is safe to merge before configuration is done. `spec-approved.yml` and `impl-complete.yml` do not use `WARP_API_KEY` (they are plain `actions/github-script` jobs) and will act on merged PRs as soon as they land, regardless of secret configuration.
+**Required repo config** (one-time): set `WARP_API_KEY` (secret), optional `WARP_AGENT_PROFILE` (variable), and create the labels listed above plus `needs-info`, `possible-duplicate`, `skip-oz`, and `implemented` (color `#0E8A16`). The three Oz-agent workflows fail fast with a clear error if `WARP_API_KEY` is missing, so the PR is safe to merge before configuration is done. `spec-approved.yml` and `impl-complete.yml` do not use `WARP_API_KEY` (they are plain `actions/github-script` jobs) and will act on merged PRs as soon as they land, regardless of secret configuration.
 
 **Specs directory**: see `.github/specs/README.md` for naming and `.github/specs/_template.md` for the canonical layout.
 


### PR DESCRIPTION
## Summary
Adds a duplicate/similar-issue check to the \`issue-triage\` skill that runs before classification, so the automated pipeline doesn't spend spec-generation or implementation effort on a request that's already open, in-flight, or already implemented.

The check:
- Searches issues and PRs (any state) for overlap using module-path and title signals.
- Greps merged specs under \`.github/specs/\` for the same module.
- Buckets results into active/completed effort, open duplicate, related-not-duplicate, or none found.

If a likely duplicate is found, triage applies the new \`possible-duplicate\` label and posts a comment linking the matches, skipping \`needs-info\`/\`ready-for-spec\` for that run. The label is a suggestion, not a verdict — editing the issue body re-triggers triage, or a maintainer can close the issue referencing the original.

\`AGENTS.md\` is updated to document the new label and the \`possible_duplicate\` pipeline state (CI/CD table, state diagram, stage list, overrides, required repo config).

## Type of Change
- [x] feat

## Testing
No automated test harness exists for skill markdown files. Verified the detection mechanics against the live repo by simulating a hypothetical re-report of issue #434 (Checkov false positives on the ECS modules, already closed/\`implemented\`):
- \`gh issue list --search "ecs task_definition"\` surfaces issue #434.
- \`gh pr list --search "ecs task_definition Checkov"\` surfaces merged spec PR #435 and implementation PR #437.
- \`grep -ril "ecs" .github/specs/\` surfaces \`issue-434-checkov-ecs-false-positives.md\`.

All three correctly land in the skill's "active or completed effort" bucket, confirming the logic would flag a duplicate rather than advancing the pipeline.

The \`possible-duplicate\` label has been created in the repo (color \`#D4C5F9\`) so the pipeline can apply it.

## Checklist
- [x] Commits are signed
- [x] PR title follows Conventional Commits format
- [x] Branch rebased onto latest main
- [ ] CI checks passing (pending)

---
Generated by [Oz](https://app.warp.dev/conversation/f54359f5-87d4-4a67-8465-cc3dee79d7b4).

Co-Authored-By: Oz <oz-agent@warp.dev>