### PR TITLE
feat(organizations): wire delegated_admin into the organizations parent module

### DIFF
--- a/modules/aws/organizations/README.md
+++ b/modules/aws/organizations/README.md
@@ -378,6 +378,9 @@ native OpenTofu tests under their own `tests/` directory, using `mock_provider "
 without real AWS credentials, cost, or cloud side effects. Run them per module:
 
 ```sh
+tofu -chdir=modules/aws/organizations/delegated_admin init -backend=false
+tofu -chdir=modules/aws/organizations/delegated_admin test
+
 tofu -chdir=modules/aws/organizations/ou init -backend=false
 tofu -chdir=modules/aws/organizations/ou test
 

--- a/modules/aws/organizations/README.md
+++ b/modules/aws/organizations/README.md
@@ -62,15 +62,16 @@
 
 ## Usage
 
-This module composes three independent, standalone submodules that live alongside it:
-[`organization`](organization), [`ou`](ou), and [`account`](account). Each remains fully usable on its
-own for partial adoption (e.g. an Organization managed by Control Tower, with only accounts vended by
-this module). Use this composed module when you always want all three managed together from a single
-set of inputs, as described in each submodule's own README.
+This module composes four independent, standalone submodules that live alongside it:
+[`organization`](organization), [`ou`](ou), [`account`](account), and
+[`delegated_admin`](delegated_admin). Each remains fully usable on its own for partial adoption (e.g.
+an Organization managed by Control Tower, with only accounts vended by this module). Use this composed
+module when you always want them managed together from a single set of inputs, as described in each
+submodule's own README.
 
-Already calling `organization`, `ou`, and/or `account` directly? See [MIGRATION.md](MIGRATION.md) for
-both available paths: keep the modules separate and update to their new map-based interfaces, or
-consolidate into this composed module.
+Already calling `organization`, `ou`, `account`, and/or `delegated_admin` directly? See
+[MIGRATION.md](MIGRATION.md) for both available paths: keep the modules separate and update to their
+new map-based interfaces, or consolidate into this composed module.
 
 ### Single YAML File Example
 
@@ -176,11 +177,11 @@ module "organizations" {
 ### Full Example (All Options)
 
 A "kitchen sink" reference showing every field available across `organization`, `organizational_units`,
-and `accounts` in one YAML file. Most fields have sensible defaults and don't need to be set explicitly
-— see the simpler examples above for the common case. This example intentionally sets every field so
-you can see the full shape each submodule accepts; cross-reference field meanings in
-[`organization/README.md`](organization/README.md), [`ou/README.md`](ou/README.md), and
-[`account/README.md`](account/README.md).
+`accounts`, and `delegated_admins` in one YAML file. Most fields have sensible defaults and don't need
+to be set explicitly — see the simpler examples above for the common case. This example intentionally
+sets every field so you can see the full shape each submodule accepts; cross-reference field meanings in
+[`organization/README.md`](organization/README.md), [`ou/README.md`](ou/README.md),
+[`account/README.md`](account/README.md), and [`delegated_admin/README.md`](delegated_admin/README.md).
 
 ```yaml
 # organization_structure.yaml
@@ -284,6 +285,26 @@ accounts:
     tags:
       environment: prod
       purpose: consulting-business
+
+delegated_admins:
+  backups:
+    # account_key resolves against the accounts defined above in this same YAML file --
+    # no need to know company_organization's account ID ahead of time.
+    account_key: company_organization
+    services:
+      - backup.amazonaws.com
+  security:
+    account_key: company_security
+    services:
+      - guardduty.amazonaws.com
+      - securityhub.amazonaws.com
+      - inspector2.amazonaws.com
+  audit:
+    # account_id is a literal ID, for an account that already exists or is managed elsewhere
+    # (i.e. not defined under accounts: above).
+    account_id: "123456789012"
+    services:
+      - config.amazonaws.com
 ```
 
 ```
@@ -297,6 +318,7 @@ module "organizations" {
   organization          = try(local.org_structure.organization, null)
   organizational_units  = local.org_structure.organizational_units
   accounts              = local.org_structure.accounts
+  delegated_admins      = try(local.org_structure.delegated_admins, {})
 
   # Module-wide default tags, merged with each organizational_units/accounts entry's own tags.
   tags = {
@@ -305,35 +327,55 @@ module "organizations" {
 }
 ```
 
+See the [Delegated Administration](#delegated-administration) section below for the inline (non-YAML)
+form of `delegated_admins`, and how to look up a specific delegated administrator instance.
+
 ### Delegated Administration
 
-This composed module does not manage delegated administrators directly — callers wire that
-separately using [`modules/aws/organizations/delegated_admin`](delegated_admin). Key point: key
-the `delegated_admins` map by a **static logical name** (not the account ID), so the `account_id`
-value can reference a newly-created account from the same plan without causing
-`Invalid for_each argument`:
+`delegated_admins` is wired directly into this composed module, keyed by a **static logical name**
+(not the account ID). Each entry sets exactly one of `account_key` (a key into this same module
+call's `accounts` input) or `account_id` (a literal ID for an account managed elsewhere):
 
 ```hcl
-module "delegated_admin" {
-  source = "github.com/zachreborn/terraform-modules//modules/aws/organizations/delegated_admin"
+module "organizations" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/organizations"
+
+  accounts = {
+    backups = {
+      email      = "backups@example.com"
+      parent_key = "aws_infrastructure"
+    }
+  }
 
   delegated_admins = {
+    # account_key resolves against the accounts created by this same module call --
+    # no need to reference an apply-time-unknown account_id from outside the module.
     backups = {
-      account_id = module.organizations.account_ids["backups"]  # apply-time value is fine as a VALUE
-      services   = ["backup.amazonaws.com"]
+      account_key = "backups"
+      services    = ["backup.amazonaws.com"]
+    }
+    # account_id remains available for accounts that already exist or are managed elsewhere.
+    security = {
+      account_id = "123456789012"
+      services   = ["guardduty.amazonaws.com", "securityhub.amazonaws.com"]
     }
   }
 }
 ```
 
-See [`delegated_admin/README.md`](delegated_admin/README.md) for the full interface, migration
-guidance from the old account-ID-keyed shape, and `moved {}` block examples.
+Look up a specific delegated administrator instance via
+`module.organizations.delegated_administrator_ids["backups-backup.amazonaws.com"]`.
+
+Prefer to call `delegated_admin` standalone (e.g. outside this composed module, referencing
+`module.organizations.account_ids["backups"]` from a separate module block)? See
+[`delegated_admin/README.md`](delegated_admin/README.md) for that interface, migration guidance from
+the old account-ID-keyed shape, and `moved {}` block examples.
 
 ### Testing
 
-This module, [`ou`](ou), and [`account`](account) each have native OpenTofu tests under their own
-`tests/` directory, using `mock_provider "aws"` so they run without real AWS credentials, cost, or
-cloud side effects. Run them per module:
+This module, [`ou`](ou), [`account`](account), and [`delegated_admin`](delegated_admin) each have
+native OpenTofu tests under their own `tests/` directory, using `mock_provider "aws"` so they run
+without real AWS credentials, cost, or cloud side effects. Run them per module:
 
 ```sh
 tofu -chdir=modules/aws/organizations/ou init -backend=false
@@ -372,6 +414,7 @@ No providers.
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_accounts"></a> [accounts](#module\_accounts) | ./account | n/a |
+| <a name="module_delegated_admins"></a> [delegated\_admins](#module\_delegated\_admins) | ./delegated_admin | n/a |
 | <a name="module_organization"></a> [organization](#module\_organization) | ./organization | n/a |
 | <a name="module_organizational_units"></a> [organizational\_units](#module\_organizational\_units) | ./ou | n/a |
 
@@ -384,6 +427,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_accounts"></a> [accounts](#input\_accounts) | (Optional) Map of AWS Organization member accounts to create, identical shape to<br/>modules/aws/organizations/account's accounts variable. organizational\_unit\_ids is wired<br/>automatically from the organizational\_units created by this same module call, so there is no<br/>separate organizational\_unit\_ids input here.<br/>Note: iam\_user\_access\_to\_billing has no default here either, for the same reason it has none in the<br/>account submodule -- see that module's variable description for details. | <pre>map(object({<br/>    name                       = optional(string)<br/>    email                      = string<br/>    parent_id                  = optional(string)<br/>    parent_key                 = optional(string)<br/>    iam_user_access_to_billing = optional(string)<br/>    role_name                  = optional(string, "OrganizationAccountAccessRole")<br/>    close_on_deletion          = optional(bool, false)<br/>    tags                       = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
+| <a name="input_delegated_admins"></a> [delegated\_admins](#input\_delegated\_admins) | (Optional) Map of delegated administrator configurations to create, identical shape to<br/>modules/aws/organizations/delegated\_admin's delegated\_admins variable. account\_ids is wired<br/>automatically from the accounts created by this same module call's `accounts` input, so entries may<br/>set account\_key to reference an account from var.accounts directly, in addition to a literal<br/>account\_id for existing/external accounts.<br/><br/>Validation of each entry (exactly one of account\_id/account\_key, a non-empty services list, and that<br/>account\_key resolves to a real entry) happens inside the delegated\_admin submodule itself -- see that<br/>module's variable description and README for the full interface and examples. | <pre>map(object({<br/>    account_id  = optional(string)<br/>    account_key = optional(string)<br/>    services    = list(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | (Optional) Configuration for the AWS Organization itself, passed through to the organization<br/>submodule (modules/aws/organizations/organization). Leave unset (the default, null) if the<br/>Organization already exists and is managed elsewhere -- this module then manages no<br/>aws\_organizations\_organization resource, and every organizational\_units entry must set an explicit<br/>parent\_id or parent\_key (the automatic root-ID default described on organizational\_units below<br/>requires organization to be set).<br/>Fields mirror modules/aws/organizations/organization's variables exactly; every field here is<br/>optional with no default of its own, so an unset field passes through as null and the organization<br/>submodule's own default takes over -- defaults stay single-sourced there. | <pre>object({<br/>    allowed_regions                               = optional(list(string))<br/>    attach_identity_center_scp                    = optional(bool)<br/>    attach_leave_organization_scp                 = optional(bool)<br/>    attach_region_scp                             = optional(bool)<br/>    attach_root_access_key_scp                    = optional(bool)<br/>    attach_root_actions_scp                       = optional(bool)<br/>    attach_security_services_scp                  = optional(bool)<br/>    aws_service_access_principals                 = optional(list(string))<br/>    enable_identity_center_scp                    = optional(bool)<br/>    enable_leave_organization_scp                 = optional(bool)<br/>    enable_organization_backup                    = optional(bool)<br/>    enable_region_scp                             = optional(bool)<br/>    enable_root_access_key_scp                    = optional(bool)<br/>    enable_root_actions_scp                       = optional(bool)<br/>    enable_security_services_scp                  = optional(bool)<br/>    enabled_features                              = optional(list(string))<br/>    enabled_policy_types                          = optional(list(string))<br/>    feature_set                                   = optional(string)<br/>    identity_center_scp_description               = optional(string)<br/>    identity_center_scp_name                      = optional(string)<br/>    identity_center_scp_target_ids                = optional(list(string))<br/>    leave_organization_scp_description            = optional(string)<br/>    leave_organization_scp_name                   = optional(string)<br/>    leave_organization_scp_target_ids             = optional(list(string))<br/>    region_scp_description                        = optional(string)<br/>    region_scp_exempted_actions                   = optional(list(string))<br/>    region_scp_exempted_principal_arns            = optional(list(string))<br/>    region_scp_name                               = optional(string)<br/>    region_scp_target_ids                         = optional(list(string))<br/>    root_access_key_scp_description               = optional(string)<br/>    root_access_key_scp_name                      = optional(string)<br/>    root_access_key_scp_target_ids                = optional(list(string))<br/>    root_actions_scp_description                  = optional(string)<br/>    root_actions_scp_exempted_actions             = optional(list(string))<br/>    root_actions_scp_name                         = optional(string)<br/>    root_actions_scp_target_ids                   = optional(list(string))<br/>    security_services_scp_description             = optional(string)<br/>    security_services_scp_exempted_principal_arns = optional(list(string))<br/>    security_services_scp_name                    = optional(string)<br/>    security_services_scp_target_ids              = optional(list(string))<br/>    tags                                          = optional(map(string))<br/>  })</pre> | `null` | no |
 | <a name="input_organizational_units"></a> [organizational\_units](#input\_organizational\_units) | (Optional) Map of Organizational Units to create, identical shape to<br/>modules/aws/organizations/ou's organizational\_units variable (including support for bare/null<br/>entries and parent\_key nesting up to 4 levels). Any entry that sets neither parent\_id nor parent\_key<br/>is automatically attached to the managed Organization's root -- this requires var.organization to be<br/>set; otherwise such an entry fails validation in the ou submodule. | <pre>map(object({<br/>    name       = optional(string)<br/>    parent_id  = optional(string)<br/>    parent_key = optional(string)<br/>    tags       = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags applied to every Organizational Unit and Account created by this module, merged with each entry's optional per-resource tags. | `map(string)` | <pre>{<br/>  "terraform": "true"<br/>}</pre> | no |
@@ -395,6 +439,8 @@ No resources.
 | <a name="output_account_arns"></a> [account\_arns](#output\_account\_arns) | Map of AWS Organization account ARNs, keyed by the same keys as var.accounts. |
 | <a name="output_account_ids"></a> [account\_ids](#output\_account\_ids) | Map of AWS Organization account IDs, keyed by the same keys as var.accounts. |
 | <a name="output_account_tags_all"></a> [account\_tags\_all](#output\_account\_tags\_all) | Map of the resolved tags for each account, keyed by the same keys as var.accounts. |
+| <a name="output_delegated_administrator_ids"></a> [delegated\_administrator\_ids](#output\_delegated\_administrator\_ids) | Map of delegated administrator instance IDs keyed by '<logical\_key>-<service\_principal>'. Each value is the resource ID in the form '<account\_id>/<service\_principal>'. |
+| <a name="output_delegated_administrators"></a> [delegated\_administrators](#output\_delegated\_administrators) | Map of full delegated administrator resource objects keyed by '<logical\_key>-<service\_principal>'. Each object exposes account\_id, service\_principal, arn, name, email, status, joined\_method, joined\_timestamp, and delegation\_enabled\_date. |
 | <a name="output_organization"></a> [organization](#output\_organization) | Full set of organization submodule outputs (id, arn, roots, master\_account\_id, SCP ids/arns, etc.), or null when var.organization was not set. |
 | <a name="output_organizational_unit_accounts"></a> [organizational\_unit\_accounts](#output\_organizational\_unit\_accounts) | Map of the list of accounts in each Organizational Unit, keyed by the same keys as var.organizational\_units. |
 | <a name="output_organizational_unit_arns"></a> [organizational\_unit\_arns](#output\_organizational\_unit\_arns) | Map of Organizational Unit ARNs, keyed by the same keys as var.organizational\_units. |

--- a/modules/aws/organizations/delegated_admin/README.md
+++ b/modules/aws/organizations/delegated_admin/README.md
@@ -139,6 +139,42 @@ module "delegated_admin" {
 }
 ```
 
+### Resolving Account IDs from a Sibling Map (`account_key`)
+
+Each entry may set `account_key` instead of `account_id`, resolving the account ID from `var.account_ids`
+(e.g. the `ids` output of [`modules/aws/organizations/account`](../account)). This is how the composed
+[`modules/aws/organizations`](..) module wires `delegated_admins` entries directly to accounts created
+by its own `accounts` input, without requiring a separate, external module block:
+
+```hcl
+module "accounts" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/organizations/account"
+
+  accounts = {
+    backups = {
+      email     = "backups@example.com"
+      parent_id = "r-abcd1234"
+    }
+  }
+}
+
+module "delegated_admin" {
+  source = "github.com/zachreborn/terraform-modules//modules/aws/organizations/delegated_admin"
+
+  account_ids = module.accounts.ids
+
+  delegated_admins = {
+    backups = {
+      account_key = "backups" # resolved against module.accounts.ids["backups"]
+      services    = ["backup.amazonaws.com"]
+    }
+  }
+}
+```
+
+An `account_key` that doesn't match any key in `var.account_ids` fails with a clear
+`precondition`-driven error rather than a generic provider error.
+
 ## Migration from the Previous Interface
 
 The `delegated_admins` variable changed from `map(list(string))` keyed by AWS account ID to
@@ -212,14 +248,14 @@ _For more examples, please refer to the [Documentation](https://github.com/zachr
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.56.0 |
 
 ## Modules
@@ -229,19 +265,20 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_organizations_delegated_administrator.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_delegated_admins"></a> [delegated\_admins](#input\_delegated\_admins) | (Optional) Map of delegated administrator configurations keyed by a caller-supplied static logical<br/>name (e.g. "backups", "security"). The map key must be known at plan time — a string literal or<br/>local value, never a resource attribute such as an AWS account ID — so the resource for\_each key<br/>remains resolvable even when account\_id is an apply-time-unknown value.<br/><br/>Each entry has:<br/>  - account\_id : The AWS account ID to register as a delegated administrator. May be an<br/>                 apply-time value such as module.organizations.account\_ids["backups"]; it is<br/>                 passed only as a resource argument value, never used as a for\_each key.<br/>  - services   : Non-empty list of service principal names to associate with the account<br/>                 (e.g. ["backup.amazonaws.com", "config.amazonaws.com"]).<br/><br/>Example:<br/>  delegated\_admins = {<br/>    backups = {<br/>      account\_id = module.organizations.account\_ids["backups"]<br/>      services   = ["backup.amazonaws.com"]<br/>    }<br/>    security = {<br/>      account\_id = "123456789012"<br/>      services   = ["guardduty.amazonaws.com", "securityhub.amazonaws.com"]<br/>    }<br/>  } | <pre>map(object({<br/>    account_id = string<br/>    services   = list(string)<br/>  }))</pre> | `{}` | no |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | (Optional) Map of AWS account IDs keyed by logical name, e.g. the `ids` output of modules/aws/organizations/account. Referenced by each delegated\_admins entry's account\_key. | `map(string)` | `{}` | no |
+| <a name="input_delegated_admins"></a> [delegated\_admins](#input\_delegated\_admins) | (Optional) Map of delegated administrator configurations keyed by a caller-supplied static logical<br/>name (e.g. "backups", "security"). The map key must be known at plan time — a string literal or<br/>local value, never a resource attribute such as an AWS account ID — so the resource for\_each key<br/>remains resolvable even when the resolved account ID is an apply-time-unknown value.<br/><br/>Each entry must set exactly one of:<br/>  - account\_id:  A literal AWS account ID to register as a delegated administrator. May be an<br/>                 apply-time value such as module.organizations.account\_ids["backups"]; it is<br/>                 passed only as a resource argument value, never used as a for\_each key.<br/>  - account\_key: A key into var.account\_ids (e.g. the `ids` output of<br/>                 modules/aws/organizations/account), letting a caller resolve the account ID from a<br/>                 sibling map instead of hard-coding or wiring it in from an outer module block.<br/>Fields:<br/>  - account\_id:  (Optional) Literal AWS account ID. Conflicts with account\_key.<br/>  - account\_key: (Optional) Key into var.account\_ids. Conflicts with account\_id.<br/>  - services:    (Required) Non-empty list of service principal names to associate with the account<br/>                 (e.g. ["backup.amazonaws.com", "config.amazonaws.com"]).<br/><br/>Example:<br/>  delegated\_admins = {<br/>    backups = {<br/>      account\_id = module.organizations.account\_ids["backups"]<br/>      services   = ["backup.amazonaws.com"]<br/>    }<br/>    security = {<br/>      account\_key = "security"<br/>      services    = ["guardduty.amazonaws.com", "securityhub.amazonaws.com"]<br/>    }<br/>  } | <pre>map(object({<br/>    account_id  = optional(string)<br/>    account_key = optional(string)<br/>    services    = list(string)<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_delegated_administrator_ids"></a> [delegated\_administrator\_ids](#output\_delegated\_administrator\_ids) | Map of delegated administrator instance IDs keyed by '<logical\_key>-<service\_principal>' (e.g. 'backups-backup.amazonaws.com'). Each value is the resource ID in the form '<account\_id>/<service\_principal>'. |
 | <a name="output_delegated_administrators"></a> [delegated\_administrators](#output\_delegated\_administrators) | Map of full delegated administrator resource objects keyed by '<logical\_key>-<service\_principal>'. Each object exposes account\_id, service\_principal, arn, name, email, status, joined\_method, joined\_timestamp, and delegation\_enabled\_date. |
 <!-- END_TF_DOCS -->

--- a/modules/aws/organizations/delegated_admin/main.tf
+++ b/modules/aws/organizations/delegated_admin/main.tf
@@ -16,11 +16,19 @@ resource "aws_organizations_delegated_administrator" "this" {
   for_each = merge([
     for admin_key, admin in var.delegated_admins : {
       for service in admin.services : "${admin_key}-${service}" => {
-        account_id        = admin.account_id
-        service_principal = service
+        account_id  = admin.account_key != null ? lookup(var.account_ids, admin.account_key, null) : admin.account_id
+        account_key = admin.account_key
+        service     = service
       }
     }
   ]...)
   account_id        = each.value.account_id
-  service_principal = each.value.service_principal
+  service_principal = each.value.service
+
+  lifecycle {
+    precondition {
+      condition     = each.value.account_key == null || contains(keys(var.account_ids), each.value.account_key)
+      error_message = "account_key \"${each.value.account_key != null ? each.value.account_key : "(none)"}\" was not found in var.account_ids. Pass a map of account IDs (e.g. the account submodule's `ids` output) through as account_ids, or check for typos."
+    }
+  }
 }

--- a/modules/aws/organizations/delegated_admin/tests/delegated_admin.tftest.hcl
+++ b/modules/aws/organizations/delegated_admin/tests/delegated_admin.tftest.hcl
@@ -153,6 +153,49 @@ run "mixed_known_and_unknown_account_ids_plans" {
 }
 
 ###########################################################
+# account_key / account_ids resolution (internal cross-reference)
+###########################################################
+
+run "resolves_account_key_against_account_ids" {
+  command = plan
+
+  variables {
+    account_ids = {
+      backups = "333333333333"
+    }
+    delegated_admins = {
+      backups = {
+        account_key = "backups"
+        services    = ["backup.amazonaws.com"]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.delegated_administrators["backups-backup.amazonaws.com"].account_id == "333333333333"
+    error_message = "account_key should resolve to the matching entry in var.account_ids."
+  }
+}
+
+run "rejects_account_key_not_found_in_account_ids" {
+  command = plan
+
+  variables {
+    account_ids = {
+      backups = "333333333333"
+    }
+    delegated_admins = {
+      security = {
+        account_key = "does_not_exist"
+        services    = ["guardduty.amazonaws.com"]
+      }
+    }
+  }
+
+  expect_failures = [aws_organizations_delegated_administrator.this]
+}
+
+###########################################################
 # Validation: expect_failures — one case per validation rule
 ###########################################################
 
@@ -164,6 +207,36 @@ run "rejects_entry_with_empty_services" {
       backups = {
         account_id = "123456789012"
         services   = []
+      }
+    }
+  }
+
+  expect_failures = [var.delegated_admins]
+}
+
+run "rejects_entry_with_both_account_id_and_account_key" {
+  command = plan
+
+  variables {
+    delegated_admins = {
+      backups = {
+        account_id  = "123456789012"
+        account_key = "backups"
+        services    = ["backup.amazonaws.com"]
+      }
+    }
+  }
+
+  expect_failures = [var.delegated_admins]
+}
+
+run "rejects_entry_with_neither_account_id_nor_account_key" {
+  command = plan
+
+  variables {
+    delegated_admins = {
+      backups = {
+        services = ["backup.amazonaws.com"]
       }
     }
   }

--- a/modules/aws/organizations/delegated_admin/variables.tf
+++ b/modules/aws/organizations/delegated_admin/variables.tf
@@ -7,13 +7,19 @@ variable "delegated_admins" {
     (Optional) Map of delegated administrator configurations keyed by a caller-supplied static logical
     name (e.g. "backups", "security"). The map key must be known at plan time — a string literal or
     local value, never a resource attribute such as an AWS account ID — so the resource for_each key
-    remains resolvable even when account_id is an apply-time-unknown value.
+    remains resolvable even when the resolved account ID is an apply-time-unknown value.
 
-    Each entry has:
-      - account_id : The AWS account ID to register as a delegated administrator. May be an
+    Each entry must set exactly one of:
+      - account_id:  A literal AWS account ID to register as a delegated administrator. May be an
                      apply-time value such as module.organizations.account_ids["backups"]; it is
                      passed only as a resource argument value, never used as a for_each key.
-      - services   : Non-empty list of service principal names to associate with the account
+      - account_key: A key into var.account_ids (e.g. the `ids` output of
+                     modules/aws/organizations/account), letting a caller resolve the account ID from a
+                     sibling map instead of hard-coding or wiring it in from an outer module block.
+    Fields:
+      - account_id:  (Optional) Literal AWS account ID. Conflicts with account_key.
+      - account_key: (Optional) Key into var.account_ids. Conflicts with account_id.
+      - services:    (Required) Non-empty list of service principal names to associate with the account
                      (e.g. ["backup.amazonaws.com", "config.amazonaws.com"]).
 
     Example:
@@ -23,17 +29,25 @@ variable "delegated_admins" {
           services   = ["backup.amazonaws.com"]
         }
         security = {
-          account_id = "123456789012"
-          services   = ["guardduty.amazonaws.com", "securityhub.amazonaws.com"]
+          account_key = "security"
+          services    = ["guardduty.amazonaws.com", "securityhub.amazonaws.com"]
         }
       }
   EOT
   type = map(object({
-    account_id = string
-    services   = list(string)
+    account_id  = optional(string)
+    account_key = optional(string)
+    services    = list(string)
   }))
   default  = {}
   nullable = false
+
+  validation {
+    condition = alltrue([
+      for key, entry in var.delegated_admins : (entry.account_id != null) != (entry.account_key != null)
+    ])
+    error_message = "Each delegated_admins entry must set exactly one of account_id or account_key."
+  }
 
   validation {
     condition = alltrue([
@@ -41,6 +55,12 @@ variable "delegated_admins" {
     ])
     error_message = "Each delegated_admins entry must have at least one service principal in its 'services' list. Check entries with an empty services list."
   }
+}
+
+variable "account_ids" {
+  description = "(Optional) Map of AWS account IDs keyed by logical name, e.g. the `ids` output of modules/aws/organizations/account. Referenced by each delegated_admins entry's account_key."
+  type        = map(string)
+  default     = {}
 }
 
 ############################################################

--- a/modules/aws/organizations/main.tf
+++ b/modules/aws/organizations/main.tf
@@ -113,3 +113,14 @@ module "accounts" {
   organizational_unit_ids = module.organizational_units.ids
   tags                    = var.tags
 }
+
+###########################
+# Delegated Administrators
+###########################
+
+module "delegated_admins" {
+  source = "./delegated_admin"
+
+  delegated_admins = var.delegated_admins
+  account_ids      = module.accounts.ids
+}

--- a/modules/aws/organizations/outputs.tf
+++ b/modules/aws/organizations/outputs.tf
@@ -44,3 +44,17 @@ output "account_tags_all" {
   description = "Map of the resolved tags for each account, keyed by the same keys as var.accounts."
   value       = module.accounts.tags_all
 }
+
+############################################################
+# Delegated Administrators
+############################################################
+
+output "delegated_administrator_ids" {
+  description = "Map of delegated administrator instance IDs keyed by '<logical_key>-<service_principal>'. Each value is the resource ID in the form '<account_id>/<service_principal>'."
+  value       = module.delegated_admins.delegated_administrator_ids
+}
+
+output "delegated_administrators" {
+  description = "Map of full delegated administrator resource objects keyed by '<logical_key>-<service_principal>'. Each object exposes account_id, service_principal, arn, name, email, status, joined_method, joined_timestamp, and delegation_enabled_date."
+  value       = module.delegated_admins.delegated_administrators
+}

--- a/modules/aws/organizations/tests/wiring.tftest.hcl
+++ b/modules/aws/organizations/tests/wiring.tftest.hcl
@@ -177,6 +177,15 @@ run "delegated_admins_wiring_uses_internal_account_ids" {
     condition     = output.delegated_administrator_ids["backups-backup.amazonaws.com"] != null
     error_message = "delegated_admins entry should resolve account_key against this module's own accounts output."
   }
+
+  # Prove the wrapper actually passed module.accounts.ids["backups"] through as account_ids -- not just
+  # that some entry landed under the expected key. "222222222222" is the mocked aws_organizations_account
+  # id above; a wrong or unresolved account_id would fail this even though the != null check above would
+  # still pass.
+  assert {
+    condition     = output.delegated_administrators["backups-backup.amazonaws.com"].account_id == "222222222222"
+    error_message = "account_key \"backups\" should resolve to the account created by this same module call's accounts input, via module.accounts.ids."
+  }
 }
 
 run "delegated_admins_accepts_external_account_id" {

--- a/modules/aws/organizations/tests/wiring.tftest.hcl
+++ b/modules/aws/organizations/tests/wiring.tftest.hcl
@@ -17,6 +17,18 @@ mock_provider "aws" {
       ]
     }
   }
+
+  mock_resource "aws_organizations_account" {
+    defaults = {
+      id = "222222222222"
+    }
+  }
+
+  mock_resource "aws_organizations_delegated_administrator" {
+    defaults = {
+      id = "222222222222/backup.amazonaws.com"
+    }
+  }
 }
 
 run "bare_top_level_ou_defaults_to_organization_root_when_org_managed" {
@@ -102,6 +114,17 @@ run "full_kitchen_sink_example_plans_successfully" {
         parent_key = "prod"
       }
     }
+
+    delegated_admins = {
+      company_security = {
+        account_key = "company_security"
+        services    = ["guardduty.amazonaws.com", "securityhub.amazonaws.com"]
+      }
+      backups = {
+        account_id = "999999999999"
+        services   = ["backup.amazonaws.com"]
+      }
+    }
   }
 
   assert {
@@ -112,5 +135,64 @@ run "full_kitchen_sink_example_plans_successfully" {
   assert {
     condition     = length(output.account_ids) == 3
     error_message = "Expected 3 accounts to be planned."
+  }
+
+  assert {
+    condition     = length(output.delegated_administrator_ids) == 3
+    error_message = "Expected 3 delegated administrator instances to be planned (two services for company_security, one for backups)."
+  }
+}
+
+# Note: the services non-empty validation failure case is exercised by
+# modules/aws/organizations/delegated_admin/tests/delegated_admin.tftest.hcl ("rejects_entry_with_empty_services").
+# It isn't re-tested here since that failure happens inside the nested delegated_admin module's own variable
+# validation, following the same precedent as the ou submodule note above.
+run "delegated_admins_wiring_uses_internal_account_ids" {
+  command = plan
+
+  variables {
+    organization = {
+      enable_identity_center_scp    = false
+      enable_leave_organization_scp = false
+      enable_root_access_key_scp    = false
+    }
+    organizational_units = {
+      workloads = {}
+    }
+    accounts = {
+      backups = {
+        email      = "backups@example.com"
+        parent_key = "workloads"
+      }
+    }
+    delegated_admins = {
+      backups = {
+        account_key = "backups"
+        services    = ["backup.amazonaws.com"]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.delegated_administrator_ids["backups-backup.amazonaws.com"] != null
+    error_message = "delegated_admins entry should resolve account_key against this module's own accounts output."
+  }
+}
+
+run "delegated_admins_accepts_external_account_id" {
+  command = plan
+
+  variables {
+    delegated_admins = {
+      security = {
+        account_id = "123456789012"
+        services   = ["guardduty.amazonaws.com"]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.delegated_administrator_ids["security-guardduty.amazonaws.com"] != null
+    error_message = "delegated_admins entry with a literal account_id (no corresponding var.accounts entry) should plan successfully."
   }
 }

--- a/modules/aws/organizations/variables.tf
+++ b/modules/aws/organizations/variables.tf
@@ -108,6 +108,30 @@ variable "accounts" {
 }
 
 ############################################################
+# Delegated Administrators
+############################################################
+
+variable "delegated_admins" {
+  description = <<-EOT
+    (Optional) Map of delegated administrator configurations to create, identical shape to
+    modules/aws/organizations/delegated_admin's delegated_admins variable. account_ids is wired
+    automatically from the accounts created by this same module call's `accounts` input, so entries may
+    set account_key to reference an account from var.accounts directly, in addition to a literal
+    account_id for existing/external accounts.
+
+    Validation of each entry (exactly one of account_id/account_key, a non-empty services list, and that
+    account_key resolves to a real entry) happens inside the delegated_admin submodule itself -- see that
+    module's variable description and README for the full interface and examples.
+  EOT
+  type = map(object({
+    account_id  = optional(string)
+    account_key = optional(string)
+    services    = list(string)
+  }))
+  default = {}
+}
+
+############################################################
 # General Variables
 ############################################################
 


### PR DESCRIPTION
# Description
Wires the `delegated_admin` submodule directly into the composed `modules/aws/organizations` parent module via a new `delegated_admins` input, so callers no longer need a separate, external module block to register delegated administrators.

Each `delegated_admins` entry sets exactly one of:
- `account_key` — resolved against accounts created by this same module call's `accounts` input (mirrors the existing `parent_key` pattern already used for `organizational_units`/`accounts`).
- `account_id` — a literal ID for an existing/external account.

To support this cleanly, the `delegated_admin` submodule itself gains `account_key` resolution and a new `account_ids` input, with a resource-level `precondition` that reports a clear error when `account_key` doesn't match any entry in `account_ids`. (An earlier approach validated this in the parent module via an output `precondition`, but that ran too late to intercept the AWS provider's own required-argument check on a `null` account_id — moving the resolution and precondition into the submodule, onto the resource itself, fixed this.)

Also extends the "Full Example (All Options)" YAML kitchen-sink documentation to show `delegated_admins` configured from a YAML file, alongside `organization`, `organizational_units`, and `accounts`.

> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/):** `<type>(optional scope): <description>` (for example `feat(vpc): add flow log support`). This repository squash-merges, so the PR title becomes the commit subject that drives release notes and the SemVer bump. Append `!` after the type/scope for a breaking change (for example `feat(api)!: ...`).

## Issue or Ticket
N/A — requested directly, no tracked issue.

## Type of change
- [x] `feat` — a new user-facing feature (SemVer MINOR)
- [ ] `fix` — a bug fix (SemVer PATCH)
- [ ] `docs` — documentation only
- [ ] `style` — formatting/whitespace; no logic change
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `test` — adding or correcting tests
- [ ] `build` — build system or dependency changes
- [ ] `ci` — CI configuration (GitHub Actions, etc.)
- [ ] `chore` — maintenance task that does not fit elsewhere
- [ ] `revert` — reverts a previous commit

## Breaking Changes
- [ ] Yes — this is a breaking change
- [x] No

### Breaking Changes Description
N/A. `delegated_admins` defaults to `{}` on both the parent and submodule, and existing `delegated_admin` callers using only `account_id` are unaffected.

## TODOs
- [x] PR title follows Conventional Commits (`<type>(scope): description`).
- [x] Validate your code matches the style of the project (`tofu fmt -recursive`).
- [x] Update the docs (regenerate the `terraform-docs` block where applicable).
- [x] Validate all tests run successfully, including pre-commit checks.
- [x] Include release notes and description. This should include both a summary of the changes and any necessary context.

## Testing
- `tofu -chdir=modules/aws/organizations/delegated_admin test` — 9 passed, 0 failed.
- `tofu -chdir=modules/aws/organizations test` — 7 passed, 0 failed.
- `tofu validate` clean in both module directories; `tofu fmt -recursive` clean.
